### PR TITLE
add support for CORS headers

### DIFF
--- a/app/controllers/qa/application_controller.rb
+++ b/app/controllers/qa/application_controller.rb
@@ -1,4 +1,21 @@
 module Qa
   class ApplicationController < ActionController::Base
+    # See https://fetch.spec.whatwg.org/#http-access-control-allow-headers
+    def options
+      unless Qa.config.cors_headers?
+        head :not_implemented
+        return
+      end
+      response.headers['Access-Control-Allow-Origin'] = '*'
+      response.headers['Access-Control-Allow-Methods'] = 'GET, OPTIONS'
+      head :no_content
+    end
+
+    private
+
+      # See https://fetch.spec.whatwg.org/#http-access-control-allow-origin
+      def cors_allow_origin_header
+        response.headers['Access-Control-Allow-Origin'] = '*' if Qa.config.cors_headers?
+      end
   end
 end

--- a/app/controllers/qa/linked_data_terms_controller.rb
+++ b/app/controllers/qa/linked_data_terms_controller.rb
@@ -1,7 +1,7 @@
 # This controller is used for all requests to linked data authorities. It will verify params and figure
 # out which linked data authority to query based on the 'vocab' param.
 
-class Qa::LinkedDataTermsController < ApplicationController
+class Qa::LinkedDataTermsController < Qa::ApplicationController
   before_action :check_authority, :init_authority
   before_action :check_search_subauthority, :check_query_param, only: :search
   before_action :check_show_subauthority, :check_id_param, only: :show
@@ -31,6 +31,7 @@ class Qa::LinkedDataTermsController < ApplicationController
       head :internal_server_error
       return
     end
+    cors_allow_origin_header
     render json: terms
   end
 
@@ -57,6 +58,7 @@ class Qa::LinkedDataTermsController < ApplicationController
       head :internal_server_error
       return
     end
+    cors_allow_origin_header
     render json: term
   end
 

--- a/app/controllers/qa/terms_controller.rb
+++ b/app/controllers/qa/terms_controller.rb
@@ -3,12 +3,13 @@
 # All the authority classes inherit from a super class so they implement the
 # same methods.
 
-class Qa::TermsController < ApplicationController
+class Qa::TermsController < Qa::ApplicationController
   before_action :check_vocab_param, :init_authority
   before_action :check_query_param, only: :search
 
   # If the subauthority supports it, return a list of all terms in the authority
   def index
+    cors_allow_origin_header
     render json: begin
       @authority.all
     rescue NotImplementedError
@@ -19,12 +20,14 @@ class Qa::TermsController < ApplicationController
   # Return a list of terms based on a query
   def search
     terms = @authority.method(:search).arity == 2 ? @authority.search(url_search, self) : @authority.search(url_search)
+    cors_allow_origin_header
     render json: terms
   end
 
   # If the subauthority supports it, return all the information for a given term
   def show
     term = @authority.find(params[:id])
+    cors_allow_origin_header
     render json: term
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,12 @@ Qa::Engine.routes.draw do
   get "/search/:vocab(/:subauthority)", controller: :terms, action: :search
   get "/show/:vocab/:id", controller: :terms, action: :show
   get "/show/:vocab/:subauthority/:id", controller: :terms, action: :show
+
+  match "/search/linked_data/:vocab(/:subauthority)", to: 'application#options', via: [:options]
+  match "/show/linked_data/:vocab/:id", to: 'application#options', via: [:options]
+  match "/show/linked_data/:vocab/:subauthority/:id", to: 'application#options', via: [:options]
+  match "/terms/:vocab(/:subauthority)",  to: 'application#options', via: [:options]
+  match "/search/:vocab(/:subauthority)", to: 'application#options', via: [:options]
+  match "/show/:vocab/:id", to: 'application#options', via: [:options]
+  match "/show/:vocab/:subauthority/:id", to: 'application#options', via: [:options]
 end

--- a/lib/generators/qa/install/install_generator.rb
+++ b/lib/generators/qa/install/install_generator.rb
@@ -7,6 +7,10 @@ class Qa::InstallGenerator < Rails::Generators::Base
     end
   end
 
+  def create_initializer_config_file
+    copy_file 'config/initializers/qa.rb'
+  end
+
   def copy_oclcts_configs
     copy_file "config/oclcts-authorities.yml", "config/oclcts-authorities.yml"
   end

--- a/lib/generators/qa/install/templates/config/initializers/qa.rb
+++ b/lib/generators/qa/install/templates/config/initializers/qa.rb
@@ -1,0 +1,7 @@
+Qa.config do |config|
+  # When enabled, CORS headers will be added to the responses for search and show.  `OPTIONS` method will also be supported.
+  # Uncomment one of the lines below to enable or disable CORS headers.  This configuration defaults to disabled when not set.
+  # More information on CORS headers at: https://fetch.spec.whatwg.org/#cors-protocol
+  # config.enable_cors_headers
+  # config.disable_cors_headers
+end

--- a/lib/qa.rb
+++ b/lib/qa.rb
@@ -6,7 +6,23 @@ module Qa
   extend ActiveSupport::Autoload
 
   autoload :Authorities
+  autoload :Configuration
   autoload :Services
+
+  # @api public
+  #
+  # Exposes the Questioning Authority configuration
+  #
+  # @yield [Qa::Configuration] if a block is passed
+  # @return [Qa::Configuration]
+  # @see Qa::Configuration for configuration options
+  def self.config(&block)
+    @config ||= Qa::Configuration.new
+
+    yield @config if block
+
+    @config
+  end
 
   # Raised when the configuration directory for local authorities doesn't exist
   class ConfigDirectoryNotFound < StandardError; end

--- a/lib/qa/configuration.rb
+++ b/lib/qa/configuration.rb
@@ -1,0 +1,16 @@
+module Qa
+  class Configuration
+    def cors_headers?
+      return @cors_headers_enabled unless @cors_headers_enabled.nil?
+      @cors_headers_enabled = false
+    end
+
+    def enable_cors_headers
+      @cors_headers_enabled = true
+    end
+
+    def disable_cors_headers
+      @cors_headers_enabled = false
+    end
+  end
+end

--- a/spec/controllers/linked_data_terms_controller_spec.rb
+++ b/spec/controllers/linked_data_terms_controller_spec.rb
@@ -123,6 +123,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
         expect(response.code).to eq('503')
       end
     end
+
     context 'in OCLC_FAST authority' do
       context '0 search results' do
         before do
@@ -167,6 +168,30 @@ describe Qa::LinkedDataTermsController, type: :controller do
         it 'succeeds' do
           get :search, params: { q: 'cornell', vocab: 'OCLC_FAST', subauthority: 'personal_name', maximumRecords: '3' }
           expect(response).to be_success
+        end
+      end
+
+      context 'when cors headers are enabled' do
+        before do
+          Qa.config.enable_cors_headers
+          stub_request(:get, 'http://experimental.worldcat.org/fast/search?maximumRecords=3&query=oclc.personalName%20all%20%22cornell%22&sortKeys=usage')
+            .to_return(status: 200, body: webmock_fixture('lod_oclc_personalName_query_3_results.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
+        end
+        it 'Access-Control-Allow-Origin is *' do
+          get :search, params: { q: 'cornell', vocab: 'OCLC_FAST', subauthority: 'personal_name', maximumRecords: '3' }
+          expect(response.headers['Access-Control-Allow-Origin']).to eq '*'
+        end
+      end
+
+      context 'when cors headers are disabled' do
+        before do
+          Qa.config.disable_cors_headers
+          stub_request(:get, 'http://experimental.worldcat.org/fast/search?maximumRecords=3&query=oclc.personalName%20all%20%22cornell%22&sortKeys=usage')
+            .to_return(status: 200, body: webmock_fixture('lod_oclc_personalName_query_3_results.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
+        end
+        it 'Access-Control-Allow-Origin is not present' do
+          get :search, params: { q: 'cornell', vocab: 'OCLC_FAST', subauthority: 'personal_name', maximumRecords: '3' }
+          expect(response.headers.key?('Access-Control-Allow-Origin')).to be false
         end
       end
     end
@@ -265,6 +290,30 @@ describe Qa::LinkedDataTermsController, type: :controller do
         it 'succeeds' do
           get :show, params: { id: '530369', vocab: 'OCLC_FAST' }
           expect(response).to be_success
+        end
+      end
+
+      context 'when cors headers are enabled' do
+        before do
+          Qa.config.enable_cors_headers
+          stub_request(:get, 'http://id.worldcat.org/fast/530369')
+            .to_return(status: 200, body: webmock_fixture('lod_oclc_term_found.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
+        end
+        it 'Access-Control-Allow-Origin is *' do
+          get :show, params: { id: '530369', vocab: 'OCLC_FAST' }
+          expect(response.headers['Access-Control-Allow-Origin']).to eq '*'
+        end
+      end
+
+      context 'when cors headers are disabled' do
+        before do
+          Qa.config.disable_cors_headers
+          stub_request(:get, 'http://id.worldcat.org/fast/530369')
+            .to_return(status: 200, body: webmock_fixture('lod_oclc_term_found.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
+        end
+        it 'Access-Control-Allow-Origin is not present' do
+          get :show, params: { id: '530369', vocab: 'OCLC_FAST' }
+          expect(response.headers.key?('Access-Control-Allow-Origin')).to be false
         end
       end
     end

--- a/spec/controllers/terms_controller_spec.rb
+++ b/spec/controllers/terms_controller_spec.rb
@@ -92,6 +92,32 @@ describe Qa::TermsController, type: :controller do
         get :search, params: { q: "Berry", vocab: "loc", subauthority: "names" }
         expect(response).to be_success
       end
+
+      context 'when cors headers are enabled' do
+        before do
+          Qa.config.enable_cors_headers
+          stub_request(:get, "http://id.loc.gov/search/?format=json&q=Berry&q=cs:http://id.loc.gov/authorities/names")
+            .with(headers: { 'Accept' => 'application/json' })
+            .to_return(body: webmock_fixture("loc-names-response.txt"), status: 200)
+        end
+        it 'Access-Control-Allow-Origin is *' do
+          get :search, params: { q: "Tibetan", vocab: "tgnlang" }
+          expect(response.headers['Access-Control-Allow-Origin']).to eq '*'
+        end
+      end
+
+      context 'when cors headers are disabled' do
+        before do
+          Qa.config.disable_cors_headers
+          stub_request(:get, "http://id.loc.gov/search/?format=json&q=Berry&q=cs:http://id.loc.gov/authorities/names")
+            .with(headers: { 'Accept' => 'application/json' })
+            .to_return(body: webmock_fixture("loc-names-response.txt"), status: 200)
+        end
+        it 'Access-Control-Allow-Origin is not present' do
+          get :search, params: { q: "Tibetan", vocab: "tgnlang" }
+          expect(response.headers.key?('Access-Control-Allow-Origin')).to be false
+        end
+      end
     end
 
     context "assign_fast" do
@@ -116,6 +142,26 @@ describe Qa::TermsController, type: :controller do
       it "returns all MeSH terms" do
         get :index, params: { vocab: "mesh" }
         expect(response).to be_success
+      end
+
+      context 'when cors headers are enabled' do
+        before do
+          Qa.config.enable_cors_headers
+        end
+        it 'Access-Control-Allow-Origin is *' do
+          get :index, params: { vocab: "local", subauthority: "states" }
+          expect(response.headers['Access-Control-Allow-Origin']).to eq '*'
+        end
+      end
+
+      context 'when cors headers are disabled' do
+        before do
+          Qa.config.disable_cors_headers
+        end
+        it 'Access-Control-Allow-Origin is not present' do
+          get :index, params: { vocab: "local", subauthority: "states" }
+          expect(response.headers.key?('Access-Control-Allow-Origin')).to be false
+        end
       end
     end
 
@@ -156,6 +202,26 @@ describe Qa::TermsController, type: :controller do
       it "returns an individual subject term" do
         get :show, params: { vocab: "loc", subauthority: "subjects", id: "sh85077565" }
         expect(response).to be_success
+      end
+
+      context 'when cors headers are enabled' do
+        before do
+          Qa.config.enable_cors_headers
+        end
+        it 'Access-Control-Allow-Origin is *' do
+          get :show, params: { vocab: "mesh", id: "D000001" }
+          expect(response.headers['Access-Control-Allow-Origin']).to eq '*'
+        end
+      end
+
+      context 'when cors headers are disabled' do
+        before do
+          Qa.config.disable_cors_headers
+        end
+        it 'Access-Control-Allow-Origin is not present' do
+          get :show, params: { vocab: "mesh", id: "D000001" }
+          expect(response.headers.key?('Access-Control-Allow-Origin')).to be false
+        end
       end
     end
   end

--- a/spec/requests/cors_headers_spec.rb
+++ b/spec/requests/cors_headers_spec.rb
@@ -1,0 +1,118 @@
+# spec/requests/cors_headers_spec.rb
+require 'spec_helper'
+
+describe "CORS OPTIONS requests" do # rubocop:disable RSpec/DescribeClass
+  context 'when cors headers are enabled' do
+    before do
+      Qa.config.enable_cors_headers
+    end
+
+    it 'return CORS header info for index' do
+      reset!
+      integration_session.__send__ :process, 'OPTIONS', "/qa/terms/loc"
+      correct_cors_response?
+    end
+
+    it 'return CORS header info for index with subauthority' do
+      reset!
+      integration_session.__send__ :process, 'OPTIONS', "/qa/terms/local/states"
+      correct_cors_response?
+    end
+
+    it 'return CORS header info for search' do
+      reset!
+      integration_session.__send__ :process, 'OPTIONS', "/qa/search/loc"
+      correct_cors_response?
+    end
+
+    it 'return CORS header info for search with subauthority' do
+      reset!
+      integration_session.__send__ :process, 'OPTIONS', "/qa/search/local/two_args?q=a query"
+      correct_cors_response?
+    end
+
+    it 'return CORS header info for show' do
+      reset!
+      integration_session.__send__ :process, 'OPTIONS', "/qa/show/mesh/D000001"
+      correct_cors_response?
+    end
+
+    it 'return CORS header info for show with subauthority' do
+      reset!
+      integration_session.__send__ :process, 'OPTIONS', "/qa/show/local/states/OH"
+      correct_cors_response?
+    end
+
+    it 'return CORS header info for linked_data/search' do
+      reset!
+      integration_session.__send__ :process, 'OPTIONS', "/qa/search/linked_data/OCLC_FAST?q=my_query&maximumRecords=3"
+      correct_cors_response?
+    end
+
+    it 'return CORS header info for linked_data/show' do
+      reset!
+      integration_session.__send__ :process, 'OPTIONS', "/qa/show/linked_data/OCLC_FAST/n24"
+      correct_cors_response?
+    end
+  end
+
+  def correct_cors_response?
+    expect(response.code).to eq('204')
+    expect(response.headers['Access-Control-Allow-Origin']).to eq '*'
+    expect(response.headers['Access-Control-Allow-Methods']).to eq 'GET, OPTIONS'
+  end
+
+  context 'when cors headers are disabled' do
+    before do
+      Qa.config.disable_cors_headers
+    end
+
+    it 'report method not supported for index' do
+      reset!
+      integration_session.__send__ :process, 'OPTIONS', "/qa/terms/loc"
+      expect(response.code).to eq('501')
+    end
+
+    it 'report method not supported for index with subauthority' do
+      reset!
+      integration_session.__send__ :process, 'OPTIONS', "/qa/terms/local/states"
+      expect(response.code).to eq('501')
+    end
+
+    it 'report method not supported for search' do
+      reset!
+      integration_session.__send__ :process, 'OPTIONS', "/qa/search/loc"
+      expect(response.code).to eq('501')
+    end
+
+    it 'report method not supported for search with subauthority' do
+      reset!
+      integration_session.__send__ :process, 'OPTIONS', "/qa/search/local/two_args?q=a query"
+      expect(response.code).to eq('501')
+    end
+
+    it 'report method not supported for show' do
+      reset!
+      integration_session.__send__ :process, 'OPTIONS', "/qa/show/mesh/D000001"
+      expect(response.code).to eq('501')
+    end
+
+    it 'report method not supported for show with subauthority' do
+      reset!
+      integration_session.__send__ :process, 'OPTIONS', "/qa/show/local/states/OH"
+      expect(response.code).to eq('501')
+    end
+
+    it 'report method not supported for linked_data/search' do
+      reset!
+      integration_session.__send__ :process, 'OPTIONS', "/qa/search/linked_data/OCLC_FAST?q=my_query&maximumRecords=3"
+      expect(response.code).to eq('501')
+    end
+
+    it 'report method not supported for linked_data/show' do
+      reset!
+      integration_session.__send__ :process, 'OPTIONS', "/qa/show/linked_data/OCLC_FAST/n24"
+      expect(response.code).to eq('501')
+    end
+  end
+end


### PR DESCRIPTION
* Added CORS support as a configurable option that can be enable or disabled.  It is disabled by default to maintain backward compatibility.
* When CORS is enabled...
  * Adds CORS response 'Access-Control-Allow-Origin' for all GET requests
  * Handles OPTIONS method requests for supported routes and responds with supported methods and allow origin header
* When CORS is disabled...
  * The 'Access-Control-Allow-Origin' header is not added to GET requests
  * If OPTIONS method is requested, a 501 (not supported) response is returned

REF: https://fetch.spec.whatwg.org/#http-cors-protocol