### PR TITLE
Add support for Rails 5.1 and address deprecations coming with Rails 6

### DIFF
--- a/lib/qa/authorities/local/mysql_table_based_authority.rb
+++ b/lib/qa/authorities/local/mysql_table_based_authority.rb
@@ -5,8 +5,7 @@ module Qa
         self.table_index = "index_qa_local_authority_entries_on_lower_label_and_authority"
 
         def self.check_for_index
-          conn = ActiveRecord::Base.connection
-          if table_or_view_exists? && conn.index_name_exists?(table_name.to_sym, table_index, :default).blank? # rubocop:disable Style/GuardClause
+          if table_or_view_exists? && index_name_exists? # rubocop:disable Style/GuardClause
             Rails.logger.error "You've installed mysql local authority tables, but you haven't indexed the lower label. "
             "Rails doesn't support functional indexes in migrations, so we tried to execute it for you but something went wrong...\n" \
             "Make sure your table has a lower_label column, which is virtually created, and that the column is indexed." \
@@ -19,6 +18,16 @@ module Qa
           return [] if q.blank?
           output_set(base_relation.where('lower_label like ?', "#{q.downcase}%").limit(25))
         end
+
+        def self.index_name_exists?
+          conn = ActiveRecord::Base.connection
+          if ActiveRecord::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 1
+            conn.index_name_exists?(table_name, table_index).blank?
+          else
+            conn.index_name_exists?(table_name, table_index, :default).blank?
+          end
+        end
+        private_class_method :index_name_exists?
       end
     end
   end

--- a/spec/controllers/linked_data_terms_controller_spec.rb
+++ b/spec/controllers/linked_data_terms_controller_spec.rb
@@ -131,7 +131,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
         end
         it 'succeeds' do
           get :search, params: { q: 'supercalifragilisticexpialidocious', vocab: 'OCLC_FAST', maximumRecords: '3' }
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
 
@@ -142,7 +142,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
         end
         it 'succeeds' do
           get :search, params: { q: 'cornell', vocab: 'OCLC_FAST', maximumRecords: '3' }
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
     end
@@ -155,7 +155,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
         end
         it 'succeeds' do
           get :search, params: { q: 'supercalifragilisticexpialidocious', vocab: 'OCLC_FAST', subauthority: 'personal_name', maximumRecords: '3' }
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
 
@@ -166,7 +166,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
         end
         it 'succeeds' do
           get :search, params: { q: 'cornell', vocab: 'OCLC_FAST', subauthority: 'personal_name', maximumRecords: '3' }
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
     end
@@ -179,7 +179,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
         end
         it 'succeeds' do
           get :search, params: { q: 'supercalifragilisticexpialidocious', vocab: 'AGROVOC' }
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
 
@@ -190,7 +190,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
         end
         it 'succeeds' do
           get :search, params: { q: 'milk', vocab: 'AGROVOC' }
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
     end
@@ -264,7 +264,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
         end
         it 'succeeds' do
           get :show, params: { id: '530369', vocab: 'OCLC_FAST' }
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
     end
@@ -277,7 +277,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
         end
         it 'succeeds' do
           get :show, params: { id: 'c_9513', vocab: 'AGROVOC' }
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
     end
@@ -290,7 +290,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
         end
         it 'succeeds' do
           get :show, params: { id: 'sh85118553', vocab: 'LOC', subauthority: 'subjects' }
-          expect(response).to be_success
+          expect(response).to be_successful
         end
       end
     end

--- a/spec/controllers/terms_controller_spec.rb
+++ b/spec/controllers/terms_controller_spec.rb
@@ -72,7 +72,7 @@ describe Qa::TermsController, type: :controller do
       end
       it "succeeds" do
         get :search, params: { q: "a query", vocab: "local", subauthority: "two_args" }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
 
@@ -85,12 +85,12 @@ describe Qa::TermsController, type: :controller do
 
       it "returns a set of terms for a tgnlang query" do
         get :search, params: { q: "Tibetan", vocab: "tgnlang" }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it "does not return 404 if subauthority is valid" do
         get :search, params: { q: "Berry", vocab: "loc", subauthority: "names" }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
 
@@ -102,7 +102,7 @@ describe Qa::TermsController, type: :controller do
       end
       it "succeeds if authority class is camelcase" do
         get :search, params: { q: "word", vocab: "assign_fast", subauthority: "topical" }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
   end
@@ -111,11 +111,11 @@ describe Qa::TermsController, type: :controller do
     context "with supported authorities" do
       it "returns all local authority state terms" do
         get :index, params: { vocab: "local", subauthority: "states" }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
       it "returns all MeSH terms" do
         get :index, params: { vocab: "mesh" }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
 
@@ -145,17 +145,17 @@ describe Qa::TermsController, type: :controller do
 
       it "returns an individual state term" do
         get :show, params: { vocab: "local", subauthority: "states", id: "OH" }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it "returns an individual MeSH term" do
         get :show, params: { vocab: "mesh", id: "D000001" }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it "returns an individual subject term" do
         get :show, params: { vocab: "loc", subauthority: "subjects", id: "sh85077565" }
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
   end


### PR DESCRIPTION
Maintain support for Rails 5.0; Add support for Rails >= 5.1:
* method `index_name_exists?(table_name, index_name, default)` had the `default` parameter removed in Rails 5.1, but it is required in Rails 5.0.  There is a check for the Rails version and it passes the default parameter when Rails is < 5.1 and doesn't when >= 5.1

Address deprecations coming with Rails 6:
* `be_success` is deprecated for Rails 6 and is being replaced with `be_successful`