### PR TITLE
add ability to sort based on a numeric ranking predicate

### DIFF
--- a/lib/qa/authorities/linked_data/search_query.rb
+++ b/lib/qa/authorities/linked_data/search_query.rb
@@ -109,7 +109,10 @@ module Qa::Authorities
           return json_results unless supports_sort?
           json_results.sort! do |a, b|
             cmp = sort_when_missing_sort_predicate(a, b)
-            next unless cmp.nil?
+            next cmp unless cmp.nil?
+
+            cmp = numeric_sort(a, b)
+            next cmp unless cmp.nil?
 
             as = a[:sort].collect(&:downcase)
             bs = b[:sort].collect(&:downcase)
@@ -137,6 +140,18 @@ module Qa::Authorities
           return -1 if as.size <= current_list_size # consider shorter a list of values lower then longer b list
           return 1 if bs.size <= current_list_size # consider shorter b list of values lower then longer a list
           nil
+        end
+
+        def numeric_sort(a, b)
+          return nil if a[:sort].size > 1
+          return nil if b[:sort].size > 1
+          return nil unless s_is_i? a[:sort][0]
+          return nil unless s_is_i? b[:sort][0]
+          Integer(a[:sort][0]) <=> Integer(b[:sort][0])
+        end
+
+        def s_is_i?(s)
+          /\A[-+]?\d+\z/ === s # rubocop:disable Style/CaseEquality
         end
     end
   end

--- a/spec/lib/authorities/linked_data/search_query_spec.rb
+++ b/spec/lib/authorities/linked_data/search_query_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Qa::Authorities::LinkedData::SearchQuery do
     context 'when sort predicate is specified in configuration' do
       let(:auth_name) { :LOD_SORT }
 
-      context "when sort term is empty" do
+      context "and sort term is empty" do
         context "for all" do
           it "does not change order" do
             json_results = [{ label: "[#{term_b}]", sort: [""] },
@@ -35,19 +35,39 @@ RSpec.describe Qa::Authorities::LinkedData::SearchQuery do
         end
 
         context "for one" do
-          it "puts empty first" do
-            json_results = [{ label: "[#{term_b}]", sort: [""] },
+          it "puts empty first when empty is in 1st position" do
+            json_results = [{ label: "['_empty_1_']", sort: [""] },
                             { label: "[#{term_c}]", sort: [term_c] },
                             { label: "[#{term_a}]", sort: [term_a] }]
-            expected_results = [{ label: "[#{term_b}]" },
+            expected_results = [{ label: "['_empty_1_']" },
                                 { label: "[#{term_a}]" },
+                                { label: "[#{term_c}]" }]
+            expect(instance.send(:sort_search_results, json_results)).to eq expected_results
+          end
+
+          it "puts empty first when empty is in 2nd position" do
+            json_results = [{ label: "[#{term_b}]", sort: [term_b] },
+                            { label: "['_empty_2_']", sort: [""] },
+                            { label: "[#{term_a}]", sort: [term_a] }]
+            expected_results = [{ label: "['_empty_2_']" },
+                                { label: "[#{term_a}]" },
+                                { label: "[#{term_b}]" }]
+            expect(instance.send(:sort_search_results, json_results)).to eq expected_results
+          end
+
+          it "puts empty first when empty is in last position" do
+            json_results = [{ label: "[#{term_b}]", sort: [term_b] },
+                            { label: "[#{term_c}]", sort: [term_c] },
+                            { label: "['_empty_last_']", sort: [""] }]
+            expected_results = [{ label: "['_empty_last_']" },
+                                { label: "[#{term_b}]" },
                                 { label: "[#{term_c}]" }]
             expect(instance.send(:sort_search_results, json_results)).to eq expected_results
           end
         end
       end
 
-      context "when sort term is single value" do
+      context "and sort term is single value" do
         context "for all" do
           it "sorts on the single value" do
             json_results = [{ label: "[#{term_b}]", sort: [term_b] },
@@ -96,6 +116,14 @@ RSpec.describe Qa::Authorities::LinkedData::SearchQuery do
                                 { label: "[#{term_b}, #{term_d}, #{term_c}]" }]
             expect(instance.send(:sort_search_results, json_results)).to eq expected_results
           end
+        end
+      end
+
+      context "and sort values are numeric" do
+        it "does numeric compare" do
+          json_results = [{ label: "['22']", sort: ["22"] }, { label: "['1']", sort: ["1"] }, { label: "['215']", sort: ["215"] }]
+          expected_results = [{ label: "['1']" }, { label: "['22']" }, { label: "['215']" }]
+          expect(instance.send(:sort_search_results, json_results)).to eq expected_results
         end
       end
     end


### PR DESCRIPTION
For linked data, the configuration can specify a predicate on which to sort the results when building the json list.  Up to this point, these predicates have all been alpha strings.  With the addition of a search rank predicate that returns a numeric value, there needs to be a numeric sort.

Example: "22", "1", "215" 

alpha sort produces:  "1", "215", "22"
numeric sort produces: "1", "22", "215"

The new code checks if the both values being compared are numeric and does a numeric sort.