### PR TITLE
Add show route

### DIFF
--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -16,8 +16,8 @@ class TermsController < ApplicationController
     @authority.parse_authority_response
     
     respond_to do |format|
-      format.html { render :layout => false, :text => @authority.results }
-      format.json { render :layout => false, :text => @authority.results }
+      format.html { render :layout => false, :text => @authority.results.to_json }
+      format.json { render :layout => false, :text => @authority.results.to_json }
       format.js   { render :layout => false, :text => @authority.results }
     end
   end
@@ -34,11 +34,24 @@ class TermsController < ApplicationController
     @authority.parse_authority_response
     
     respond_to do |format|
-      format.html { render :layout => false, :text => @authority.results }
-      format.json { render :layout => false, :text => @authority.results }
+      format.html { render :layout => false, :text => @authority.results.to_json }
+      format.json { render :layout => false, :text => @authority.results.to_json }
       format.js   { render :layout => false, :text => @authority.results }
     end
 
+  end
+
+  def show
+    check_sub_authority
+    authority = authority_class.constantize.new("", params[:sub_authority])
+    authority.parse_authority_response
+    result = authority.get_full_record(params[:id])
+
+    respond_to do |format|
+      format.html { render :layout => false, :text => result.to_json }
+      format.json { render :layout => false, :text => result.to_json }
+      format.js   { render :layout => false, :text => result }
+    end
   end
 
   def check_vocab_param

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,7 @@ QuestioningAuthority::Application.routes.draw do
   match "/search/:vocab/:sub_authority" => "terms#search", :via=>:get
   match "/terms/:vocab" => "terms#index", :via=>:get
   match "/terms/:vocab/:sub_authority" => "terms#index", :via=>:get
+  match "/show/:vocab/:id" => "terms#show", :via=>:get
+  match "/show/:vocab/:sub_authority/:id" => "terms#show", :via=>:get
   resources :terms
 end

--- a/lib/authorities/base.rb
+++ b/lib/authorities/base.rb
@@ -35,12 +35,12 @@ module Authorities
 
     def get_full_record(id)
       # implement me
-      {"id"=>id}.to_json
+      {"id"=>id}
     end
 
     # Parse the result from LOC, and return an JSON array of terms that match the query.
     def results
-      self.response.to_json
+      self.response
     end
 
     # TODO: there's other info in the self.response that might be worth making access to, such as

--- a/lib/authorities/local.rb
+++ b/lib/authorities/local.rb
@@ -48,7 +48,7 @@ module Authorities
           target_term = term
         end
       end
-      target_term.to_json
+      target_term
     end
     
     def self.sub_authorities_path

--- a/lib/authorities/mesh.rb
+++ b/lib/authorities/mesh.rb
@@ -9,7 +9,14 @@ module Authorities
       @results ||= begin
                      r = SubjectMeshTerm.where('term_lower LIKE ?', "#{@q}%").limit(10)
                      r.map { |t| {id: t.term_id, label: t.term} }
-                   end.to_json
+                   end
+    end
+
+    def get_full_record(id)
+      @results ||= begin
+                     r = SubjectMeshTerm.where(term_id: id).limit(1).first
+                     r.nil? ? nil : {id: r.term_id, label: r.term, synonyms: r.synonyms}
+                   end
     end
 
     # satisfy TermsController

--- a/lib/authorities/oclcts.rb
+++ b/lib/authorities/oclcts.rb
@@ -53,11 +53,11 @@ module Authorities
           a[child.name] = child.children.first.to_s;    
         end
       end
-      a;
+      a
     end
 
     def results
-      self.response.to_json
+      self.response
     end
   end
 end

--- a/lib/authorities/tgnlang.rb
+++ b/lib/authorities/tgnlang.rb
@@ -27,7 +27,7 @@ module Authorities
           obj.push(h)
         end
       end
-      obj.to_json
+      obj
     end
 
     def results

--- a/spec/lib/authorities_lcsh_spec.rb
+++ b/spec/lib/authorities_lcsh_spec.rb
@@ -48,7 +48,7 @@ describe Authorities::Lcsh do
 
     it "should give us an array of suggestions" do
       @terms.suggestions.should be_kind_of Array
-      @terms.suggestions.should include "ABBA (Musical group)"
+      @terms.suggestions.should include({"id"=>"ABBA (Musical group)", "label"=>"ABBA (Musical group)"})
     end
 
     it "should give us an array of urls for each suggestion" do
@@ -66,4 +66,4 @@ describe Authorities::Lcsh do
     end
   end
 
- end  
+end

--- a/spec/lib/authorities_local_spec.rb
+++ b/spec/lib/authorities_local_spec.rb
@@ -55,7 +55,7 @@ describe Authorities::Local do
     
     context "term exists" do
       let(:id) { "A2" }
-      let(:expected) { { :id => "A2", :term => "Term A2", :active => false }.to_json }
+      let(:expected) { { :id => "A2", :term => "Term A2", :active => false } }
       it "should return the full term record" do
         expect(authorities.get_full_record(id)).to eq(expected)
       end
@@ -63,7 +63,7 @@ describe Authorities::Local do
     
     context "term does not exist" do
       let(:id) { "NonID" }
-      let(:expected) { {}.to_json }
+      let(:expected) { {} }
       it "should return an empty hash" do
         expect(authorities.get_full_record(id)).to eq(expected)
       end

--- a/spec/lib/authorities_mesh_spec.rb
+++ b/spec/lib/authorities_mesh_spec.rb
@@ -30,12 +30,17 @@ describe Authorities::Mesh do
     # Re-enable this test once Mesh#results is changed to return a hash of results
     # instead of a single json string
 
-    it "handles queries"
-    #do
-    #  m = Authorities::Mesh.new('mr')
-    #  results = m.results
-    #  results.should include( {id: '1', label: 'Mr Plow'} )
-    #  results.length.should == 3
-    #end
+    it "handles queries" do
+      m = Authorities::Mesh.new('mr')
+      results = m.results
+      results.should include( {id: '1', label: 'Mr Plow'} )
+      results.length.should == 3
+    end
+
+    it "gets full records" do
+      m = Authorities::Mesh.new('')
+      result = m.get_full_record('2')
+      result.should == {id: '2', label: 'Mr Snow', synonyms: []}
+    end
   end
 end

--- a/spec/lib/authorities_tgnlang_spec.rb
+++ b/spec/lib/authorities_tgnlang_spec.rb
@@ -7,16 +7,12 @@ describe Authorities::Tgnlang do
   end
 
   describe "response from dataset" do
-    it "should return size 34 with query of Tibetan" do
-      @terms.results.size.should == 34
+    it "should return unique record with query of Tibetan" do
+      @terms.results.should == [{"id"=>"75446", "label"=>"Tibetan"}]
     end
-    it "should return type string" do
-      @terms.results.class.name.should == "String"
+    it "should return type Array" do
+      @terms.results.class.should == Array
     end
-    it "should return a string it contains" do
-      @terms.results["Tibetan"].should == "Tibetan"
-    end
-
   end
 
 end


### PR DESCRIPTION
Alter authorities as needed to return a full item record.

To facilitate testing, changed the authorities to return hashes instead of json strings. The TermController then converts the hash to json.
