### PR TITLE
Add show route and refactor authority/controller interface

### DIFF
--- a/app/controllers/qa/terms_controller.rb
+++ b/app/controllers/qa/terms_controller.rb
@@ -6,50 +6,57 @@ class Qa::TermsController < ApplicationController
 
   before_action :check_search_params, only:[:search]
   before_action :check_vocab_param, :check_authority, :check_sub_authority
-  
+
   #search that returns all results
   def index
     #initialize the authority and run the search. if there's a sub-authority and it's valid, include that param
-    @authority = authority_class.constantize.new(params[:q], params[:sub_authority])
-    
-    #parse the results
-    @authority.parse_authority_response
-    
+    @authority = authority_class.constantize.new
+    @authority.search(params[:q], params[:sub_authority])
+
     respond_to do |format|
-      format.html { render :layout => false, :text => @authority.results }
-      format.json { render :layout => false, :text => @authority.results }
+      format.html { render :layout => false, json: @authority.results }
+      format.json { render :layout => false, json: @authority.results }
       format.js   { render :layout => false, :text => @authority.results }
     end
   end
-  
+
   def search
-    
     #convert wildcard to be URI encoded
     params[:q].gsub!("*", "%2A")
-   
+
     #initialize the authority and run the search. if there's a sub-authority and it's valid, include that param
-    @authority = authority_class.constantize.new(params[:q], params[:sub_authority])
-    
-    #parse the results
-    @authority.parse_authority_response
-    
+    @authority = authority_class.constantize.new
+    @authority.search(params[:q], params[:sub_authority])
+
     respond_to do |format|
-      format.html { render :layout => false, :text => @authority.results }
-      format.json { render :layout => false, :text => @authority.results }
+      format.html { render :layout => false, :text => @authority.results.to_json }
+      format.json { render :layout => false, :text => @authority.results.to_json }
       format.js   { render :layout => false, :text => @authority.results }
     end
 
+  end
+
+  def show
+    check_sub_authority
+    authority = authority_class.constantize.new
+    result = authority.get_full_record(params[:id], params[:sub_authority])
+
+    respond_to do |format|
+      format.html { render :layout => false, :text => result.to_json }
+      format.json { render :layout => false, :text => result.to_json }
+      format.js   { render :layout => false, :text => result }
+    end
   end
 
   def check_vocab_param
     unless params[:vocab].present?
-      redirect_to :status => 400
+      head :bad_request
     end
   end
-  
+
   def check_search_params
     unless params[:q].present? && params[:vocab].present?
-      redirect_to :status => 400
+      head :bad_request
     end
   end
 
@@ -57,13 +64,13 @@ class Qa::TermsController < ApplicationController
     begin
       authority_class.constantize
     rescue
-      redirect_to :status => 400
-    end 
+      head :bad_request
+    end
   end
 
   def check_sub_authority
     unless params[:sub_authority].nil?
-      redirect_to :status => 400 unless authority_class.constantize.authority_valid?(params[:sub_authority])
+      head :bad_request unless authority_class.constantize.authority_valid?(params[:sub_authority])
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,6 @@ Qa::Engine.routes.draw do
   match "/terms/:vocab" => "terms#index", :via=>:get
   match "/terms/:vocab/:sub_authority" => "terms#index", :via=>:get
   match "/terms" => "terms#index", :via=>:get
+  match "/show/:vocab/:id" => "terms#show", :via=>:get
+  match "/show/:vocab/:sub_authority/:id" => "terms#show", :via=>:get
 end

--- a/lib/qa/authorities.rb
+++ b/lib/qa/authorities.rb
@@ -9,4 +9,5 @@ module Qa::Authorities
   autoload :MeshTools
   autoload :Oclcts
   autoload :Tgnlang
+  autoload :WebServiceBase
 end

--- a/lib/qa/authorities/base.rb
+++ b/lib/qa/authorities/base.rb
@@ -2,22 +2,19 @@ require 'curl'
 
 module Qa::Authorities
   class Base
-    attr_accessor :response, :query_url, :raw_response
+    attr_accessor :response
 
-    def initialize(q, sub_authority='')
-      # Implement Me and set self.query_url
-
-      if self.query_url == nil
-        raise Exception 'query url in your authorities lib is not set (implement in initialize)'
-      end
-
-      #Default implementation assumed query_url is set
-      http = Curl.get(self.query_url) do |http|
-        http.headers['Accept'] = 'application/json'
-      end
-
-      self.raw_response = JSON.parse(http.body_str)
+    def initialize
     end
+
+    # do an autocomplete search
+    def search(query, sub_authority=nil)
+    end
+
+    # return information on a specific record
+    def get_full_record(id, sub_authority=nil)
+    end
+
 
     def self.authority_valid?(sub_authority)
       sub_authority == nil || sub_authorities.include?(sub_authority)
@@ -27,20 +24,9 @@ module Qa::Authorities
       [] #Overwrite if you have sub_authorities
     end
 
-    def parse_authority_response
-      # Overwrite me unless your raw response needs no parsing
-      self.response = self.raw_response
-
-    end
-
-    def get_full_record(id)
-      # implement me
-      {"id"=>id}.to_json
-    end
-
     # Parse the result from LOC, and return an JSON array of terms that match the query.
     def results
-      self.response.to_json
+      self.response
     end
 
     # TODO: there's other info in the self.response that might be worth making access to, such as

--- a/lib/qa/authorities/lcsh.rb
+++ b/lib/qa/authorities/lcsh.rb
@@ -1,45 +1,40 @@
 require 'uri'
 
 module Qa::Authorities
-  class Lcsh < Qa::Authorities::Base
+  class Lcsh < Qa::Authorities::WebServiceBase
 
-    # Initialze the Lcsh class with a query and get the http response from LOC's server.
-    # This is set to a JSON object
-    def initialize(q, sub_authority='')
-      self.query_url= "http://id.loc.gov/authorities/suggest/?q=" + q
-
+    def initialize
       super
     end
 
-    # Format response to the correct JSON structure
-    def parse_authority_response
-      self.response = build_response
+    def search(q, sub_authority='')
+      query_url = "http://id.loc.gov/authorities/suggest/?q=" + q
+      json_terms = get_json(query_url)
+      self.response = build_response(json_terms)
     end
 
-    def query
-      self.raw_response[0]
-    end
-
-    def suggestions
-      self.raw_response[1]
-    end
-
-    def urls_for_suggestions
-      self.raw_response[3]
+    def get_full_record(id, sub_authority)
     end
 
     private
 
-    def build_response a = Array.new
-      self.suggestions.each_index do |i|
-        a << {"id"=>get_id_from_url(urls_for_suggestions[i]), "label"=>suggestions[i]}
+    def build_response(json_response)
+      a = Array.new
+      suggests = json_response[1].each
+      urls = json_response[3].each
+      loop do
+        begin
+          a << {"id"=>get_id_from_url(urls.next), "label"=>suggests.next }
+        rescue StopIteration
+          break
+        end
       end
-      return a
+      self.response = a
     end
 
-    def get_id_from_url url
+    def get_id_from_url(url)
       uri = URI(url)
-      return uri.path.split(/\//).last
+      return uri.path.split('/').last
     end
 
   end

--- a/lib/qa/authorities/loc.rb
+++ b/lib/qa/authorities/loc.rb
@@ -1,199 +1,159 @@
 require 'uri'
 
 module Qa::Authorities
-  class Loc < Qa::Authorities::Base
+  class Loc < Qa::Authorities::WebServiceBase
 
     # Initialze the Loc class with a query and get the http response from LOC's server.
     # This is set to a JSON object
-    def initialize(q, sub_authority='')
-      q += '*'
-      authority_url = sub_authorityURL(sub_authority)
-      self.query_url =  "http://id.loc.gov/search/?q=#{q}&q=#{authority_url}&format=json"
-
-      super
+    def initialize
     end
 
-    def sub_authorityURL(sub_authority)
-      vocab_base_url = 'cs%3Ahttp%3A%2F%2Fid.loc.gov%2Fvocabulary%2F'
-      authority_base_url = 'cs%3Ahttp%3A%2F%2Fid.loc.gov%2Fauthorities%2F'
-      datatype_base_url = 'cs%3Ahttp%3A%2F%2Fid.loc.gov%2Fdatatypes%2F'
-      vocab_preservation_base_url = 'cs%3Ahttp%3A%2F%2Fid.loc.gov%2Fvocabulary%2Fpreservation%2F'
-
-      case sub_authority
-        when 'subjects'
-          return authority_base_url + URI.escape(sub_authority)
-        when 'names'
-          return authority_base_url + URI.escape(sub_authority)
-        when 'classification'
-          return authority_base_url + URI.escape(sub_authority)
-        when 'childrensSubjects'
-          return authority_base_url + URI.escape(sub_authority)
-        when 'genreForms'
-          return authority_base_url + URI.escape(sub_authority)
-        when 'graphicMaterials'
-          return vocab_base_url + URI.escape(sub_authority)
-        when 'organizations'
-          return vocab_base_url + URI.escape(sub_authority)
-        when 'relators'
-          return vocab_base_url + URI.escape(sub_authority)
-        when 'countries'
-          return vocab_base_url + URI.escape(sub_authority)
-        when 'geographicAreas'
-          return vocab_base_url + URI.escape(sub_authority)
-        when 'languages'
-          return vocab_base_url + URI.escape(sub_authority)
-        when 'iso639-1'
-          return vocab_base_url + URI.escape(sub_authority)
-        when 'iso639-2'
-          return vocab_base_url + URI.escape(sub_authority)
-        when 'iso639-5'
-          return vocab_base_url + URI.escape(sub_authority)
-        when 'edtf'
-          return datatype_base_url + URI.escape(sub_authority)
-        when 'preservation'
-          return vocab_base_url + URI.escape(sub_authority)
-        when 'actionsGranted'
-          return vocab_base_url + URI.escape(sub_authority)
-        when 'agentType'
-          return vocab_base_url + URI.escape(sub_authority)
-        when 'contentLocationType'
-          return vocab_preservation_base_url + URI.escape(sub_authority)
-        when 'copyrightStatus'
-          return vocab_preservation_base_url + URI.escape(sub_authority)
-        when 'cryptographicHashFunctions'
-          return vocab_preservation_base_url + URI.escape(sub_authority)
-        when 'environmentCharacteristic'
-          return vocab_preservation_base_url + URI.escape(sub_authority)
-        when 'environmentPurpose'
-          return vocab_preservation_base_url + URI.escape(sub_authority)
-        when 'eventRelatedAgentRole'
-          return vocab_preservation_base_url + URI.escape(sub_authority)
-        when 'eventRelatedObjectRole'
-          return vocab_preservation_base_url + URI.escape(sub_authority)
-        when 'eventType'
-          return vocab_preservation_base_url + URI.escape(sub_authority)
-        when 'formatRegistryRole'
-          return vocab_preservation_base_url + URI.escape(sub_authority)
-        when 'hardwareType'
-          return vocab_preservation_base_url + URI.escape(sub_authority)
-        when 'inhibitorTarget'
-          return vocab_preservation_base_url + URI.escape(sub_authority)
-        when 'inhibitorType'
-          return vocab_preservation_base_url + URI.escape(sub_authority)
-        when 'objectCategory'
-          return vocab_preservation_base_url + URI.escape(sub_authority)
-        when 'preservationLevelRole'
-          return vocab_preservation_base_url + URI.escape(sub_authority)
-        when 'relationshipSubType'
-          return vocab_preservation_base_url + URI.escape(sub_authority)
-        when 'relationshipType'
-          return vocab_preservation_base_url + URI.escape(sub_authority)
-        when 'rightsBasis'
-          return vocab_preservation_base_url + URI.escape(sub_authority)
-        when 'rightsRelatedAgentRole'
-          return vocab_preservation_base_url + URI.escape(sub_authority)
-        when 'signatureEncoding'
-          return vocab_preservation_base_url + URI.escape(sub_authority)
-        when 'signatureMethod'
-          return vocab_preservation_base_url + URI.escape(sub_authority)
-        when 'softwareType'
-          return vocab_preservation_base_url + URI.escape(sub_authority)
-        when 'storageMedium'
-          return vocab_preservation_base_url + URI.escape(sub_authority)
-        else
-          return ''
+    def search(q, sub_authority=nil)
+      if ! (sub_authority.nil?  || Loc.sub_authorities.include?(sub_authority))
+        @raw_response = nil
+        @response = nil
+        return
       end
+      q += '*'
+      authority_fragment = sub_authorityURL(sub_authority)
+      query_url =  "http://id.loc.gov/search/?q=#{q}&q=#{authority_fragment}&format=json"
+      @raw_response = get_json(query_url)
+      @response = parse_authority_response(@raw_response)
+    end
+
+    def self.sub_authority_table
+      @sub_authority_table ||=
+        begin
+          vocab_base_url = 'cs%3Ahttp%3A%2F%2Fid.loc.gov%2Fvocabulary%2F'
+          authority_base_url = 'cs%3Ahttp%3A%2F%2Fid.loc.gov%2Fauthorities%2F'
+          datatype_base_url = 'cs%3Ahttp%3A%2F%2Fid.loc.gov%2Fdatatypes%2F'
+          vocab_preservation_base_url = 'cs%3Ahttp%3A%2F%2Fid.loc.gov%2Fvocabulary%2Fpreservation%2F'
+          {
+            'subjects' => authority_base_url,
+            'names' => authority_base_url,
+            'classification' => authority_base_url,
+            'childrensSubjects' => authority_base_url,
+            'genreForms' => authority_base_url,
+            'graphicMaterials' => vocab_base_url,
+            'organizations' => vocab_base_url,
+            'relators' => vocab_base_url,
+            'countries' => vocab_base_url,
+            'geographicAreas' => vocab_base_url,
+            'languages' => vocab_base_url,
+            'iso639-1' => vocab_base_url,
+            'iso639-2' => vocab_base_url,
+            'iso639-5' => vocab_base_url,
+            'edtf' => datatype_base_url,
+            'preservation' => vocab_base_url,
+            'actionsGranted' => vocab_base_url,
+            'agentType' => vocab_base_url,
+            'contentLocationType' => vocab_preservation_base_url,
+            'copyrightStatus' => vocab_preservation_base_url,
+            'cryptographicHashFunctions' => vocab_preservation_base_url,
+            'environmentCharacteristic' => vocab_preservation_base_url,
+            'environmentPurpose' => vocab_preservation_base_url,
+            'eventRelatedAgentRole' => vocab_preservation_base_url,
+            'eventRelatedObjectRole' => vocab_preservation_base_url,
+            'eventType' => vocab_preservation_base_url,
+            'formatRegistryRole' => vocab_preservation_base_url,
+            'hardwareType' => vocab_preservation_base_url,
+            'inhibitorTarget' => vocab_preservation_base_url,
+            'inhibitorType' => vocab_preservation_base_url,
+            'objectCategory' => vocab_preservation_base_url,
+            'preservationLevelRole' => vocab_preservation_base_url,
+            'relationshipSubType' => vocab_preservation_base_url,
+            'relationshipType' => vocab_preservation_base_url,
+            'rightsBasis' => vocab_preservation_base_url,
+            'rightsRelatedAgentRole' => vocab_preservation_base_url,
+            'signatureEncoding' => vocab_preservation_base_url,
+            'signatureMethod' => vocab_preservation_base_url,
+            'softwareType' => vocab_preservation_base_url,
+            'storageMedium' => vocab_preservation_base_url
+          }
+        end
+    end
+
+
+    def sub_authorityURL(sub_authority)
+      base_url = Loc.sub_authority_table[sub_authority]
+      return "" if base_url.nil?
+      base_url + URI.escape(sub_authority)
+    end
+
+    def self.authority_valid?(authority)
+      self.sub_authorities.include?(authority)
     end
 
     def self.sub_authorities
-      ['iso639-2', 'subjects', 'names', 'classification', 'childrensSubjects', 'genreForms', 'graphicMaterials', 'organizations', 'relators', 'countries', 'geographicAreas', 'languages', 'iso639-5', 'edtf', 'preservation', 'actionsGranted', 'agentType', 'contentLocationType', 'copyrightStatus', 'cryptographicHashFunctions', 'environmentCharacteristic', 'environmentPurpose', 'eventRelatedAgentRole', 'eventRelatedObjectRole', 'eventType', 'formatRegistryRole', 'hardwareType', 'inhibitorTarget', 'inhibitorType', 'objectCategory', 'preservationLevelRole', 'relationshipSubType', 'relationshipType', 'rightsBasis', 'rightsRelatedAgentRole', 'signatureEncoding', 'signatureMethod', 'softwareType', 'storageMedium']
+      @sub_authorities ||= sub_authority_table.keys
     end
 
 
-    def parse_authority_response
+    def parse_authority_response(raw_response)
       result = []
-      self.raw_response.each do |single_response|
-        if single_response[0] == "atom:entry"
-          id = nil
-          label = ''
-          single_response.each do |result_part|
-            if(result_part[0] == 'atom:title')
-              label = result_part[2]
-            end
-
-            if(result_part[0] == 'atom:id')
-              id = result_part[2]
-            end
-
+      raw_response.each do |single_response|
+        next if single_response[0] != "atom:entry"
+        id = nil
+        label = ''
+        single_response.each do |result_part|
+          case result_part[0]
+          when 'atom:title'
+            label = result_part[2]
+          when 'atom:id'
+            id = result_part[2]
           end
-
-          id ||= label
-          result << {"id"=>id, "label"=>label}
-
         end
+
+        id ||= label
+        result << {"id"=>id, "label"=>label}
       end
-      self.response = result
+      result
     end
 
-    def get_full_record(id)
-      full_record = nil
+    def find_record_in_response(raw_response, id)
+      raw_response.each do |single_response|
+        next if single_response[0] != "atom:entry"
+        single_response.each do |result_part|
+          if (result_part[0] == 'atom:title' ||
+              result_part[0] == 'atom:id') && id == result_part[2]
+            return single_response
+          end
+        end
+      end
+      return nil
+    end
+
+    def get_full_record(id, sub_authority)
+      search(id, sub_authority)
+      full_record = find_record_in_response(@raw_response, id)
+
+      if full_record.nil?
+        # record not found
+        return {}
+      end
+
       parsed_result = {}
-      self.raw_response.each do |single_response|
-        if single_response[0] == "atom:entry"
-
-          single_response.each do |result_part|
-            if(result_part[0] == 'atom:title')
-              if id == result_part[2]
-                full_record = single_response
-              end
+      full_record.each do |section|
+        if section.class == Array
+          label = section[0].split(':').last.to_s
+          case label
+          when 'title', 'id', 'updated', 'created'
+            parsed_result[label] = section[2]
+          when 'link'
+            if section[1]['type'] != nil
+              parsed_result[label + "||#{section[1]['type']}"] = section[1]["href"]
+            else
+              parsed_result[label] = section[1]["href"]
             end
-
-            if(result_part[0] == 'atom:id')
-              if id == result_part[2]
-                full_record = single_response
-              end
-            end
-
-          end
-
-        end
-      end
-
-
-      if full_record != nil
-        full_record.each do |section|
-          if section.class == Array
-            label = section[0].split(':').last.to_s
-            case label
-              when 'title'
-                parsed_result[label] = section[2]
-              when 'link'
-                if section[1]['type'] != nil
-                  parsed_result[label + "||#{section[1]['type']}"] = section[1]["href"]
-                else
-                  parsed_result[label] = section[1]["href"]
-                end
-              when 'id'
-                parsed_result[label] = section[2]
-              when 'author'
-                author_list = []
-                #FIXME: Find example with two authors to better understand this data.
-                author_list << section[2][2]
-                parsed_result[label] = author_list
-              when 'updated'
-                parsed_result[label] = section[2]
-              when 'created'
-                parsed_result[label] = section[2]
-            end
-
+          when 'author'
+            author_list = []
+            #FIXME: Find example with two authors to better understand this data.
+            author_list << section[2][2]
+            parsed_result[label] = author_list
           end
         end
-      else
-        raise Exception 'Lookup without using a result search first not implemented yet'
       end
-
       parsed_result
-
     end
 
   end

--- a/lib/qa/authorities/local.rb
+++ b/lib/qa/authorities/local.rb
@@ -1,69 +1,67 @@
 module Qa::Authorities
+
   class Local < Qa::Authorities::Base
-    
+
     attr_accessor :response
-    
-    def initialize(q, sub_authority)
-      begin
-        sub_authority_hash = YAML.load(File.read(File.join(Qa::Authorities::Local.sub_authorities_path, "#{sub_authority}.yml")))
-      rescue
-        sub_authority_hash = {}
-      end
-      @terms = normalize_terms(sub_authority_hash.fetch(:terms, []))
-      if q.blank?
-        self.response = @terms
-      else
-        sub_terms = []
-        @terms.each { |term| sub_terms << term if term[:term].downcase.start_with?(q.downcase) }
-        self.response = sub_terms
-      end
-    end
 
-    def normalize_terms(terms)
-      normalized_terms = []
-      terms.each do |term|
-        if term.is_a? String
-          normalized_terms << { :id => term, :term => term }
-        else
-          term[:id] = term[:id] || term[:term]
-          normalized_terms << term
-        end
-      end
-      normalized_terms
-    end
-
-    def parse_authority_response
-      parsed_response = []
-      self.response.each do |res|
-        parsed_response << { :id => res[:id], :label => res[:term] }
-      end
-      self.response = parsed_response
-    end
-    
-    def get_full_record(id)
-      target_term = {}
-      @terms.each do |term|
-        if term[:id] == id
-          target_term = term
-        end
-      end
-      target_term.to_json
-    end
-    
     def self.sub_authorities_path
       config_path = AUTHORITIES_CONFIG[:local_path]
       if config_path.starts_with?(File::Separator)
-        config_path
-      else
-        File.join(Rails.root, config_path)
+        return config_path
+      end
+      File.join(Rails.root, config_path)
+    end
+
+    def self.sub_authorities
+      @sub_auths ||=
+        begin
+          sub_auths = []
+          Dir.foreach(self.sub_authorities_path) { |file| sub_auths << File.basename(file, File.extname(file)) }
+          sub_auths
+        end
+    end
+
+    def self.terms(sub_authority)
+      @terms = {} if @terms.nil?
+      return @terms[sub_authority] if @terms.has_key?(sub_authority)
+      sub_authority_hash =
+        begin
+          YAML.load(File.read(File.join(self.sub_authorities_path, "#{sub_authority}.yml")))
+        rescue
+          {}
+        end
+      @terms[sub_authority] = normalize_terms(sub_authority_hash.fetch(:terms, []))
+    end
+
+    def self.normalize_terms(terms)
+      terms.map do |term|
+        if term.is_a? String
+          { :id => term, :term => term }
+        else
+          term[:id] ||= term[:term]
+          term
+        end
       end
     end
-    
-    def self.sub_authorities
-      sub_auths = []
-      Dir.foreach(Qa::Authorities::Local.sub_authorities_path) { |file| sub_auths << File.basename(file, File.extname(file)) }
-      sub_auths
+
+    def initialize
     end
-        
+
+    def search(q, sub_authority=nil)
+      @terms = Local.terms(sub_authority)
+      r = q.blank? ? @terms : @terms.select { |term| term[:term].downcase.start_with?(q.downcase) }
+      self.response = r.map do |res|
+        { :id => res[:id], :label => res[:term] }
+      end
+    end
+
+    def get_full_record(id, sub_authority=nil)
+      @terms = Local.terms(sub_authority)
+      @terms.each do |term|
+        return term if term[:id] == id
+      end
+      return {}
+    end
+
   end
 end

--- a/lib/qa/authorities/mesh.rb
+++ b/lib/qa/authorities/mesh.rb
@@ -1,15 +1,22 @@
 module Qa::Authorities
   class Mesh
 
-    def initialize(q, sub_authority=nil)
+    def results
+      @results ||= begin
+                     r = Qa::SubjectMeshTerm.where('term_lower LIKE ?', "#{@q}%").limit(10)
+                     r.map { |t| {id: t.term_id, label: t.term} }
+                   end
+    end
+
+    def search(q, sub_authority=nil)
       @q = q
     end
 
-    def results
+    def get_full_record(id)
       @results ||= begin
-                     r = SubjectMeshTerm.where('term_lower LIKE ?', "#{@q}%").limit(10)
-                     r.map { |t| {id: t.term_id, label: t.term} }
-                   end.to_json
+                     r = Qa::SubjectMeshTerm.where(term_id: id).limit(1).first
+                     r.nil? ? nil : {id: r.term_id, label: r.term, synonyms: r.synonyms}
+                   end
     end
 
     # satisfy TermsController

--- a/lib/qa/authorities/oclcts.rb
+++ b/lib/qa/authorities/oclcts.rb
@@ -8,56 +8,49 @@ module Qa::Authorities
     
     attr_accessor :sub_authority
 
-    def initialize(q, sub_authority='')
-      self.sub_authority = sub_authority
-      self.query_url = SRU_SERVER_CONFIG["url-pattern"]["prefix-query"].gsub(/\{query\}/, q).gsub(/\{authority\-id\}/, sub_authority)
-      self.raw_response = Nokogiri::XML(open(self.query_url))
+    def initialize
     end
 
     def self.authority_valid?(sub_authority)
-      sub_authorities.include?(sub_authority)
+      self.sub_authorities.include?(sub_authority)
     end
 
     def self.sub_authorities
-      a = []
-      SRU_SERVER_CONFIG["authorities"].each do | sub_authority |
-        a.append(sub_authority[0])
-      end
-      a
+      @sub_authorities ||= SRU_SERVER_CONFIG["authorities"].map { |sub_authority| sub_authority[0] }
     end
 
-    def parse_authority_response
+    def search(q, sub_authority=nil)
+      raw_response = get_raw_response("prefix-query", q, sub_authority)
       r = Array.new
-      self.raw_response.xpath('sru:searchRetrieveResponse/sru:records/sru:record/sru:recordData', 'sru' => 'http://www.loc.gov/zing/srw/').each do |record|
+      raw_response.xpath('sru:searchRetrieveResponse/sru:records/sru:record/sru:recordData', 'sru' => 'http://www.loc.gov/zing/srw/').each do |record|
         r.append({"id" => record.xpath('Zthes/term/termId').first.content, "label" => record.xpath('Zthes/term/termName').first.content})
       end
       self.response = r
     end
 
-    def get_full_record(id)
-      unless self.raw_response.xpath("sru:searchRetrieveResponse/sru:records/sru:record/sru:recordData/Zthes/term[termId='" + id + "']", 'sru' => 'http://www.loc.gov/zing/srw/').blank?
-        parse_full_record(self.raw_response, id)
-      else
-        url = SRU_SERVER_CONFIG["url-pattern"]["id-lookup"].gsub(/\{id\}/, id).gsub(/\{authority\-id\}/, self.sub_authority)
-        parse_full_record(Nokogiri::XML(open(url)), id)
-      end
-      
+    def get_full_record(id, sub_authority)
+      raw_response = get_raw_response("id-lookup", id, sub_authority)
+      parse_full_record(raw_response, id)
     end
-    
+
     def parse_full_record(raw_xml, id)
       a = {}
-      zthes_record = raw_xml.xpath("sru:searchRetrieveResponse/sru:records/sru:record/sru:recordData/Zthes/term[termId='" + id + "']", 'sru' => 'http://www.loc.gov/zing/srw/');
-      zthes_record.children.each do | child | 
+      zthes_record = raw_xml.xpath("sru:searchRetrieveResponse/sru:records/sru:record/sru:recordData/Zthes/term[termId='#{id}']", 'sru' => 'http://www.loc.gov/zing/srw/')
+      zthes_record.children.each do |child|
         if (child.is_a? Nokogiri::XML::Element) && (!child.children.nil?) && (child.children.size == 1) && (child.children.first.is_a? Nokogiri::XML::Text)
-          a[child.name] = child.children.first.to_s;    
+          a[child.name] = child.children.first.to_s
         end
       end
-      a;
+      a
     end
 
     def results
-      self.response.to_json
+      self.response
     end
-    
+
+    def get_raw_response(query_type, id, sub_authority)
+      query_url = SRU_SERVER_CONFIG["url-pattern"][query_type].gsub("{query}", id).gsub("{id}", id).gsub("{authority-id}", sub_authority)
+      Nokogiri::XML(open(query_url))
+    end
   end
 end

--- a/lib/qa/authorities/web_service_base.rb
+++ b/lib/qa/authorities/web_service_base.rb
@@ -1,0 +1,20 @@
+require 'curl'
+require 'rest_client'
+
+module Qa::Authorities
+  class WebServiceBase
+    attr_accessor :response, :raw_response
+
+    # mix-in to retreive and parse JSON content from the web
+    def get_json(url)
+      r = RestClient.get url, {accept: :json}
+      self.response = JSON.parse(r)
+    end
+
+    # This method should be removed
+    # use #response instead
+    def results
+      self.response
+    end
+  end
+end

--- a/qa.gemspec
+++ b/qa.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", "~> 4.0.0"
   s.add_dependency "curb"
+  s.add_dependency "rest-client"
   s.add_dependency "nokogiri", "~> 1.6.0"
   s.add_dependency "activerecord-import", ">= 0.4.0"
 

--- a/spec/controllers/terms_controller_spec.rb
+++ b/spec/controllers/terms_controller_spec.rb
@@ -14,7 +14,7 @@ describe Qa::TermsController do
         get :index, { :vocab => nil}
         response.code.should == "400"
       end
-  
+
       it "should return 400 if no query is specified" do
         get :index, { :q => nil}
         response.code.should == "400"
@@ -65,6 +65,10 @@ describe Qa::TermsController do
       end
 
     end
-  
+
+    describe "#show" do
+      it "the path resolves"
+    end
+
   end
 end

--- a/spec/lib/authorities_loc_spec.rb
+++ b/spec/lib/authorities_loc_spec.rb
@@ -6,7 +6,8 @@ describe Qa::Authorities::Loc do
     stub_request(:get, "http://id.loc.gov/search/?format=json&q=haw*&q=cs:http://id.loc.gov/vocabulary/geographicAreas").
       with(:headers => {'Accept'=>'application/json'}).
       to_return(:body => webmock_fixture("loc-response.txt"), :status => 200)
-    @authority = Qa::Authorities::Loc.new("haw*", "geographicAreas")
+    @authority = Qa::Authorities::Loc.new
+    @authority.search("haw*", "geographicAreas")
   end
   
   it "should instantiate with a query and return data" do
@@ -28,7 +29,7 @@ describe Qa::Authorities::Loc do
   
   it "should return JSON" do
     @authority.should_not be_nil
-    json = @authority.parse_authority_response
+    json = @authority.parse_authority_response(@authority.raw_response)
     expect(json).not_to be_empty
   end
 

--- a/spec/lib/authorities_local_spec.rb
+++ b/spec/lib/authorities_local_spec.rb
@@ -16,8 +16,9 @@ describe Qa::Authorities::Local do
   context "retrieve all entries for a local sub_authority" do
     let(:expected) { [ { :id => "A1", :label => "Abc Term A1" }, { :id => "A2", :label => "Term A2" }, { :id => "A3", :label => "Abc Term A3" } ] }
     it "should return all the entries" do
-      authorities = Qa::Authorities::Local.new("", "authority_A")
-      expect(authorities.parse_authority_response).to eq(expected)
+      authorities = Qa::Authorities::Local.new
+      authorities.search("", "authority_A")
+      expect(authorities.response).to eq(expected)
     end
   end
   
@@ -26,63 +27,66 @@ describe Qa::Authorities::Local do
     context "at least one matching entry" do
       let(:expected) { [ { :id => "A1", :label => "Abc Term A1" }, { :id => "A3", :label => "Abc Term A3" } ] }
       it "should return only entries matching the query term" do
-        authorities = Qa::Authorities::Local.new("Abc", "authority_A")
-        expect(authorities.parse_authority_response).to eq(expected)
+        authorities = Qa::Authorities::Local.new
+        authorities.search("Abc", "authority_A")
+        expect(authorities.response).to eq(expected)
       end
     end
     
     context "no matching entries" do
       let(:expected) { [] }
       it "should return an empty array" do
-        authorities = Qa::Authorities::Local.new("def", "authority_A")
-        expect(authorities.parse_authority_response).to eq(expected)
-      end      
+        authorities = Qa::Authorities::Local.new
+        authorities.search("def", "authority_A")
+        expect(authorities.response).to eq(expected)
+      end
     end
     
     context "search not case-sensitive" do
       let(:expected) { [ { :id => "A1", :label => "Abc Term A1" }, { :id => "A3", :label => "Abc Term A3" } ] }
       it "should return entries matching the query term without regard to case" do
-        authorities = Qa::Authorities::Local.new("aBc", "authority_A")
-        expect(authorities.parse_authority_response).to eq(expected)
-      end      
+        authorities = Qa::Authorities::Local.new
+        authorities.search("aBc", "authority_A")
+        expect(authorities.response).to eq(expected)
+      end
     end
     
   end
   
   context "retrieve full record for term" do
 
-    let(:authorities) { Qa::Authorities::Local.new("", "authority_A") }
+    let(:authorities) { Qa::Authorities::Local.new }
     
     context "term exists" do
       let(:id) { "A2" }
-      let(:expected) { { :id => "A2", :term => "Term A2", :active => false }.to_json }
+      let(:expected) { { :id => "A2", :term => "Term A2", :active => false } }
       it "should return the full term record" do
-        expect(authorities.get_full_record(id)).to eq(expected)
+        expect(authorities.get_full_record(id, "authority_A")).to eq(expected)
       end
     end
     
     context "term does not exist" do
       let(:id) { "NonID" }
-      let(:expected) { {}.to_json }
+      let(:expected) { {} }
       it "should return an empty hash" do
-        expect(authorities.get_full_record(id)).to eq(expected)
+        expect(authorities.get_full_record(id, "authority_A")).to eq(expected)
       end
     end
   end
   
   context "term does not an id" do
-    let(:authorities) { Qa::Authorities::Local.new("", "authority_B") }
+    let(:authorities) { Qa::Authorities::Local.new }
     let(:expected) { [ { :id => "Term B1", :label => "Term B1" }, { :id => "Term B2", :label => "Term B2" }, { :id => "Term B3", :label => "Term B3" } ] }
     it "should set the id to be same as the label" do
-      expect(authorities.parse_authority_response).to eq(expected)      
+      expect(authorities.search("", "authority_B")).to eq(expected)
     end
   end
   
   context "authority YAML is a list of terms" do
-    let(:authorities) { Qa::Authorities::Local.new("", "authority_C") }
+    let(:authorities) { Qa::Authorities::Local.new }
     let(:expected) { [ { :id => "Term C1", :label => "Term C1" }, { :id => "Term C2", :label => "Term C2" }, { :id => "Term C3", :label => "Term C3" } ] }
     it "should use the terms as labels" do
-      expect(authorities.parse_authority_response).to eq(expected)      
+      expect(authorities.search("", "authority_C")).to eq(expected)
     end
   end
 

--- a/spec/lib/authorities_mesh_spec.rb
+++ b/spec/lib/authorities_mesh_spec.rb
@@ -28,11 +28,17 @@ describe Qa::Authorities::Mesh do
     end
 
     it "handles queries" do
-      pending "Re-enable this test once Mesh#results is changed to return a hash of results instead of a single json string"
-      m = Authorities::Mesh.new('mr')
+      m = Qa::Authorities::Mesh.new
+      m.search('mr')
       results = m.results
       results.should include( {id: '1', label: 'Mr Plow'} )
       results.length.should == 3
+    end
+
+    it "gets full records" do
+      m = Qa::Authorities::Mesh.new
+      result = m.get_full_record('2')
+      result.should == {id: '2', label: 'Mr Snow', synonyms: []}
     end
   end
 end

--- a/spec/lib/authorities_oclcts_spec.rb
+++ b/spec/lib/authorities_oclcts_spec.rb
@@ -10,10 +10,12 @@ describe Qa::Authorities::Oclcts do
     stub_request(:get, "http://tspilot.oclc.org/mesh/?maximumRecords=10&operation=searchRetrieve&query=dc.identifier%20exact%20%22D031329Q000821%22&recordPacking=xml&recordSchema=http://zthes.z3950.org/xml/1.0/&recordXPath=&resultSetTTL=300&sortKeys=&startRecord=1&version=1.1").
         to_return(:body => webmock_fixture("oclcts-response-mesh-3.txt"), :status => 200)
 
-    @first_query = Qa::Authorities::Oclcts.new("ball", "mesh")
-    @terms = @first_query.parse_authority_response
-    @term_record = @first_query.get_full_record @terms.first["id"]
-    @second_query = Qa::Authorities::Oclcts.new("alph", "mesh")
+    @first_query = Qa::Authorities::Oclcts.new
+    @first_query.search("ball", "mesh")
+    @terms = @first_query.response
+    @term_record = @first_query.get_full_record(@terms.first["id"], "mesh")
+    @second_query = Qa::Authorities::Oclcts.new
+    @second_query.search("alph", "mesh")
   end
 
   describe "a query for terms" do
@@ -40,7 +42,7 @@ describe Qa::Authorities::Oclcts do
     end
     
     it "should succeed for valid ids, even if the id is not in the initial list of responses" do
-      record = @second_query.get_full_record @terms.first["id"]
+      record = @second_query.get_full_record(@terms.first["id"], "mesh")
       record.values.should include @terms.first["id"]
       record.values.should include @terms.first["label"]
     end

--- a/spec/lib/authorities_tgnlang_spec.rb
+++ b/spec/lib/authorities_tgnlang_spec.rb
@@ -3,20 +3,17 @@ require 'spec_helper'
 describe Qa::Authorities::Tgnlang do
 
   before :all do
-    @terms = Qa::Authorities::Tgnlang.new("Tibetan")
+    @terms = Qa::Authorities::Tgnlang.new
+    @terms.search("Tibetan")
   end
 
   describe "response from dataset" do
-    it "should return size 34 with query of Tibetan" do
-      @terms.results.size.should == 34
+    it "should return unique record with query of Tibetan" do
+      @terms.results.should == [{"id"=>"75446", "label"=>"Tibetan"}]
     end
-    it "should return type string" do
-      @terms.results.class.name.should == "String"
+    it "should return type Array" do
+      @terms.results.class.should == Array
     end
-    it "should return a string it contains" do
-      @terms.results["Tibetan"].should == "Tibetan"
-    end
-
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,3 +58,10 @@ end
 def local_authorities_path
   File.expand_path(File.join("../fixtures/authorities"),  __FILE__)
 end
+
+# returns the file contents
+def load_fixture_file(fname)
+  File.open(Rails.root.join("spec/fixtures", fname)) do |f|
+    return f.read
+  end
+end


### PR DESCRIPTION
Added an item show route, and changed the interface between the authorities and the controller. Making a new authority object will no longer do a search---call #search
to do that. Can also call #get_full_record for show information.

Also did some refactoring of the individual authorities.

More tests on the show route are needed. I wasn't sure how to test it. It seems that each authority should test its own web interface.

All comments are welcome.
