### PR TITLE
Adding support for running spec with coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 /tmp
 Gemfile.lock
 Gemfile.lock
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -46,5 +46,6 @@ group :test do
   gem 'rspec'
   gem 'rspec-rails'
   gem 'webmock'
+  gem 'simplecov', require: false
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,12 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'
+
+if ENV['COVERAGE']
+  require 'simplecov'
+  SimpleCov.start 'rails'
+  SimpleCov.command_name "spec"
+end
+
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'rspec/autorun'


### PR DESCRIPTION
If you are interested in generating the code coverage for the specs
this can be done via `COVERAGE=T rake spec` then review
./coverage/index.html
