### PR TITLE
Build better SPARQL for ULAN queries with spaces in them

### DIFF
--- a/lib/qa/authorities/getty/ulan.rb
+++ b/lib/qa/authorities/getty/ulan.rb
@@ -15,25 +15,22 @@ module Qa::Authorities
       search = untaint(q)
       # if more than one term is supplied, check both preferred and alt labels
       if search.include?(' ')
-        ex = "("
-        search.split(' ').each do |i|
-          ex += "regex(CONCAT(?name, ' ', ?alt), \"#{i}\",\"i\" ) && "
+        clauses = search.split(' ').collect do |i|
+          %((regex(?name, "#{i}", "i") || regex(?alt, "#{i}", "i")))
         end
-        ex = ex[0..ex.length - 4]
-        ex += ")"
+        ex = "(#{clauses.join(' && ')})"
       else
-        ex = "regex(?name, \"#{search}\", \"i\")"
+        ex = %(regex(?name, "#{search}", "i"))
       end
       # The full text index matches on fields besides the term, so we filter to ensure the match is in the term.
-      sparql = "SELECT DISTINCT ?s ?name ?bio {
-              ?s a skos:Concept; luc:term \"#{search}\";
-                 skos:inScheme <http://vocab.getty.edu/ulan/> ;
-                 gvp:prefLabelGVP [skosxl:literalForm ?name] ;
-                 foaf:focus/gvp:biographyPreferred [schema:description ?bio] ;
-                 skos:altLabel ?alt .
-              FILTER #{ex} .
-            } ORDER BY ?name"
-      sparql
+      %(SELECT DISTINCT ?s ?name ?bio {
+        ?s a skos:Concept; luc:term "#{search}";
+            skos:inScheme <http://vocab.getty.edu/ulan/> ;
+            gvp:prefLabelGVP [skosxl:literalForm ?name] ;
+            foaf:focus/gvp:biographyPreferred [schema:description ?bio] ;
+            skos:altLabel ?alt .
+        FILTER #{ex} .
+      } ORDER BY ?name).gsub(/[\s\n]+/, " ")
     end
 
     def untaint(q)

--- a/spec/lib/authorities/getty/ulan_spec.rb
+++ b/spec/lib/authorities/getty/ulan_spec.rb
@@ -77,19 +77,19 @@ describe Qa::Authorities::Getty::Ulan do
                  foaf:focus/gvp:biographyPreferred [schema:description ?bio] ;
                  skos:altLabel ?alt .
               FILTER regex(?name, "search_term", "i") .
-            } ORDER BY ?name' }
+            } ORDER BY ?name'.gsub(/[\s\n]+/, ' ') }
     end
     context "using a two subject terms" do
       subject { authority.sparql('search term') }
       it {
-        is_expected.to eq "SELECT DISTINCT ?s ?name ?bio {
-              ?s a skos:Concept; luc:term \"search term\";
+        is_expected.to eq %(SELECT DISTINCT ?s ?name ?bio {
+              ?s a skos:Concept; luc:term "search term";
                  skos:inScheme <http://vocab.getty.edu/ulan/> ;
                  gvp:prefLabelGVP [skosxl:literalForm ?name] ;
                  foaf:focus/gvp:biographyPreferred [schema:description ?bio] ;
                  skos:altLabel ?alt .
-              FILTER (regex(CONCAT(?name, ' ', ?alt), \"search\",\"i\" ) && regex(CONCAT(?name, ' ', ?alt), \"term\",\"i\" ) ) .
-            } ORDER BY ?name" }
+              FILTER ((regex(?name, "search", "i") || regex(?alt, "search", "i")) && (regex(?name, "term", "i") || regex(?alt, "term", "i"))) .
+            } ORDER BY ?name).gsub(/[\s\n]+/, ' ') }
     end
   end
 end


### PR DESCRIPTION
Getty's server was choking on the previous multi-term SPARQL, possibly because of a URI encoding error. This PR changes the way multi-term queries are built and encoded. Also updates specs to match.

Fixes #163 

*Note*: There is some other misbehaving SPARQL, notably in the TGN authority searcher but possibly others as well. We are focusing on a ULAN fix because that's what is hampering our production rollout, but hopefully this can be used as an example for working with the others.