### PR TITLE
Remove 'response' method. [API change]

### DIFF
--- a/lib/qa/authorities/base.rb
+++ b/lib/qa/authorities/base.rb
@@ -2,10 +2,6 @@ require 'curl'
 
 module Qa::Authorities
   class Base
-    attr_accessor :response
-
-    def initialize
-    end
 
     # do an autocomplete search
     def search(query, sub_authority=nil)
@@ -15,7 +11,6 @@ module Qa::Authorities
     def get_full_record(id, sub_authority=nil)
     end
 
-
     def self.authority_valid?(sub_authority)
       sub_authority == nil || sub_authorities.include?(sub_authority)
     end
@@ -23,14 +18,6 @@ module Qa::Authorities
     def self.sub_authorities
       [] #Overwrite if you have sub_authorities
     end
-
-    # Parse the result from LOC, and return an JSON array of terms that match the query.
-    def results
-      self.response
-    end
-
-    # TODO: there's other info in the self.response that might be worth making access to, such as
-    # RDF links, etc.
 
   end
 end

--- a/lib/qa/authorities/local.rb
+++ b/lib/qa/authorities/local.rb
@@ -2,8 +2,6 @@ module Qa::Authorities
 
   class Local < Qa::Authorities::Base
 
-    attr_accessor :response
-
     class << self
       def sub_authority(name)
         @sub_authorities ||= {}
@@ -23,7 +21,7 @@ module Qa::Authorities
     def search(q, sub_authority)
       terms = Local.sub_authority(sub_authority).terms
       r = q.blank? ? terms : terms.select { |term| term[:term].downcase.start_with?(q.downcase) }
-      self.response = r.map do |res|
+      r.map do |res|
         { :id => res[:id], :label => res[:term] }.with_indifferent_access
       end
     end

--- a/lib/qa/authorities/oclcts.rb
+++ b/lib/qa/authorities/oclcts.rb
@@ -25,7 +25,7 @@ module Qa::Authorities
       raw_response.xpath('sru:searchRetrieveResponse/sru:records/sru:record/sru:recordData', 'sru' => 'http://www.loc.gov/zing/srw/').each do |record|
         r.append({"id" => record.xpath('Zthes/term/termId').first.content, "label" => record.xpath('Zthes/term/termName').first.content})
       end
-      self.response = r
+      r
     end
 
     def get_full_record(id, sub_authority)
@@ -42,10 +42,6 @@ module Qa::Authorities
         end
       end
       a
-    end
-
-    def results
-      self.response
     end
 
     def get_raw_response(query_type, id, sub_authority)

--- a/spec/lib/authorities_local_spec.rb
+++ b/spec/lib/authorities_local_spec.rb
@@ -24,8 +24,7 @@ describe Qa::Authorities::Local do
                        { 'id' => "A3", 'label' => "Abc Term A3" } ] }
     it "should return all the entries" do
       authorities = Qa::Authorities::Local.new
-      authorities.search("", "authority_A")
-      expect(authorities.response).to eq(expected)
+      expect(authorities.search("", "authority_A")).to eq(expected)
     end
   end
 
@@ -43,8 +42,7 @@ describe Qa::Authorities::Local do
                          { 'id' => "A3", 'label' => "Abc Term A3" } ] }
       it "should return only entries matching the query term" do
         authorities = Qa::Authorities::Local.new
-        authorities.search("Abc", "authority_A")
-        expect(authorities.response).to eq(expected)
+        expect(authorities.search("Abc", "authority_A")).to eq(expected)
       end
     end
     
@@ -52,8 +50,7 @@ describe Qa::Authorities::Local do
       let(:expected) { [] }
       it "should return an empty array" do
         authorities = Qa::Authorities::Local.new
-        authorities.search("def", "authority_A")
-        expect(authorities.response).to eq(expected)
+        expect(authorities.search("def", "authority_A")).to eq(expected)
       end
     end
     
@@ -62,8 +59,7 @@ describe Qa::Authorities::Local do
                          { 'id' => "A3", 'label' => "Abc Term A3" } ] }
       it "should return entries matching the query term without regard to case" do
         authorities = Qa::Authorities::Local.new
-        authorities.search("aBc", "authority_A")
-        expect(authorities.response).to eq(expected)
+        expect(authorities.search("aBc", "authority_A")).to eq(expected)
       end
     end
     

--- a/spec/lib/authorities_oclcts_spec.rb
+++ b/spec/lib/authorities_oclcts_spec.rb
@@ -11,8 +11,7 @@ describe Qa::Authorities::Oclcts do
         to_return(:body => webmock_fixture("oclcts-response-mesh-3.txt"), :status => 200)
 
     @first_query = Qa::Authorities::Oclcts.new
-    @first_query.search("ball", "mesh")
-    @terms = @first_query.response
+    @terms = @first_query.search("ball", "mesh")
     @term_record = @first_query.get_full_record(@terms.first["id"], "mesh")
     @second_query = Qa::Authorities::Oclcts.new
     @second_query.search("alph", "mesh")


### PR DESCRIPTION
@coblej @dbrower Are you guys okay with this API change?  The `response` didn't seem to do anything we couldn't already do with the results from `search`.   The last call to search is always overwriting what is in response, which seems more confusing than it needs to be.
