### PR TITLE
Check for query parameter when searching; updating to Rspec v3 syntax

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,6 @@
 #!/usr/bin/env rake
 require 'bundler/gem_tasks'
 require 'engine_cart/rake_task'
-EngineCart.rails_options = '--skip-spring'
 require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)

--- a/app/controllers/qa/terms_controller.rb
+++ b/app/controllers/qa/terms_controller.rb
@@ -5,17 +5,16 @@
 class Qa::TermsController < ApplicationController
 
   before_action :check_vocab_param, :init_authority
+  before_action :check_query_param, only: :search
 
   # If the subauthority supports it, return a list of all terms in the authority
   def index
     render json: @authority.all
   end
 
-  # Return a list of terms based on a query
-  # - converts query wildcards appropriately  
+  # Return a list of terms based on a query 
   def search
-    params[:q].gsub!("*", "%2A") if params[:q]
-    terms = @authority.search(params[:q])
+    terms = @authority.search(url_search)
     render json: terms
   end
 
@@ -26,9 +25,7 @@ class Qa::TermsController < ApplicationController
   end
 
   def check_vocab_param
-    unless params[:vocab].present?
-      head :not_found
-    end
+    head :not_found unless params[:vocab].present?
   end
 
   def init_authority
@@ -37,10 +34,19 @@ class Qa::TermsController < ApplicationController
     head :not_found
   end
 
+  def check_query_param
+    head :not_found unless params[:q].present?
+  end
+
   private
 
   def authority_class
     "Qa::Authorities::"+params[:vocab].capitalize
+  end
+
+  # converts wildcards into URL-encoded characters
+  def url_search
+    params[:q].gsub("*", "%2A")
   end
 
 end

--- a/spec/controllers/terms_controller_spec.rb
+++ b/spec/controllers/terms_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Qa::TermsController do
+describe Qa::TermsController, :type => :controller do
 
   before do
     @routes = Qa::Engine.routes
@@ -9,6 +9,13 @@ describe Qa::TermsController do
   describe "#check_vocab_param" do
     it "should return 404 if the vocabulary is missing" do
       get :search, { :q => "a query", :vocab => "" }
+      expect(response.code).to eq("404")
+    end
+  end
+
+  describe "#check_query_param" do
+    it "should return 404 if the query is missing" do
+      get :search, { :q => "", :vocab => "tgnlang" }
       expect(response.code).to eq("404")
     end
   end
@@ -63,26 +70,26 @@ describe Qa::TermsController do
     context "with supported authorities" do
       it "should return all local authority state terms" do
         get :index, { :vocab => "local", :sub_authority => "states" }
-        response.should be_success
+        expect(response).to be_success
       end
       it "should return all MeSH terms" do
         get :index, { :vocab => "mesh" }
-        response.should be_success
+        expect(response).to be_success
       end
     end
 
     context "when the authority does not support #all" do
       it "should return null for tgnlang" do
         get :index, { :vocab => "tgnlang" }
-        response.body.should == "null"
+        expect(response.body).to eq("null")
       end
       it "should return null for oclcts" do
         get :index, { :vocab => "oclcts", :sub_authority => "mesh" }
-        response.body.should == "null"
+        expect(response.body).to eq("null")
       end
       it "should return null for LOC authorities" do
         get :index, { :vocab => "loc", :sub_authority => "relators" }
-        response.body.should == "null"
+        expect(response.body).to eq("null")
       end
     end
 
@@ -100,17 +107,17 @@ describe Qa::TermsController do
 
       it "should return an individual state term" do
         get :show, { :vocab => "local", :sub_authority => "states", id: "OH" }
-        response.should be_success
+        expect(response).to be_success
       end
 
       it "should return an individual MeSH term" do
         get :show, { vocab: "mesh", id: "D000001" }
-        response.should be_success
+        expect(response).to be_success
       end
 
       it "should return an individual subject term" do
         get :show, { vocab: "loc", sub_authority: "subjects", id: "sh85077565" }
-        response.should be_success
+        expect(response).to be_success
       end
 
     end

--- a/spec/lib/authorities_loc_spec.rb
+++ b/spec/lib/authorities_loc_spec.rb
@@ -5,17 +5,17 @@ describe Qa::Authorities::Loc do
   describe "#new" do
     context "without a sub-authority" do
       it "should raise an exception" do
-        lambda { Qa::Authorities::Loc.new }.should raise_error
+        expect { Qa::Authorities::Loc.new }.to raise_error
       end
     end
     context "with an invalid sub-authority" do
       it "should raise an exception" do
-        lambda { Qa::Authorities::Loc.new("foo") }.should raise_error
+        expect { Qa::Authorities::Loc.new("foo") }.to raise_error
       end
     end
     context "with a valid sub-authority" do
       it "should create the authority" do
-        Qa::Authorities::Loc.new("subjects").should be_kind_of Qa::Authorities::Loc
+        expect(Qa::Authorities::Loc.new("subjects")).to be_kind_of Qa::Authorities::Loc
       end
     end
   end
@@ -29,14 +29,14 @@ describe Qa::Authorities::Loc do
     context "for searching" do
       it "should return a url" do
         url = 'http://id.loc.gov/search/?q=foo&q=cs%3Ahttp%3A%2F%2Fid.loc.gov%2Fauthorities%2Fsubjects&format=json'
-        authority.build_query_url("foo").should eq(url)
+        expect(authority.build_query_url("foo")).to eq(url)
       end
     end
 
     context "for returning single terms" do
       it "returns a url with an authority and id" do
         url = "http://id.loc.gov/authorities/subjects/sh2002003586.json"
-        authority.find_url("sh2002003586").should eq(url)
+        expect(authority.find_url("sh2002003586")).to eq(url)
       end
     end
   
@@ -53,10 +53,10 @@ describe Qa::Authorities::Loc do
       end
 
       it "should retain the raw respsonse from the LC service in JSON" do
-        authority.raw_response.should be_nil
+        expect(authority.raw_response).to be_nil
         json = Qa::Authorities::WebServiceBase.new.get_json(authority.build_query_url("s"))
         authority.search("s")
-        authority.raw_response.should eq(json)
+        expect(authority.raw_response).to eq(json)
       end
 
       describe "the returned results" do
@@ -66,11 +66,11 @@ describe Qa::Authorities::Loc do
         end
 
         it "should have :id and :label elements" do
-          results.first["label"].should == "West (U.S.)"
-          results.first["id"].should == "info:lc/vocabulary/geographicAreas/n-usp"
-          results.last["label"].should == "Baltic States"
-          results.last["id"].should == "info:lc/vocabulary/geographicAreas/eb"
-          results.size.should == 20
+          expect(results.first["label"]).to eq("West (U.S.)")
+          expect(results.first["id"]).to eq("info:lc/vocabulary/geographicAreas/n-usp")
+          expect(results.last["label"]).to eq("Baltic States")
+          expect(results.last["id"]).to eq("info:lc/vocabulary/geographicAreas/eb")
+          expect(results.size).to eq(20)
         end
 
       end
@@ -84,11 +84,11 @@ describe Qa::Authorities::Loc do
         Qa::Authorities::Loc.new("subjects").search("History--")
       end
       it "should have a URI for the id and a string label" do
-        results.count.should == 20
-        results.first["label"].should == "History--Philosophy--History--20th century"
-        results.first["id"].should == "info:lc/authorities/subjects/sh2008121753"
-        results[1]["label"].should == "History--Philosophy--History--19th century"
-        results[1]["id"].should == "info:lc/authorities/subjects/sh2008121752"
+        expect(results.count).to eq(20)
+        expect(results.first["label"]).to eq("History--Philosophy--History--20th century")
+        expect(results.first["id"]).to eq("info:lc/authorities/subjects/sh2008121753")
+        expect(results[1]["label"]).to eq("History--Philosophy--History--19th century")
+        expect(results[1]["id"]).to eq("info:lc/authorities/subjects/sh2008121752")
       end
     end
 
@@ -100,7 +100,7 @@ describe Qa::Authorities::Loc do
             Qa::Authorities::Loc.new("names").search("Berry")
       end
       it "should retrieve names via search" do
-        results.first["label"].should == "Berry, James W. (James William), 1938-"
+        expect(results.first["label"]).to eq("Berry, James W. (James William), 1938-")
       end
     end
 
@@ -115,8 +115,8 @@ describe Qa::Authorities::Loc do
         Qa::Authorities::Loc.new("subjects").find("sh2002003586")
       end
       it "returns the complete record for a given subject" do
-        results.count.should eq(20)
-        results.first.should be_kind_of(Hash)
+        expect(results.count).to eq(20)
+        expect(results.first).to be_kind_of(Hash)
       end
     end
   end

--- a/spec/lib/authorities_loc_subauthorities.rb
+++ b/spec/lib/authorities_loc_subauthorities.rb
@@ -12,14 +12,14 @@ describe Qa::Authorities::LocSubauthority do
   context "with a valid subauthority" do
     it "should return a url" do
       sub_authority_table.keys.each do |authority|
-        subject.get_url_for_authority(authority).should == sub_authority_table[authority]
+        expect(subject.get_url_for_authority(authority)).to eq(sub_authority_table[authority])
       end
     end
   end
 
   context "with a non-existent subauthority" do
     it "should return nil" do
-      subject.get_url_for_authority("fake").should be_nil
+      expect(subject.get_url_for_authority("fake")).to be_nil
     end
   end
 

--- a/spec/lib/authorities_local_spec.rb
+++ b/spec/lib/authorities_local_spec.rb
@@ -10,10 +10,10 @@ describe Qa::Authorities::Local do
   describe "::new" do
     context "without a sub-authority" do
       it "should raise an error is the sub-authority is not provided" do
-        lambda { Qa::Authorities::Local.new }.should raise_error
+        expect { Qa::Authorities::Local.new }.to raise_error
       end
       it "should raise an error is the sub-authority does not exist" do
-        lambda { Qa::Authorities::Local.new("foo") }.should raise_error
+        expect { Qa::Authorities::Local.new("foo") }.to raise_error
       end
     end
   end
@@ -23,7 +23,7 @@ describe Qa::Authorities::Local do
                        { 'id' => "A2", 'label'=> "Term A2" },
                        { 'id' => "A3", 'label' => "Abc Term A3" } ] }
     it "should return all the entries" do
-      authority_a.all.should eq(expected)
+      expect(authority_a.all).to eq(expected)
     end
     context "when terms do not have ids" do
       let(:expected) { [ { 'id' => "Term B1", 'label' => "Term B1" },
@@ -43,7 +43,7 @@ describe Qa::Authorities::Local do
     end
     context "YAML file is malformed" do
       it "should raise an error" do
-        lambda { authority_d.all }.should raise_error
+        expect { authority_d.all }.to raise_error
       end
     end
   end

--- a/spec/lib/authorities_local_subauthorities_spec.rb
+++ b/spec/lib/authorities_local_subauthorities_spec.rb
@@ -21,7 +21,7 @@ describe Qa::Authorities::LocalSubauthority do
         AUTHORITIES_CONFIG[:local_path] = "/full/path"
       end
       it "returns a full path" do
-        test.sub_authorities_path.should == AUTHORITIES_CONFIG[:local_path]
+        expect(test.sub_authorities_path).to eq(AUTHORITIES_CONFIG[:local_path])
       end
     end
     context "configured with a relative path" do
@@ -29,14 +29,14 @@ describe Qa::Authorities::LocalSubauthority do
         AUTHORITIES_CONFIG[:local_path] = "relative/path"
       end
       it "returns a path relative to the Rails applicaition" do
-        test.sub_authorities_path.should == File.join(Rails.root, AUTHORITIES_CONFIG[:local_path])
+        expect(test.sub_authorities_path).to eq(File.join(Rails.root, AUTHORITIES_CONFIG[:local_path]))
       end
     end
   end
 
   describe "#names" do  
     it "returns a list of yaml files" do
-      test.names.should include("authority_A", "authority_B", "authority_C", "authority_D", "states")
+      expect(test.names).to include("authority_A", "authority_B", "authority_C", "authority_D", "states")
     end
   end
 

--- a/spec/lib/authorities_mesh_spec.rb
+++ b/spec/lib/authorities_mesh_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Qa::Authorities::Mesh do
   def where_unique_record(klass, q)
-    klass.where(q).length.should == 1
+    expect(klass.where(q).length).to eq(1)
   end
 
   it "imports a mesh dump file" do
@@ -13,7 +13,7 @@ describe Qa::Authorities::Mesh do
     where_unique_record(Qa::SubjectMeshTerm, {term_lower: "malaria"})
     where_unique_record(Qa::SubjectMeshTerm, {term: "Malaria"})
     where_unique_record(Qa::SubjectMeshTerm, {term_id: "D008288"})
-    Qa::SubjectMeshTerm.all.length.should == 11
+    expect(Qa::SubjectMeshTerm.all.length).to eq(11)
   end
 
   describe "the query interface" do
@@ -31,18 +31,18 @@ describe Qa::Authorities::Mesh do
 
     it "handles queries" do
       results = m.search('mr')
-      results.should include( {id: '1', label: 'Mr Plow'} )
-      results.length.should == 3
+      expect(results).to include( {id: '1', label: 'Mr Plow'} )
+      expect(results.length).to eq(3)
     end
 
-    it "gets full records" do
-      result = m.full_record('2')
-      result.should == {id: '2', label: 'Mr Snow', synonyms: []}
+    it "returns individual records" do
+      result = m.find('2')
+      expect(result).to eq({id: '2', label: 'Mr Snow', synonyms: []})
     end
 
     it "returns all records" do
-      m.all.count.should == 3
-      m.all.should include({:id=>"2", :label=>"Mr Snow"})
+      expect(m.all.count).to eq(3)
+      expect(m.all).to include({:id=>"2", :label=>"Mr Snow"})
     end
   end
 end

--- a/spec/lib/authorities_oclcts_spec.rb
+++ b/spec/lib/authorities_oclcts_spec.rb
@@ -20,30 +20,30 @@ describe Qa::Authorities::Oclcts do
   describe "a query for terms" do
 
     it "should have an array of hashes that match the query" do
-      @terms.should be_kind_of Array
-      @terms.first.should be_kind_of Hash
-      @terms.first["label"].should be_kind_of String
-      @terms.first["label"].should include "Ballota"
+      expect(@terms).to be_kind_of Array
+      expect(@terms.first).to be_kind_of Hash
+      expect(@terms.first["label"]).to be_kind_of String
+      expect(@terms.first["label"]).to include "Ballota"
     end
 
     it "should have an array of hashes containing unique id and label" do
-      @terms.first.should have_key("id")
-      @terms.first.should have_key("label")
+      expect(@terms.first).to have_key("id")
+      expect(@terms.first).to have_key("label")
     end
 
   end
 
   describe "a query for a single item" do
     it "should have a hash of values that represent the item requested" do
-      @term_record.should be_kind_of Hash
-      @term_record.values.should include @terms.first["id"] 
-      @term_record.values.should include @terms.first["label"]
+      expect(@term_record).to be_kind_of Hash
+      expect(@term_record.values).to include @terms.first["id"] 
+      expect(@term_record.values).to include @terms.first["label"]
     end
     
     it "should succeed for valid ids, even if the id is not in the initial list of responses" do
       record = @second_query.find(@terms.first["id"])
-      record.values.should include @terms.first["id"]
-      record.values.should include @terms.first["label"]
+      expect(record.values).to include @terms.first["id"]
+      expect(record.values).to include @terms.first["label"]
     end
   end
 

--- a/spec/lib/authorities_tgnlang_spec.rb
+++ b/spec/lib/authorities_tgnlang_spec.rb
@@ -6,10 +6,10 @@ describe Qa::Authorities::Tgnlang do
 
   describe "#search" do
     it "should return unique record with query of Tibetan" do
-      subject.search("Tibetan").should == [{"id"=>"75446", "label"=>"Tibetan"}]
+      expect(subject.search("Tibetan")).to eq([{"id"=>"75446", "label"=>"Tibetan"}])
     end
     it "should return type Array" do
-      subject.search("Tibetan").should be_kind_of(Array)
+      expect(subject.search("Tibetan")).to be_kind_of(Array)
     end
   end
 

--- a/spec/lib/mesh_data_parser_spec.rb
+++ b/spec/lib/mesh_data_parser_spec.rb
@@ -11,8 +11,8 @@ B = more than one
 EOS
     mesh = Qa::Authorities::MeshTools::MeshDataParser.new(StringIO.new(data))
     records = mesh.all_records
-    records.length.should == 1
-    records[0].should == {'A'=>['45'],'B'=>['a = b = c = d','more than one']}
+    expect(records.length).to eq(1)
+    expect(records[0]).to eq({'A'=>['45'],'B'=>['a = b = c = d','more than one']})
   end
 
   it "handles two records" do
@@ -28,9 +28,9 @@ print entry = test
 EOS
     mesh = Qa::Authorities::MeshTools::MeshDataParser.new(StringIO.new(data))
     records = mesh.all_records
-    records.length.should == 2
-    records[0].should == {'A'=>['45'],'B'=>['a = b = c = d']}
-    records[1].should == {'A'=>['another field'], 'print entry'=>['test']}
+    expect(records.length).to eq(2)
+    expect(records[0]).to eq({'A'=>['45'],'B'=>['a = b = c = d']})
+    expect(records[1]).to eq({'A'=>['another field'], 'print entry'=>['test']})
   end
 
   it 'ignores bad input' do
@@ -43,16 +43,16 @@ B=no space
 EOS
     mesh = Qa::Authorities::MeshTools::MeshDataParser.new(StringIO.new(data))
     records = mesh.all_records
-    records.length.should == 2
-    records[0].should == {'A'=>['45']}
-    records[1].should == {}
+    expect(records.length).to eq(2)
+    expect(records[0]).to eq({'A'=>['45']})
+    expect(records[1]).to eq({})
   end
 
   it 'parses a sample mesh file' do
     mesh = Qa::Authorities::MeshTools::MeshDataParser.new(webmock_fixture('mesh.txt'))
     records = mesh.all_records
-    records.length.should == 11
-    records[0].should == {
+    expect(records.length).to eq(11)
+    expect(records[0]).to eq({
       "RECTYPE" => ["D"],
       "MH" => ["Malaria"],
       "AQ" => ["BL CF CI CL CN CO DH DI DT EC EH EM EN EP ET GE HI IM ME MI MO NU PA PC PP PS PX RA RH RI RT SU TH TM UR US VE VI"],
@@ -86,8 +86,8 @@ EOS
       "DA" => ["19990101"],
       "DC" => ["1"],
       "UI" => ["D008288"]
-    }
-    records[1].should == {
+    })
+    expect(records[1]).to eq({
       "RECTYPE" => ["D"],
       "MH" => ["Calcimycin"],
       "AQ" => ["AA AD AE AG AI AN BI BL CF CH CL CS CT DU EC HI IM IP ME PD PK PO RE SD ST TO TU UR"],
@@ -119,7 +119,7 @@ EOS
       "DC" => ["1"],
       "DX" => ["19840101"],
       "UI" => ["D000001"]
-    }
+    })
   end
 end
 

--- a/spec/lib/tasks/mesh.rake_spec.rb
+++ b/spec/lib/tasks/mesh.rake_spec.rb
@@ -20,13 +20,13 @@ describe "mesh rake tasks" do
       $stdout = STDOUT
     end
     it "should have 'environment' as a prereq" do
-      @rake[@task_name].prerequisites.should include("environment")
+      expect(@rake[@task_name].prerequisites).to include("environment")
     end
     it "should require $MESH_FILE to be set" do
       old_mesh_file = ENV.delete('MESH_FILE')
       @rake[@task_name].invoke
       @output.seek(0)
-      @output.read.should =~ /Need to set \$MESH_FILE with path to file to ingest/
+      expect(@output.read).to match(/Need to set \$MESH_FILE with path to file to ingest/)
       ENV['MESH_FILE'] = old_mesh_file
     end
     it "should create or update all records in the config file" do
@@ -35,8 +35,8 @@ describe "mesh rake tasks" do
       expect(File).to receive(:open).with("dummy").and_yield(input)
       @rake[@task_name].invoke
       term = Qa::SubjectMeshTerm.find_by_term_id(5)
-      term.should_not be_nil
-      term.term.should == "test"
+      expect(term).not_to be_nil
+      expect(term.term).to eq("test")
       ENV['MESH_FILE'] = nil
     end
   end

--- a/spec/models/subject_mesh_term_spec.rb
+++ b/spec/models/subject_mesh_term_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Qa::SubjectMeshTerm do
+describe Qa::SubjectMeshTerm, :type => :model do
   before(:all) do
     @term = Qa::SubjectMeshTerm.new
     @term.term_id = "ABCDEFG"
@@ -11,17 +11,17 @@ describe Qa::SubjectMeshTerm do
     @term.destroy
   end
   it "returns an empty synonym list" do
-    @term.synonyms.should == []
+    expect(@term.synonyms).to eq([])
   end
   it "returns a list of trees" do
-    @term.trees.should == []
+    expect(@term.trees).to eq([])
   end
   it "saves a synonym list" do
     a = Qa::SubjectMeshTerm.new
     a.term_id = 'a'
     a.synonyms = ['b','c']
     a.save
-    a.synonyms.should == ['b', 'c']
+    expect(a.synonyms).to eq(['b', 'c'])
   end
   it "finds a term by tree number" do
     t = Qa::MeshTree.new
@@ -29,7 +29,7 @@ describe Qa::SubjectMeshTerm do
     t.tree_number = "D1.2.3.4"
     t.save!
     a = Qa::SubjectMeshTerm.from_tree_number("D1.2.3.4")
-    a.length.should == 1
+    expect(a.length).to eq(1)
   end
 
   it "returns parents"

--- a/spec/routing/route_spec.rb
+++ b/spec/routing/route_spec.rb
@@ -1,33 +1,33 @@
 require 'spec_helper'
 
-describe "QA Routes" do
+describe "QA Routes", :type => :routing do
 
   routes { Qa::Engine.routes }
 
   context "listing terms" do
     it "should route to index with an authority" do
-      { get: '/terms/vocab' }.should route_to(controller: 'qa/terms', action: 'index', vocab: 'vocab')
+      expect({ get: '/terms/vocab' }).to route_to(controller: 'qa/terms', action: 'index', vocab: 'vocab')
     end
     it "should route to index with an authority and a subauthority" do
-      { get: '/terms/vocab/sub' }.should route_to(controller: 'qa/terms', action: 'index', vocab: 'vocab', sub_authority: 'sub')
+      expect({ get: '/terms/vocab/sub' }).to route_to(controller: 'qa/terms', action: 'index', vocab: 'vocab', sub_authority: 'sub')
     end
   end
 
   context "searching for terms" do
     it "should route to searching for an authority" do
-      { get: '/search/vocab' }.should route_to(controller: 'qa/terms', action: 'search', vocab: 'vocab')
+      expect({ get: '/search/vocab' }).to route_to(controller: 'qa/terms', action: 'search', vocab: 'vocab')
     end
     it "should route to searching for an authority and a subauthority" do
-      { get: '/search/vocab/sub' }.should route_to(controller: 'qa/terms', action: 'search', vocab: 'vocab', sub_authority: 'sub')
+      expect({ get: '/search/vocab/sub' }).to route_to(controller: 'qa/terms', action: 'search', vocab: 'vocab', sub_authority: 'sub')
     end
   end
 
   context "displaying a single term" do
     it "should route to an authority" do
-      { get: '/show/vocab/term_id' }.should route_to(controller: 'qa/terms', action: 'show', vocab: 'vocab', id: 'term_id')
+      expect({ get: '/show/vocab/term_id' }).to route_to(controller: 'qa/terms', action: 'show', vocab: 'vocab', id: 'term_id')
     end
     it "should route to an authority with a subauthority" do
-      { get: '/show/vocab/sub/term_id' }.should route_to(controller: 'qa/terms', action: 'show', vocab: 'vocab', sub_authority: 'sub', id: 'term_id')
+      expect({ get: '/show/vocab/sub/term_id' }).to route_to(controller: 'qa/terms', action: 'show', vocab: 'vocab', sub_authority: 'sub', id: 'term_id')
     end
   end
   

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,16 +2,13 @@ require File.expand_path("../internal/config/environment.rb",  __FILE__)
 require 'rspec/rails'
 require 'webmock/rspec'
 require 'engine_cart'
+require 'simplecov'
 require 'byebug' unless ENV['TRAVIS']
 
-ENV["RAILS_ENV"] ||= 'test'
+ENV["RAILS_ENV"] ||= "test"
 
-if ENV['COVERAGE']
-  require 'simplecov'
-  SimpleCov.start 'rails'
-  SimpleCov.command_name "spec"
-end
-
+SimpleCov.start "rails"
+SimpleCov.command_name "spec"
 EngineCart.load_application!
 
 # Requires supporting ruby files with custom matchers and macros, etc,
@@ -19,24 +16,12 @@ EngineCart.load_application!
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 # Checks for pending migrations before tests are run.
-# If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)
 
 RSpec.configure do |config|
-  # ## Mock Framework
-  #
-  # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:
-  #
-  # config.mock_with :mocha
-  # config.mock_with :flexmock
-  # config.mock_with :rr
 
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "../spec/fixtures"
 
-  # If you're not using ActiveRecord, or you'd prefer not to run each of your
-  # examples within a transaction, remove the following line or assign false
-  # instead of true.
   config.use_transactional_fixtures = true
 
   # If true, the base class of anonymous controllers will be inferred


### PR DESCRIPTION
Fixes #65 and updates tests to the new RSpec v.3 syntax
