### PR TITLE
Add geonames linked data access and usage notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ You should question your authorities.
       * [Configuring a LOD Authority](#configuring-a-lod-authority)
       * [Query](#query)
       * [Find term](#find-term)
+      * [Authority Usage Notes](#linked-data-authority-usage-notes)
+        * [Agrovoc](#agrovoc-linked-data)
+        * [Geonames](#geonames-linked-data)
+        * [Library of Congress](#library-of-congress-linked-data)
+        * [OCLC FAST](#oclc-fast-linked-data)
       * [Add javascript to support autocomplete](#add-javascript-to-support-autocomplete)
   * [Developer Notes](#developer-notes)
     * [Compatibility](#compatibility)
@@ -608,6 +613,170 @@ Returns results in the format...
 ```
 
 NOTE: All predicates with the URI as the subject will be included under "predicates" key.  The selected keys are determined by the configuration file and can be one or more of id_predicate, label_predicate (required), altlabel_predicate, sameas_predicate, narrower_predicate, or broader_predicate.
+
+#### Linked Data Authority Usage Notes
+##### Agrovoc Linked Data
+
+Configuration File: [agrovoc.json](https://github.com/projecthydra/questioning_authority/blob/master/config/authorities/linked_data/agrovoc.json)
+
+*Example Search URLs*
+
+Pattern:  `http://www.your.host/qa/search/linked_data/agrovoc?q={?query}&lang={?language_code}`
+
+Localhost Examples:
+<br>http://localhost:3000/qa/search/linked_data/agrovoc?q=hive
+<br>http://localhost:3000/qa/search/linked_data/agrovoc?q=ruche&lang=fr
+
+where,
+
+| parameter | required? | description | default value | example values |
+| --------- | --------- | ----------- | ------------- | -------------- |
+| {?query}  | required  | the query string to send to the authority | N/A | cornell, twain, ezra, etc. |
+| {?language_code} | optional | results will be filtered to the language code | en | en, fr, de, etc. |
+
+*Example Fetch Term URLs*
+
+Pattern:  `http://www.your.host/qa/show/linked_data/agrovoc/{?term_id}`
+
+Localhost Examples:
+<br>http://localhost:3000/qa/show/linked_data/agrovoc/c_3655
+
+where,
+
+| parameter  | required? | description | default value | example values |
+| ---------  | --------- | ----------- | ------------- | -------------- |
+| {?term_id} | required  | the id of the term to fetch from the authority | N/A | c_123 |
+
+NOTE: A default language of `['en']` is set in the configuration for term fetch.  You can change the default language by copying the entire configuration file from QA /config/authorities/linked_data/agrovoc.json to your app in the same location.  The language can be set to one or more languages by using the standard language codes in an array, e.g. `['fr']` or `['en', 'fr']`, etc.
+
+
+##### Geonames Linked Data
+
+Configuration File: [geonames.json](https://github.com/projecthydra/questioning_authority/blob/master/config/authorities/linked_data/geonames.json)
+
+*Example Search URLs*
+
+Pattern:  `http://www.your.host/qa/search/linked_data/geonames?q={?query}&maximumRecords={?maximumRecords}&username={?username}`
+
+Localhost Examples:
+<br>http://localhost:3000/qa/search/linked_data/geonames?q=ithaca&username=yourusername
+<br>http://localhost:3000/qa/search/linked_data/geonames?q=london&maximumRecords=5&username=yourusername
+  
+where,
+
+| parameter | required? | description | default value | example values |
+| --------- | --------- | ----------- | ------------- | -------------- |
+| {?query}  | required  | the query string to send to the authority | N/A | cornell, twain, ezra, etc. |
+| {?maximumRecords | optional | the number of results for the authority to return | 20 | positive integer |
+| {?username | required | the username required to access geonames api | demo | must be updated to your username |
+
+NOTE: You must register at [geonames.org](http://www.geonames.org/login) to get a username.  The search URL will not work with the default `demo` username.  If you do not want to pass the username as part of the QA url, you can copy the entire configuration file from QA /config/authorities/linked_data/geonames.json to your app in the same location.  Then change the default value from `demo` to your username.
+
+*Example Fetch Term URLs*
+
+Pattern:  `http://www.your.host/qa/show/linked_data/geonames/{?term_uri}`
+
+Localhost Examples:
+<br>http://localhost:3000/qa/show/linked_data/geonames/http%3A%2F%2Fsws%2Egeonames%2Eorg%2F2643741
+  
+where,
+
+| parameter   | required? | description | default value | example values |
+| ---------   | --------- | ----------- | ------------- | -------------- |
+| {?term_uri} | required  | the uri of the term to fetch from the authority | N/A | `http://sws.geonames.org/5070896/` as the url encoded form.  See example below. |
+
+NOTE: The `{?term_uri}` must be URL Encoded.  The example value as part of the Fetch URL should be: http%3A%2F%2Fsws%2Egeonames%2Eorg%2F2643741
+
+
+##### Library of Congress Linked Data
+
+Configuration File: [loc.json](https://github.com/projecthydra/questioning_authority/blob/master/config/authorities/linked_data/loc.json)
+
+*Example Search URLs*
+
+Not supported.  You can use non-linked data access to Library of Congress, get the URI for each search result, and make individual term fetchs to get the remainder of the information.  This approach will be slow.
+
+*Example Fetch Term URLs*
+
+Pattern:  `http://www.your.host/qa/show/linked_data/loc/{?subauthority}/{?term_id}`
+
+Localhost Examples:
+<br>http://localhost:3000/qa/show/linked_data/loc/n79065220
+<br>http://localhost:3000/qa/show/linked_data/loc/names/n79065220
+<br>http://localhost:3000/qa/show/linked_data/loc/subjects/sh85118553
+  
+where,
+
+| parameter  | required? | description | default value | example values |
+| ---------  | --------- | ----------- | ------------- | -------------- |
+| {?term_id} | required  | the id of the term to fetch from the authority | N/A | 123 |
+| {?subauthority} | required  | a Library of Congress subauthority | names | see list below |
+
+You can use any of the following subauthorities in place of `{?subauthority}`.
+
+| use in QA URL  | translates to LoC subauthority | 
+| -------------- | ------------------------------------ |
+| subjects       | subjects           |
+| names          | names              |
+| classification | classification     |
+| child_subject  | childrensSubjects  |
+| genre          | genreForms         |
+| demographic    | demographicTerms   |
+
+NOTE: A default language of `['en']` is set in the configuration for term fetch.  You can change the default language by copying the entire configuration file from QA /config/authorities/linked_data/loc.json to your app in the same location.  The language can be set to one or more languages by using the standard language codes in an array, e.g. `['fr']` or `['en', 'fr']`, etc.
+
+
+##### OCLC FAST Linked Data
+
+Configuration File: [oclc_fast.json](https://github.com/projecthydra/questioning_authority/blob/master/config/authorities/linked_data/oclc_fast.json)
+
+*Example Search URLs*
+
+Pattern (search all):  `http://www.your.host/qa/search/linked_data/oclc_fast?q={?query}&maximumRecords={?maximumRecords}`
+Pattern (search subauthority):  `http://www.your.host/qa/search/linked_data/oclc_fast/{?subauthority}?q={?query}&maximumRecords={?maximumRecords}`
+
+Localhost Examples:
+<br>http://localhost:3000/qa/search/linked_data/oclc_fast?q=cornell
+<br>http://localhost:3000/qa/search/linked_data/oclc_fast?q=cornell&maximumRecords=3
+<br>http://localhost:3000/qa/search/linked_data/oclc_fast/personal_name?q=ezra
+<br>http://localhost:3000/qa/search/linked_data/oclc_fast/personal_name?q=ezra&maximumRecords=5
+
+where,
+
+| parameter | required? | description | default value | example values |
+| --------- | --------- | ----------- | ------------- | -------------- |
+| {?query}  | required  | the query string to send to the authority | N/A | cornell, twain, ezra, etc. |
+| {?maximumRecords | optional | the number of results for the authority to return | 20 | positive integer |
+| {?subauthority | optional | an OCLC FAST subauthority to search | ALL | see list below |
+
+You can use any of the following subauthorities in place of `{?subauthority}`.
+
+| use in QA URL  | translates to OCLC FAST subauthority | 
+| -------------- | ------------------------------------ |
+| topic          | oclc.topic           |
+| geographic     | oclc.geographic      | 
+| event_name     | oclc.eventName       |
+| personal_name  | oclc.personalName    |
+| corporate_name | oclc.corporateName   |
+| uniform_title  | oclc.uniformTitle    |
+| period         | oclc.period          |
+| form           | oclc.form            |
+| alt_lc         | oclc.altlc           |
+
+*Example Fetch Term URLs*
+
+Pattern:  `http://www.your.host/qa/show/linked_data/oclc_fast/{?term_id}`
+
+Localhost Examples:
+<br>http://localhost:3000/qa/show/linked_data/oclc_fast/409667
+
+where,
+
+| parameter  | required? | description | default value | example values |
+| ---------  | --------- | ----------- | ------------- | -------------- |
+| {?term_id} | required  | the id of the term to fetch from the authority | N/A | 123 |
+
+
 
 #### Add javascript to support autocomplete
 

--- a/config/authorities/linked_data/geonames.json
+++ b/config/authorities/linked_data/geonames.json
@@ -1,0 +1,67 @@
+{
+  "term": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type":    "IriTemplate",
+      "template": "{?term_id}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "term_id",
+          "property": "hydra:freetextQuery",
+          "required": true
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "term_id": "term_id"
+    },
+    "term_id": "URI",
+    "results": {
+      "label_predicate":    "http://www.geonames.org/ontology#name",
+      "altlabel_predicate": "http://www.geonames.org/ontology#countryCode",
+      "broader_predicate":  "http://www.geonames.org/ontology#parentFeature",
+      "sameas_predicate":   "http://www.w3.org/2000/01/rdf-schema#seeAlso"
+    }
+  },
+  "search": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type": "IriTemplate",
+      "template": "http://api.geonames.org/search?q={?query}&maxRows={?maximumRecords}&username={?username}&type=rdf",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "query",
+          "property": "hydra:freetextQuery",
+          "required": true
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "username",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "default": "demo"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "maximumRecords",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "10"
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "query":   "query"
+    },
+    "language": ["en"],
+    "results": {
+      "label_predicate":    "http://www.geonames.org/ontology#name",
+      "altlabel_predicate": "http://www.geonames.org/ontology#countryCode",
+      "sort_predicate":     "http://www.geonames.org/ontology#name"
+    }
+  }
+}

--- a/lib/qa/authorities/linked_data/search_query.rb
+++ b/lib/qa/authorities/linked_data/search_query.rb
@@ -92,6 +92,8 @@ module Qa::Authorities
         end
 
         def full_label(label = [], altlabel = [])
+          label.map!(&:strip)
+          altlabel.map!(&:strip)
           lbl = wrap_labels(label)
           lbl += " (#{altlabel.join(', ')})" unless altlabel.nil? || altlabel.length <= 0
           lbl = lbl.slice(0..95) + '...' if lbl.length > 98

--- a/spec/controllers/linked_data_terms_controller_spec.rb
+++ b/spec/controllers/linked_data_terms_controller_spec.rb
@@ -143,6 +143,30 @@ describe Qa::LinkedDataTermsController, type: :controller do
         end
       end
     end
+
+    context 'in GEONAMES authority' do
+      context '0 search results' do
+        before do
+          stub_request(:get, 'http://api.geonames.org/search?q=supercalifragilisticexpialidocious&maxRows=10&username=demo&type=rdf')
+            .to_return(status: 200, body: webmock_fixture('lod_geonames_query_no_results.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
+        end
+        it 'succeeds' do
+          get :search, params: { q: 'supercalifragilisticexpialidocious', vocab: 'GEONAMES' }
+          expect(response).to be_success
+        end
+      end
+
+      context '4 search results' do
+        before do
+          stub_request(:get, 'http://api.geonames.org/search?q=ithaca&maxRows=10&username=demo&type=rdf')
+            .to_return(status: 200, body: webmock_fixture('lod_geonames_query_many_results.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
+        end
+        it 'succeeds' do
+          get :search, params: { q: 'ithaca', vocab: 'GEONAMES' }
+          expect(response).to be_success
+        end
+      end
+    end
   end
 
   describe '#show' do
@@ -181,6 +205,19 @@ describe Qa::LinkedDataTermsController, type: :controller do
         end
         it 'succeeds' do
           get :show, params: { id: 'c_9513', vocab: 'AGROVOC' }
+          expect(response).to be_success
+        end
+      end
+    end
+
+    context 'in GEONAMES authority' do
+      context 'term found' do
+        before do
+          stub_request(:get, 'http://sws.geonames.org/5122432/')
+            .to_return(status: 200, body: webmock_fixture('lod_geonames_term_found.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
+        end
+        it 'succeeds' do
+          get :show, params: { id: 'http://sws.geonames.org/5122432/', vocab: 'GEONAMES' }
           expect(response).to be_success
         end
       end

--- a/spec/fixtures/lod_geonames_query_many_results.rdf.xml
+++ b/spec/fixtures/lod_geonames_query_many_results.rdf.xml
@@ -1,0 +1,102 @@
+<rdf:RDF xmlns:cc="http://creativecommons.org/ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:gn="http://www.geonames.org/ontology#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:wgs84_pos="http://www.w3.org/2003/01/geo/wgs84_pos#">
+  <gn:Feature rdf:about="http://sws.geonames.org/261707/">
+    <rdfs:isDefinedBy rdf:resource="http://sws.geonames.org/261707/about.rdf"/>
+    <gn:name>Ithaca Island  </gn:name>
+    <gn:alternateName xml:lang="ang">Iþacige  </gn:alternateName>
+    <gn:alternateName xml:lang="bg">Итака  </gn:alternateName>
+    <gn:alternateName xml:lang="ca">Ítaca  </gn:alternateName>
+    <gn:alternateName xml:lang="cs">Ithaka  </gn:alternateName>
+    <gn:alternateName xml:lang="da">Ithaka  </gn:alternateName>
+    <gn:alternateName xml:lang="de">Ithaka  </gn:alternateName>
+    <gn:alternateName xml:lang="el">Νησί Ιθάκη  </gn:alternateName>
+    <gn:alternateName xml:lang="en">Ithaca Island  </gn:alternateName>
+    <gn:alternateName xml:lang="eo">Itako  </gn:alternateName>
+    <gn:alternateName xml:lang="es">Ítaca  </gn:alternateName>
+    <gn:alternateName xml:lang="et">Ithaka  </gn:alternateName>
+    <gn:alternateName xml:lang="fi">Ithaka  </gn:alternateName>
+    <gn:alternateName xml:lang="fr">Ithaque  </gn:alternateName>
+    <gn:alternateName xml:lang="he">איתקה  </gn:alternateName>
+    <gn:alternateName xml:lang="id">Ithaca  </gn:alternateName>
+    <gn:alternateName xml:lang="it">Itaca  </gn:alternateName>
+    <gn:alternateName xml:lang="lv">Itaka  </gn:alternateName>
+    <gn:alternateName xml:lang="nl">Ithaka  </gn:alternateName>
+    <gn:alternateName xml:lang="pl">Itaka  </gn:alternateName>
+    <gn:alternateName xml:lang="pt">Ítaca  </gn:alternateName>
+    <gn:alternateName xml:lang="ro">Itaca  </gn:alternateName>
+    <gn:alternateName xml:lang="ru">Итака  </gn:alternateName>
+    <gn:alternateName xml:lang="sr">Итака  </gn:alternateName>
+    <gn:alternateName xml:lang="sv">Ithaka  </gn:alternateName>
+    <gn:featureClass rdf:resource="http://www.geonames.org/ontology#T"/>
+    <gn:featureCode rdf:resource="http://www.geonames.org/ontology#T.ISL"/>
+    <gn:countryCode>GR  </gn:countryCode>
+    <wgs84_pos:lat>38.38419</wgs84_pos:lat>
+    <wgs84_pos:long>20.67078</wgs84_pos:long>
+    <gn:parentCountry rdf:resource="http://sws.geonames.org/390903/"/>
+    <gn:nearbyFeatures rdf:resource="http://sws.geonames.org/261707/nearby.rdf"/>
+    <gn:locationMap rdf:resource="http://www.geonames.org/261707/ithaca-island.html"/>
+    <gn:wikipediaArticle rdf:resource="http://en.wikipedia.org/wiki/Ithaca"/>
+    <rdfs:seeAlso rdf:resource="http://dbpedia.org/resource/Ithaca"/>
+  </gn:Feature>
+  <gn:Feature rdf:about="http://sws.geonames.org/261708/">
+    <rdfs:isDefinedBy rdf:resource="http://sws.geonames.org/261708/about.rdf"/>
+    <gn:name>Itháki  </gn:name>
+    <gn:officialName xml:lang="el">Ιθάκη  </gn:officialName>
+    <gn:featureClass rdf:resource="http://www.geonames.org/ontology#P"/>
+    <gn:featureCode rdf:resource="http://www.geonames.org/ontology#P.PPL"/>
+    <gn:countryCode>GR  </gn:countryCode>
+    <gn:population>1843  </gn:population>
+    <wgs84_pos:lat>38.36421</wgs84_pos:lat>
+    <wgs84_pos:long>20.71848</wgs84_pos:long>
+    <gn:parentCountry rdf:resource="http://sws.geonames.org/390903/"/>
+    <gn:nearbyFeatures rdf:resource="http://sws.geonames.org/261708/nearby.rdf"/>
+    <gn:locationMap rdf:resource="http://www.geonames.org/261708/ithaki.html"/>
+    <gn:wikipediaArticle rdf:resource="http://en.wikipedia.org/wiki/Ithaca"/>
+    <rdfs:seeAlso rdf:resource="http://dbpedia.org/resource/Ithaca"/>
+  </gn:Feature>
+  <gn:Feature rdf:about="http://sws.geonames.org/8133849/">
+    <rdfs:isDefinedBy rdf:resource="http://sws.geonames.org/8133849/about.rdf"/>
+    <gn:name>Ithaca  </gn:name>
+    <gn:alternateName xml:lang="el">Ιθάκης  </gn:alternateName>
+    <gn:shortName xml:lang="en">Ithaca  </gn:shortName>
+    <gn:featureClass rdf:resource="http://www.geonames.org/ontology#A"/>
+    <gn:featureCode rdf:resource="http://www.geonames.org/ontology#A.ADM3"/>
+    <gn:countryCode>GR  </gn:countryCode>
+    <gn:population>3212  </gn:population>
+    <wgs84_pos:lat>38.40025</wgs84_pos:lat>
+    <wgs84_pos:long>20.66942</wgs84_pos:long>
+    <gn:parentCountry rdf:resource="http://sws.geonames.org/390903/"/>
+    <gn:childrenFeatures rdf:resource="http://sws.geonames.org/8133849/contains.rdf"/>
+    <gn:locationMap rdf:resource="http://www.geonames.org/8133849/dimos-ithaca.html"/>
+  </gn:Feature>
+  <gn:Feature rdf:about="http://sws.geonames.org/5122432/">
+    <rdfs:isDefinedBy rdf:resource="http://sws.geonames.org/5122432/about.rdf"/>
+    <gn:name>Ithaca</gn:name>
+    <gn:alternateName xml:lang="ar">إثاكا</gn:alternateName>
+    <gn:alternateName xml:lang="bg">Итака</gn:alternateName>
+    <gn:alternateName xml:lang="bn">ইথাকা</gn:alternateName>
+    <gn:alternateName xml:lang="fa">ایتاکا، نیویورک</gn:alternateName>
+    <gn:alternateName xml:lang="he">איתקה</gn:alternateName>
+    <gn:alternateName xml:lang="ja">イサカ</gn:alternateName>
+    <gn:alternateName xml:lang="ko">이사카</gn:alternateName>
+    <gn:alternateName xml:lang="lv">Itaka</gn:alternateName>
+    <gn:alternateName xml:lang="ru">Итак</gn:alternateName>
+    <gn:alternateName xml:lang="sr">Итака</gn:alternateName>
+    <gn:alternateName xml:lang="tg">Итако</gn:alternateName>
+    <gn:alternateName xml:lang="uk">Ітака</gn:alternateName>
+    <gn:alternateName xml:lang="ur">اتھاکا، نیو یارک</gn:alternateName>
+    <gn:alternateName xml:lang="zh">伊萨卡</gn:alternateName>
+    <gn:featureClass rdf:resource="http://www.geonames.org/ontology#P"/>
+    <gn:featureCode rdf:resource="http://www.geonames.org/ontology#P.PPLA2"/>
+    <gn:countryCode>US</gn:countryCode>
+    <gn:population>30788</gn:population>
+    <gn:postalCode>14852</gn:postalCode>
+    <wgs84_pos:lat>42.44063</wgs84_pos:lat>
+    <wgs84_pos:long>-76.49661</wgs84_pos:long>
+    <wgs84_pos:alt>125</wgs84_pos:alt>
+    <gn:parentCountry rdf:resource="http://sws.geonames.org/6252001/"/>
+    <gn:nearbyFeatures rdf:resource="http://sws.geonames.org/5122432/nearby.rdf"/>
+    <gn:locationMap rdf:resource="http://www.geonames.org/5122432/ithaca.html"/>
+    <gn:wikipediaArticle rdf:resource="http://en.wikipedia.org/wiki/Ithaca%2C_New_York"/>
+    <rdfs:seeAlso rdf:resource="http://dbpedia.org/resource/Ithaca%2C_New_York"/>
+  </gn:Feature>
+</rdf:RDF>

--- a/spec/fixtures/lod_geonames_query_no_results.rdf.xml
+++ b/spec/fixtures/lod_geonames_query_no_results.rdf.xml
@@ -1,0 +1,1 @@
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>

--- a/spec/fixtures/lod_geonames_term_found.rdf.xml
+++ b/spec/fixtures/lod_geonames_term_found.rdf.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<rdf:RDF xmlns:cc="http://creativecommons.org/ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:gn="http://www.geonames.org/ontology#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:wgs84_pos="http://www.w3.org/2003/01/geo/wgs84_pos#">
+  <gn:Feature rdf:about="http://sws.geonames.org/5122432/">
+    <rdfs:isDefinedBy rdf:resource="http://sws.geonames.org/5122432/about.rdf"/>
+    <gn:name>Ithaca</gn:name>
+    <gn:alternateName xml:lang="ja">イサカ</gn:alternateName>
+    <gn:alternateName xml:lang="ko">이사카</gn:alternateName>
+    <gn:alternateName>Cayuga City</gn:alternateName>
+    <gn:alternateName xml:lang="lv">Itaka</gn:alternateName>
+    <gn:officialName xml:lang="en">Ithaca</gn:officialName>
+    <gn:alternateName>Markle's Flats</gn:alternateName>
+    <gn:alternateName>Sodom</gn:alternateName>
+    <gn:alternateName>The Flats</gn:alternateName>
+    <gn:alternateName xml:lang="ur">اتھاکا، نیو یارک</gn:alternateName>
+    <gn:alternateName xml:lang="fa">ایتاکا، نیویورک</gn:alternateName>
+    <gn:alternateName xml:lang="ar">إثاكا</gn:alternateName>
+    <gn:alternateName xml:lang="he">איתקה</gn:alternateName>
+    <gn:alternateName xml:lang="ru">Итак</gn:alternateName>
+    <gn:alternateName xml:lang="bg">Итака</gn:alternateName>
+    <gn:alternateName xml:lang="ru">Итака</gn:alternateName>
+    <gn:alternateName xml:lang="sr">Итака</gn:alternateName>
+    <gn:alternateName xml:lang="tg">Итако</gn:alternateName>
+    <gn:alternateName xml:lang="uk">Ітака</gn:alternateName>
+    <gn:alternateName xml:lang="bn">ইথাকা</gn:alternateName>
+    <gn:alternateName xml:lang="zh">伊萨卡</gn:alternateName>
+    <gn:featureClass rdf:resource="http://www.geonames.org/ontology#P"/>
+    <gn:featureCode rdf:resource="http://www.geonames.org/ontology#P.PPLA2"/>
+    <gn:countryCode>US</gn:countryCode>
+    <gn:population>30788</gn:population>
+    <gn:postalCode>14850</gn:postalCode>
+    <gn:postalCode>14851</gn:postalCode>
+    <gn:postalCode>14852</gn:postalCode>
+    <gn:postalCode>14853</gn:postalCode>
+    <wgs84_pos:lat>42.44063</wgs84_pos:lat>
+    <wgs84_pos:long>-76.49661</wgs84_pos:long>
+    <wgs84_pos:alt>125</wgs84_pos:alt>
+    <gn:parentFeature rdf:resource="http://sws.geonames.org/5141153/"/>
+    <gn:parentCountry rdf:resource="http://sws.geonames.org/6252001/"/>
+    <gn:parentADM1 rdf:resource="http://sws.geonames.org/5128638/"/>
+    <gn:parentADM2 rdf:resource="http://sws.geonames.org/5141153/"/>
+    <gn:nearbyFeatures rdf:resource="http://sws.geonames.org/5122432/nearby.rdf"/>
+    <gn:locationMap rdf:resource="http://www.geonames.org/5122432/ithaca.html"/>
+    <gn:wikipediaArticle rdf:resource="http://en.wikipedia.org/wiki/Ithaca%2C_New_York"/>
+    <rdfs:seeAlso rdf:resource="http://dbpedia.org/resource/Ithaca%2C_New_York"/>
+    <gn:wikipediaArticle rdf:resource="http://ru.wikipedia.org/wiki/%D0%98%D1%82%D0%B0%D0%BA%D0%B0_%28%D0%9D%D1%8C%D1%8E-%D0%99%D0%BE%D1%80%D0%BA%29"/>
+  </gn:Feature>
+  <foaf:Document rdf:about="http://sws.geonames.org/5122432/about.rdf">
+    <foaf:primaryTopic rdf:resource="http://sws.geonames.org/5122432/"/>
+    <cc:license rdf:resource="http://creativecommons.org/licenses/by/3.0/"/>
+    <cc:attributionURL rdf:resource="http://sws.geonames.org/5122432/"/>
+    <cc:attributionName rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GeoNames</cc:attributionName>
+    <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2006-01-15</dcterms:created>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2017-03-09</dcterms:modified>
+  </foaf:Document>
+</rdf:RDF>


### PR DESCRIPTION
Supports search query and term fetch for geonames authority.

NOTE: You must get a username from geonames.org.  See [README](https://github.com/projecthydra/questioning_authority/blob/master/README.md#geonames-linked-data) notes for more information.