### PR TITLE
Fix LCSH queries

### DIFF
--- a/spec/fixtures/loc-response.txt
+++ b/spec/fixtures/loc-response.txt
@@ -43,7 +43,7 @@
                 "xmlns:opensearch" : "http://a9.com/-/spec/opensearch/1.1/"
             }
             ,
-                "1"
+                "2"
             ],
                             [
             "opensearch:startIndex",
@@ -62,6 +62,89 @@
                 "20"
             ],
                             [
+            "atom:entry",
+            {
+                "xmlns:atom" : "http://www.w3.org/2005/Atom"
+            }
+            ,
+                        [
+            "atom:title",
+            {
+                "xmlns:atom" : "http://www.w3.org/2005/Atom"
+            }
+            ,
+                "Haw, Lily, 1890?-1915"
+            ],
+                            [
+            "atom:link",
+            {
+                "xmlns:atom" : "http://www.w3.org/2005/Atom", 
+                "rel" : "alternate", 
+                "href" : "http://id.loc.gov/authorities/names/n2008008718"
+            }
+            
+            ],
+                            [
+            "atom:link",
+            {
+                "xmlns:atom" : "http://www.w3.org/2005/Atom", 
+                "rel" : "alternate", 
+                "type" : "application/rdf+xml", 
+                "href" : "http://id.loc.gov/authorities/names/n2008008718.rdf"
+            }
+            
+            ],
+                            [
+            "atom:link",
+            {
+                "xmlns:atom" : "http://www.w3.org/2005/Atom", 
+                "rel" : "alternate", 
+                "type" : "application/json", 
+                "href" : "http://id.loc.gov/authorities/names/n2008008718.json"
+            }
+            
+            ],
+                            [
+            "atom:id",
+            {
+                "xmlns:atom" : "http://www.w3.org/2005/Atom"
+            }
+            ,
+                "info:lc/authorities/names/n2008008718"
+            ],
+                            [
+            "atom:author",
+            {
+                "xmlns:atom" : "http://www.w3.org/2005/Atom"
+            }
+            ,
+                        [
+            "atom:name",
+            {
+                "xmlns:atom" : "http://www.w3.org/2005/Atom"
+            }
+            ,
+                "Library of Congress"
+            ]
+            ],
+                            [
+            "atom:updated",
+            {
+                "xmlns:atom" : "http://www.w3.org/2005/Atom"
+            }
+            ,
+                "2008-03-05T00:00:00-04:00"
+            ],
+                            [
+            "dcterms:created",
+            {
+                "xmlns:dcterms" : "http://purl.org/dc/terms/"
+            }
+            ,
+                "2008-02-05T00:00:00-04:00"
+            ]
+            ],
+            [
             "atom:entry",
             {
                 "xmlns:atom" : "http://www.w3.org/2005/Atom"

--- a/spec/lib/authorities_loc_spec.rb
+++ b/spec/lib/authorities_loc_spec.rb
@@ -67,4 +67,25 @@ describe Qa::Authorities::Loc do
  
   end
 
+  describe "#parse_authority_response" do
+    before :all  do
+      stub_request(:get, "http://id.loc.gov/search/?format=json&q=h&q=cs:http://id.loc.gov/authorities/subjects").
+        with(:headers => {'Accept'=>'application/json'}).
+        to_return(:body => webmock_fixture("loc-response.txt"), :status => 200)
+      @authority.search("h", "subjects")
+    end
+
+    let(:parsed_response) { @authority.parse_authority_response(@authority.raw_response) }
+
+    it "should return an array of entries returned in the JSON" do
+      expect(parsed_response.length).to eq(2)
+    end
+
+    it "should have a URI for the id and a string label" do
+      expect(parsed_response[0]["id"]).to eq("info:lc/authorities/names/n2008008718")
+      expect(parsed_response[0]["label"]).to eq("Haw, Lily, 1890?-1915")
+      expect(parsed_response[1]["id"]).to eq("info:lc/vocabulary/geographicAreas/n-us-hi")
+      expect(parsed_response[1]["label"]).to eq("Hawaii")
+    end
+  end
 end


### PR DESCRIPTION
- Refactors Loc authority for easier overriding
- Escapes queries before sending to LC, fixing issues when typing a
  search with spaces, such as "food portions"
- Adds slightly more LoC query testing to validate refactoring work
- Fixes searches for "obvious" subjects by removing the forced wildcard,
  which converted a search for "dogs" into "dogs*", which didn't return
  the simple subject heading of just plain ol' "Dogs".
