### PR TITLE
support the common forms used to define a term template

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -9,6 +9,7 @@ Metrics/ClassLength:
     - 'app/controllers/qa/linked_data_terms_controller.rb'
     - 'lib/qa/authorities/linked_data/find_term.rb'
     - 'lib/qa/authorities/linked_data/search_query.rb'
+    - 'lib/qa/authorities/linked_data/config/term_config.rb'
 
 RSpec/ExampleLength:
   Max: 7

--- a/lib/qa/authorities/linked_data/config.rb
+++ b/lib/qa/authorities/linked_data/config.rb
@@ -1,6 +1,7 @@
 require 'qa/authorities/linked_data/config/term_config'.freeze
 require 'qa/authorities/linked_data/config/search_config'.freeze
 require 'json'
+require 'erb'
 
 # Provide attr_reader methods for linked data authority configurations.  Some default configurations are provided for several
 # linked data authorities and can be found at /config/authorities/linked_data.  You can add configurations for new authorities by
@@ -17,6 +18,10 @@ require 'json'
 module Qa::Authorities
   module LinkedData
     class Config
+      class << self
+        include ERB::Util
+      end
+
       attr_reader :authority_name
       attr_reader :authority_config
 
@@ -56,7 +61,8 @@ module Qa::Authorities
         pred_uri
       end
 
-      def self.replace_pattern(url, pattern, value)
+      def self.replace_pattern(url, pattern, value, encode = false)
+        value = url_encode(value).gsub(".", "%2E") if encode
         url.gsub("{?#{pattern}}", value)
       end
 
@@ -71,7 +77,7 @@ module Qa::Authorities
         config.each do |param_key, rep_pattern|
           s_param_key = param_key.to_s
           value = replacements[param_key] || replacements[s_param_key] || rep_pattern[:default]
-          url = replace_pattern(url, param_key, value)
+          url = replace_pattern(url, param_key, value, rep_pattern[:encode])
         end
         url
       end

--- a/lib/qa/authorities/linked_data/config/search_config.rb
+++ b/lib/qa/authorities/linked_data/config/search_config.rb
@@ -95,10 +95,24 @@ module Qa::Authorities
         search_config.fetch(:qa_replacement_patterns)
       end
 
+      # Should the replacement pattern be encoded?
+      # @return [Boolean] true, if the pattern should be encoded; otherwise, false
+      def qa_replacement_encoded?(pattern_key)
+        map_key = qa_replacement_patterns[pattern_key].to_sym
+        replacement_encoded? map_key
+      end
+
       # Are there replacement parameters configured for search query?
       # @return [True|False] true if there are replacement parameters configured for search query; otherwise, false
       def replacements?
         replacement_count.positive?
+      end
+
+      # Should the replacement parameter be encoded?
+      # @return [True|False] true if the replacement parameter should be encoded; otherwise, false
+      def replacement_encoded?(map_key)
+        return false unless url_mappings[map_key].key? :encode
+        url_mappings[map_key][:encode]
       end
 
       # Return the number of possible replacement values to make in the search URL
@@ -159,8 +173,8 @@ module Qa::Authorities
       # @return [String] the search encoded url
       def url_with_replacements(query, sub_auth = nil, search_replacements = {})
         return nil unless supports_search?
-        sub_auth = sub_auth.to_sym if sub_auth.is_a? String
-        url = Config.replace_pattern(url_template, qa_replacement_patterns[:query], query)
+        sub_auth = sub_auth.to_sym if sub_auth.present?
+        url = Config.replace_pattern(url_template, qa_replacement_patterns[:query], query, qa_replacement_encoded?(:query))
         url = Config.process_subauthority(url, subauthority_replacement_pattern, subauthorities, sub_auth) if subauthorities?
         url = Config.apply_replacements(url, replacements, search_replacements) if replacements?
         url

--- a/lib/qa/authorities/linked_data/config/term_config.rb
+++ b/lib/qa/authorities/linked_data/config/term_config.rb
@@ -112,10 +112,24 @@ module Qa::Authorities
         Config.config_value(term_config, :qa_replacement_patterns)
       end
 
+      # Should the replacement pattern be encoded?
+      # @return [Boolean] true, if the pattern should be encoded; otherwise, false
+      def term_qa_replacement_encoded?(pattern_key)
+        map_key = term_qa_replacement_patterns[pattern_key].to_sym
+        term_replacement_encoded? map_key
+      end
+
       # Are there replacement parameters configured for term fetch?
-      # @return [True|False] true if there are replacement parameters configured for term fetch; otherwise, false
+      # @return [Boolean] true if there are replacement parameters configured for term fetch; otherwise, false
       def term_replacements?
         term_replacement_count.positive?
+      end
+
+      # Should the replacement parameter be encoded?
+      # @return [Boolean] true if the replacement parameter should be encoded; otherwise, false
+      def term_replacement_encoded?(map_key)
+        return false unless term_url_mappings[map_key].key? :encode
+        term_url_mappings[map_key][:encode]
       end
 
       # Return the number of possible replacement values to make in the term URL
@@ -129,7 +143,7 @@ module Qa::Authorities
       def term_replacements
         return @term_replacements unless @term_replacements.nil?
         @term_replacements = {}
-        @term_replacements = term_url_mappings.select { |k, _v| !term_qa_replacement_patterns.include?(k) } unless term_config.nil? || term_url_mappings.nil?
+        @term_replacements = term_url_mappings.select { |k, _v| !term_qa_replacement_patterns.value?(k.to_s) } unless term_config.nil? || term_url_mappings.nil?
         @term_replacements
       end
 
@@ -176,7 +190,7 @@ module Qa::Authorities
       def term_url_with_replacements(id, sub_auth = nil, replacements = {})
         return nil unless supports_term?
         sub_auth = sub_auth.to_sym if sub_auth.is_a? String
-        url = Config.replace_pattern(term_url_template, term_qa_replacement_patterns[:term_id], id)
+        url = Config.replace_pattern(term_url_template, term_qa_replacement_patterns[:term_id], id, term_qa_replacement_encoded?(:term_id))
         url = Config.process_subauthority(url, term_subauthority_replacement_pattern, term_subauthorities, sub_auth) if term_subauthorities?
         url = Config.apply_replacements(url, term_replacements, replacements) if term_replacements?
         url

--- a/spec/fixtures/authorities/linked_data/lod_encoding_config.json
+++ b/spec/fixtures/authorities/linked_data/lod_encoding_config.json
@@ -1,0 +1,91 @@
+{
+  "term": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type":    "IriTemplate",
+      "template": "http://localhost/test_default/term?uri={?term_uri}&{?encode_true}&{?encode_false}&{?encode_not_specified}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "term_uri",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode":   true
+        },
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "encode_true",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode":   true
+        },
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "encode_false",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode":   false
+        },
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "encode_not_specified",
+          "property": "hydra:freetextQuery",
+          "required": true
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "term_id": "term_uri"
+    },
+    "term_id": "URI",
+    "results": {
+      "id_predicate":       "http://id.loc.gov/vocabulary/identifiers/lccn",
+      "label_predicate":    "http://www.w3.org/2004/02/skos/core#prefLabel"
+    }
+  },
+  "search": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type":    "IriTemplate",
+      "template": "http://localhost/test_default/search?query={?query}&{?encode_true}&{?encode_false}&{?encode_not_specified}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "query",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode":   true
+        },
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "encode_true",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode":   true
+        },
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "encode_false",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode":   false
+        },
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "encode_not_specified",
+          "property": "hydra:freetextQuery",
+          "required": true
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "query": "query"
+    },
+    "results": {
+      "id_predicate":       "http://purl.org/dc/terms/identifier",
+      "label_predicate":    "http://www.w3.org/2004/02/skos/core#prefLabel"
+    }
+  }
+}

--- a/spec/fixtures/authorities/linked_data/lod_term_id_param_config.json
+++ b/spec/fixtures/authorities/linked_data/lod_term_id_param_config.json
@@ -1,0 +1,27 @@
+{
+  "term": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type":    "IriTemplate",
+      "template": "http://localhost/test_default/term/{?term_id}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "term_id",
+          "property": "hydra:freetextQuery",
+          "required": true
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "term_id": "term_id"
+    },
+    "term_id": "ID",
+    "results": {
+      "id_predicate":       "http://id.loc.gov/vocabulary/identifiers/lccn",
+      "label_predicate":    "http://www.w3.org/2004/02/skos/core#prefLabel"
+    }
+  },
+  "search": {}
+}

--- a/spec/lib/authorities/linked_data/search_config_spec.rb
+++ b/spec/lib/authorities/linked_data/search_config_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Qa::Authorities::LinkedData::SearchConfig do
   let(:full_config) { Qa::Authorities::LinkedData::Config.new(:LOD_FULL_CONFIG).search }
   let(:min_config) { Qa::Authorities::LinkedData::Config.new(:LOD_MIN_CONFIG).search }
   let(:term_only_config) { Qa::Authorities::LinkedData::Config.new(:LOD_TERM_ONLY_CONFIG).search }
+  let(:encoding_config) { Qa::Authorities::LinkedData::Config.new(:LOD_ENCODING_CONFIG).search }
 
   describe '#search_config' do
     let(:full_search_config) do
@@ -379,6 +380,15 @@ RSpec.describe Qa::Authorities::LinkedData::SearchConfig do
       it 'and replacements param is included returns the url with query substitution applied ignoring the replacements' do
         expected_url = 'http://localhost/test_default/search?query=Smith'
         expect(min_config.url_with_replacements('Smith', nil, fake_replacement_key: 'fake_value')).to eq expected_url
+      end
+    end
+
+    context 'with encoding specified in config' do
+      it 'returns the uri as the url' do
+        expected_url = 'http://localhost/test_default/search?query=encoded%20because%3Aencode%3Dtrue&yes%3Aencoded%20here&no:encoding here&defaults:to not encoded'
+        query = 'encoded because:encode=true'
+        replacements = { encode_true: 'yes:encoded here', encode_false: 'no:encoding here', encode_not_specified: 'defaults:to not encoded' }
+        expect(encoding_config.url_with_replacements(query, nil, replacements)).to eq expected_url
       end
     end
   end

--- a/spec/lib/authorities/linked_data/term_config_spec.rb
+++ b/spec/lib/authorities/linked_data/term_config_spec.rb
@@ -4,6 +4,7 @@ describe Qa::Authorities::LinkedData::TermConfig do
   let(:full_config) { Qa::Authorities::LinkedData::Config.new(:LOD_FULL_CONFIG).term }
   let(:min_config) { Qa::Authorities::LinkedData::Config.new(:LOD_MIN_CONFIG).term }
   let(:search_only_config) { Qa::Authorities::LinkedData::Config.new(:LOD_SEARCH_ONLY_CONFIG).term }
+  let(:encoding_config) { Qa::Authorities::LinkedData::Config.new(:LOD_ENCODING_CONFIG).term }
 
   describe '#term_config' do
     let(:full_term_config) do
@@ -413,6 +414,15 @@ describe Qa::Authorities::LinkedData::TermConfig do
       it 'and replacements param is included returns the url with query substitution applied ignoring the replacements' do
         expected_url = 'http://localhost/test_default/term/C123'
         expect(min_config.term_url_with_replacements('C123', nil, fake_replacement_key: 'fake_value')).to eq expected_url
+      end
+    end
+
+    context 'with encoding specified in config' do
+      it 'returns the uri as the url' do
+        expected_url = 'http://localhost/test_default/term?uri=http%3A%2F%2Fencoded%2Ebecause%3Fencode%3Dtrue&yes%3Aencoded%20here&no:encoding here&defaults:to not encoded'
+        term_uri = 'http://encoded.because?encode=true'
+        replacements = { encode_true: 'yes:encoded here', encode_false: 'no:encoding here', encode_not_specified: 'defaults:to not encoded' }
+        expect(encoding_config.term_url_with_replacements(term_uri, nil, replacements)).to eq expected_url
       end
     end
   end


### PR DESCRIPTION
Supports term templates in the form…
```
"{?term_uri}"              # term_uri is the entire template
"{?term_uri}.rdf"          # term_uri starts the template
"http://localhost/test_default/term?uri={?term_uri}"   # term_uri is a parameter of the template
"http://localhost/test_default/term/{?term_id}"        # term_id is a parameter of the template
```

Fixed errors:
* term_uri needs to be url encoded when it is a parameter
* term_uri should not be encoded when it is the entire template
* substitution of term id was only done when the template parameter was named term_id and not when it was named term_uri, but now happens for both