### PR TITLE
Add version to migrations to support rails >= 5.1

### DIFF
--- a/db/migrate/20130917200611_create_qa_subject_mesh_terms.rb
+++ b/db/migrate/20130917200611_create_qa_subject_mesh_terms.rb
@@ -1,4 +1,4 @@
-class CreateQaSubjectMeshTerms < ActiveRecord::Migration
+class CreateQaSubjectMeshTerms < ActiveRecord::Migration[4.2]
   def change
     create_table :qa_subject_mesh_terms do |t|
       t.string :term_id

--- a/db/migrate/20130917201026_create_qa_mesh_tree.rb
+++ b/db/migrate/20130917201026_create_qa_mesh_tree.rb
@@ -1,4 +1,4 @@
-class CreateQaMeshTree < ActiveRecord::Migration
+class CreateQaMeshTree < ActiveRecord::Migration[4.2]
   def change
     create_table :qa_mesh_trees do |t|
       t.string :term_id

--- a/db/migrate/20130918141523_add_term_lower_to_qa_subject_mesh_terms.rb
+++ b/db/migrate/20130918141523_add_term_lower_to_qa_subject_mesh_terms.rb
@@ -1,4 +1,4 @@
-class AddTermLowerToQaSubjectMeshTerms < ActiveRecord::Migration
+class AddTermLowerToQaSubjectMeshTerms < ActiveRecord::Migration[4.2]
   def change
     add_column :qa_subject_mesh_terms, :term_lower, :string
     add_index :qa_subject_mesh_terms, :term_lower


### PR DESCRIPTION
For all migrations, this PR adds [4.2] as the version under which the migrations were created.  A version number is required for migrations to run under Rails 5.1 and later.  It cannot be present in migrations run under Rails < 5.0.

A branch, named `stable_1.2_for_rails_4.2` was created to allow bug fixes if needed to be made available for Rails 4.2.

Release 1.2 is the last one that supports Rails 4.2.  A release will be made with the migration changes in this PR and released as 1.3.  The release notes for both will be updated to reflect the Rails versions supported.