### PR TITLE
Extend the linked data API

### DIFF
--- a/app/controllers/qa/linked_data_terms_controller.rb
+++ b/app/controllers/qa/linked_data_terms_controller.rb
@@ -2,9 +2,11 @@
 # out which linked data authority to query based on the 'vocab' param.
 
 class Qa::LinkedDataTermsController < ::ApplicationController
-  before_action :check_authority, :init_authority
+  before_action :check_authority, :init_authority, except: [:list, :reload]
   before_action :check_search_subauthority, :check_query_param, only: :search
   before_action :check_show_subauthority, :check_id_param, only: :show
+  before_action :check_uri_param, only: :fetch
+  before_action :validate_auth_reload_token, only: :reload
 
   delegate :cors_allow_origin_header, to: Qa::ApplicationController
 
@@ -14,55 +16,85 @@ class Qa::LinkedDataTermsController < ::ApplicationController
     head :not_found
   end
 
-  # Return a list of terms based on a query
-  # @see Qa::Authorities::LinkedData::SearchQuery#search
-  def search # rubocop:disable Metrics/MethodLength
-    begin
-      terms = @authority.search(query, subauth: subauthority, language: language, replacements: replacement_params)
-    rescue Qa::ServiceUnavailable
-      logger.warn "Service Unavailable - Search query #{query} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
-      head :service_unavailable
-      return
-    rescue Qa::ServiceError
-      logger.warn "Internal Server Error - Search query #{query} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
-      head :internal_server_error
-      return
-    rescue RDF::FormatError
-      logger.warn "RDF Format Error - Results from search query #{query} for#{subauth_warn_msg} authority #{vocab_param} " \
-                  "was not identified as a valid RDF format.  You may need to include the linkeddata gem."
-      head :internal_server_error
-      return
-    end
-    cors_allow_origin_header(response)
-    render json: terms
+  # Return a list of supported authority names
+  # get "/list/linked_data/authorities"
+  # @see Qa::Authorities::LinkedData::AuthorityService#authority_names
+  def list
+    render json: Qa::Authorities::LinkedData::AuthorityService.authority_names.to_json
   end
 
-  # Return all the information for a given term
+  # Reload authority configurations
+  # get "/reload/linked_data/authorities?auth_token=YOUR_AUTH_TOKEN_DEFINED_HERE"
+  # @see Qa::Authorities::LinkedData::AuthorityService#load_authorities
+  def reload
+    Qa::Authorities::LinkedData::AuthorityService.load_authorities
+    list
+  end
+
+  # Return a list of terms based on a query
+  # get "/search/linked_data/:vocab(/:subauthority)"
+  # @see Qa::Authorities::LinkedData::SearchQuery#search
+  def search
+    terms = @authority.search(query, subauth: subauthority, language: language, replacements: replacement_params)
+    cors_allow_origin_header(response)
+    render json: terms
+  rescue Qa::ServiceUnavailable
+    logger.warn "Service Unavailable - Search query #{query} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
+    head :service_unavailable
+  rescue Qa::ServiceError
+    logger.warn "Internal Server Error - Search query #{query} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
+    head :internal_server_error
+  rescue RDF::FormatError
+    logger.warn "RDF Format Error - Results from search query #{query} for#{subauth_warn_msg} authority #{vocab_param} " \
+                "was not identified as a valid RDF format.  You may need to include the linkeddata gem."
+    head :internal_server_error
+  end
+
+  # Return all the information for a given term given an id or URI
+  # get "/show/linked_data/:vocab/:id"
+  # get "/show/linked_data/:vocab/:subauthority/:id
   # @see Qa::Authorities::LinkedData::FindTerm#find
   def show # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-    begin
-      term = @authority.find(id, subauth: subauthority, language: language, replacements: replacement_params, jsonld: jsonld?)
-    rescue Qa::TermNotFound
-      logger.warn "Term Not Found - Fetch term #{id} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
-      head :not_found
-      return
-    rescue Qa::ServiceUnavailable
-      logger.warn "Service Unavailable - Fetch term #{id} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
-      head :service_unavailable
-      return
-    rescue Qa::ServiceError
-      logger.warn "Internal Server Error - Fetch term #{id} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
-      head :internal_server_error
-      return
-    rescue RDF::FormatError
-      logger.warn "RDF Format Error - Results from fetch term #{id} for#{subauth_warn_msg} authority #{vocab_param} " \
-                  "was not identified as a valid RDF format.  You may need to include the linkeddata gem."
-      head :internal_server_error
-      return
-    end
+    term = @authority.find(id, subauth: subauthority, language: language, replacements: replacement_params, jsonld: jsonld?)
     cors_allow_origin_header(response)
     content_type = jsonld? ? 'application/ld+json' : 'application/json'
     render json: term, content_type: content_type
+  rescue Qa::TermNotFound
+    logger.warn "Term Not Found - Fetch term #{id} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
+    head :not_found
+  rescue Qa::ServiceUnavailable
+    logger.warn "Service Unavailable - Fetch term #{id} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
+    head :service_unavailable
+  rescue Qa::ServiceError
+    logger.warn "Internal Server Error - Fetch term #{id} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
+    head :internal_server_error
+  rescue RDF::FormatError
+    logger.warn "RDF Format Error - Results from fetch term #{id} for#{subauth_warn_msg} authority #{vocab_param} " \
+                "was not identified as a valid RDF format.  You may need to include the linkeddata gem."
+    head :internal_server_error
+  end
+
+  # Return all the information for a given term given a URI
+  # get "/fetch/linked_data/:vocab"
+  # @see Qa::Authorities::LinkedData::FindTerm#find
+  def fetch # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    term = @authority.find(uri, subauth: subauthority, language: language, replacements: replacement_params, jsonld: jsonld?)
+    cors_allow_origin_header(response)
+    content_type = jsonld? ? 'application/ld+json' : 'application/json'
+    render json: term, content_type: content_type
+  rescue Qa::TermNotFound
+    logger.warn "Term Not Found - Fetch term #{uri} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
+    head :not_found
+  rescue Qa::ServiceUnavailable
+    logger.warn "Service Unavailable - Fetch term #{uri} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
+    head :service_unavailable
+  rescue Qa::ServiceError
+    logger.warn "Internal Server Error - Fetch term #{uri} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
+    head :internal_server_error
+  rescue RDF::FormatError
+    logger.warn "RDF Format Error - Results from fetch term #{uri} for#{subauth_warn_msg} authority #{vocab_param} " \
+                "was not identified as a valid RDF format.  You may need to include the linkeddata gem."
+    head :internal_server_error
   end
 
   private
@@ -102,10 +134,20 @@ class Qa::LinkedDataTermsController < ::ApplicationController
     end
 
     def check_query_param
-      if params[:q].nil? || !params[:q].size.positive? # rubocop:disable Style/GuardClause
-        logger.warn "Required search param 'q' is missing or empty"
-        head :bad_request
-      end
+      missing_required_param('search', 'q') if params[:q].blank?
+    end
+
+    def check_id_param
+      missing_required_param('show', 'id') if id.blank?
+    end
+
+    def check_uri_param
+      missing_required_param('fetch', 'uri') if uri.blank?
+    end
+
+    def missing_required_param(action_name, param_name)
+      logger.warn "Required #{action_name} param '#{param_name}' is missing or empty"
+      head :bad_request
     end
 
     # converts wildcards into URL-encoded characters
@@ -113,11 +155,8 @@ class Qa::LinkedDataTermsController < ::ApplicationController
       params[:q].gsub("*", "%2A")
     end
 
-    def check_id_param
-      if params[:id].nil? || !params[:id].size.positive? # rubocop:disable Style/GuardClause
-        logger.warn "Required show param 'id' is missing or empty"
-        head :bad_request
-      end
+    def uri
+      params[:uri]
     end
 
     def id
@@ -148,5 +187,14 @@ class Qa::LinkedDataTermsController < ::ApplicationController
 
     def jsonld?
       format == 'jsonld'
+    end
+
+    def validate_auth_reload_token
+      token = params.key?(:auth_token) ? params[:auth_token] : nil
+      valid = Qa.config.valid_authority_reload_token?(token)
+      return true if valid
+      logger.warn "FAIL: unable to reload authorities; error_msg: Invalid token (#{token}) does not match expected token."
+      head :unauthorized
+      false
     end
 end

--- a/config/initializers/linked_data_authorities.rb
+++ b/config/initializers/linked_data_authorities.rb
@@ -1,17 +1,1 @@
-auth_cfg = {}
-# load QA configured linked data authorities
-Dir[File.join(Qa::Engine.root, 'config', 'authorities', 'linked_data', '*.json')].each do |fn|
-  auth = File.basename(fn, '.json').upcase.to_sym
-  json = File.read(File.expand_path(fn, __FILE__))
-  cfg = JSON.parse(json).deep_symbolize_keys
-  auth_cfg[auth] = cfg
-end
-
-# load app configured linked data authorities and overrides
-Dir[Rails.root.join('config', 'authorities', 'linked_data', '*.json')].each do |fn|
-  auth = File.basename(fn, '.json').upcase.to_sym
-  json = File.read(File.expand_path(fn, __FILE__))
-  cfg = JSON.parse(json).deep_symbolize_keys
-  auth_cfg[auth] = cfg
-end
-LINKED_DATA_AUTHORITIES_CONFIG = auth_cfg.freeze
+Qa::Authorities::LinkedData::AuthorityService.load_authorities

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Qa::Engine.routes.draw do
+  get "/list/linked_data/authorities", controller: :linked_data_terms, action: :list
+  get "/reload/linked_data/authorities", controller: :linked_data_terms, action: :reload
   get "/search/linked_data/:vocab(/:subauthority)", controller: :linked_data_terms, action: :search
+  get "/fetch/linked_data/:vocab", controller: :linked_data_terms, action: :fetch
   get "/show/linked_data/:vocab/:id", controller: :linked_data_terms, action: :show
   get "/show/linked_data/:vocab/:subauthority/:id", controller: :linked_data_terms, action: :show
   get "/terms/:vocab(/:subauthority)",  controller: :terms, action: :index

--- a/lib/generators/qa/apidoc/templates/public/qa/apidoc/apidoc.json
+++ b/lib/generators/qa/apidoc/templates/public/qa/apidoc/apidoc.json
@@ -1,8 +1,8 @@
 {
   "openapi": "3.0.1",
   "info": {
-    "title": "QA 2.1 Linked Data API",
-    "version": "2.1",
+    "title": "QA 2.2 Linked Data API",
+    "version": "2.2",
     "license": {
       "name": "Apache 2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
@@ -11,7 +11,7 @@
   "servers": [
     {
       "url": "http://{site_host}/{apiBase}",
-      "description": "QA v2.1 API Server",
+      "description": "QA v2.2 API Server",
       "variables": {
         "site_host": {
           "default": "localhost:3000",
@@ -24,6 +24,87 @@
     }
   ],
   "paths": {
+    "/list/linked_data/authorities": {
+      "get": {
+        "summary": "List currently loaded linked data authorities",
+        "operationId": "GET_listAuthorities",
+        "tags": [
+          "Authority Management"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully accessed authority and received results.",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "description": "CORS header will be * if cors_headers_enabled",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/linked_data_authorities_list_result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reload/linked_data/authorities": {
+      "get": {
+        "summary": "Reload linked data authorities.  Using this command avoids having to restart the rails server.",
+        "operationId": "GET_reloadAuthorities",
+        "tags": [
+          "Authority Management"
+        ],
+        "parameters": [
+          {
+            "description": "Security token which must be included for this command to execute.",
+            "in": "query",
+            "name": "auth_token",
+            "required": true,
+            "schema": {
+              "default": "",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully reloaded authorities.",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "description": "CORS header will be * if cors_headers_enabled",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/linked_data_authorities_list_result"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": ""
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/search/linked_data/{vocab}": {
       "get": {
         "summary": "Send a query string to an authority and return search results.  Parameters are typical examples.  Actual parameters are driven by the authority's config file.",
@@ -38,7 +119,7 @@
             "name": "vocab",
             "required": true,
             "schema": {
-              "default": "agrovoc",
+              "default": "oclc_fast",
               "type": "string"
             }
           },
@@ -48,14 +129,14 @@
             "name": "q",
             "required": true,
             "schema": {
-              "default": "milk",
+              "default": "science",
               "type": "string"
             }
           },
           {
-            "description": "Limit number of returned results",
+            "description": "Limit number of returned results. NOTE: Most authorities use maxRecords instead of maximumRecords for this parameter.",
             "in": "query",
-            "name": "maxRecords",
+            "name": "maximumRecords",
             "required": false,
             "schema": {
               "default": 4,
@@ -92,8 +173,8 @@
               }
             }
           },
-          "503": {
-            "description": "Service Unavailable",
+          "400": {
+            "description": "Bad Request - occurs when required params are missing (e.g. q)",
             "content": {
               "text/plain": {
                 "schema": {
@@ -104,7 +185,18 @@
             }
           },
           "500": {
-            "description": "Internal Server Error",
+            "description": "Internal Server Error - can be raised while attempting to access the external authority OR during processing of results when results are not a valid RDF Format",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": ""
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable - can be raised while attempting to access the external authority",
             "content": {
               "text/plain": {
                 "schema": {
@@ -129,7 +221,7 @@
             "name": "vocab",
             "required": true,
             "schema": {
-              "default": "agrovoc",
+              "default": "oclc_fast",
               "type": "string"
             }
           }
@@ -252,8 +344,8 @@
               }
             }
           },
-          "503": {
-            "description": "Service Unavailable",
+          "400": {
+            "description": "Bad Request - occurs when required params are missing (e.g. q)",
             "content": {
               "text/plain": {
                 "schema": {
@@ -264,7 +356,18 @@
             }
           },
           "500": {
-            "description": "Internal Server Error",
+            "description": "Internal Server Error - can be raised while attempting to access the external authority OR during processing of results when results are not a valid RDF Format",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": ""
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable - can be raised while attempting to access the external authority",
             "content": {
               "text/plain": {
                 "schema": {
@@ -358,7 +461,7 @@
             "name": "vocab",
             "required": true,
             "schema": {
-              "default": "agrovoc",
+              "default": "oclc_fast",
               "type": "string"
             }
           },
@@ -368,8 +471,22 @@
             "name": "id",
             "required": true,
             "schema": {
-              "default": "c_9513",
+              "default": "1914919",
               "type": "string"
+            }
+          },
+          {
+            "description": "The format of the returned result.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "default": "json",
+              "type": "string",
+              "enum": [
+                "json",
+                "jsonld"
+              ]
             }
           }
         ],
@@ -387,7 +504,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/linked_data_term"
+                  "$ref": "#/components/schemas/linked_data_term_json_result"
+                }
+              },
+              "application/ld+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/linked_data_term_jsonld_result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - occurs when required params are missing (e.g. id)",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": ""
                 }
               }
             }
@@ -403,8 +536,8 @@
               }
             }
           },
-          "503": {
-            "description": "Service Unavailable",
+          "500": {
+            "description": "Internal Server Error - can be raised while attempting to access the external authority OR during processing of results when results are not a valid RDF Format",
             "content": {
               "text/plain": {
                 "schema": {
@@ -414,8 +547,8 @@
               }
             }
           },
-          "500": {
-            "description": "Internal Server Error",
+          "503": {
+            "description": "Service Unavailable - can be raised while attempting to access the external authority",
             "content": {
               "text/plain": {
                 "schema": {
@@ -440,7 +573,7 @@
             "name": "vocab",
             "required": true,
             "schema": {
-              "default": "agrovoc",
+              "default": "oclc_fast",
               "type": "string"
             }
           },
@@ -450,7 +583,7 @@
             "name": "id",
             "required": true,
             "schema": {
-              "default": "c_9513",
+              "default": "1914919",
               "type": "string"
             }
           }
@@ -532,6 +665,20 @@
               "default": "n92016188",
               "type": "string"
             }
+          },
+          {
+            "description": "The format of the returned result.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "default": "json",
+              "type": "string",
+              "enum": [
+                "json",
+                "jsonld"
+              ]
+            }
           }
         ],
         "responses": {
@@ -548,7 +695,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/linked_data_term_result"
+                  "$ref": "#/components/schemas/linked_data_term_json_result"
+                }
+              },
+              "application/ld+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/linked_data_term_jsonld_result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - occurs when required params are missing (e.g. id)",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": ""
                 }
               }
             }
@@ -564,8 +727,8 @@
               }
             }
           },
-          "503": {
-            "description": "Service Unavailable",
+          "500": {
+            "description": "Internal Server Error - can be raised while attempting to access the external authority OR during processing of results when results are not a valid RDF Format",
             "content": {
               "text/plain": {
                 "schema": {
@@ -575,8 +738,8 @@
               }
             }
           },
-          "500": {
-            "description": "Internal Server Error",
+          "503": {
+            "description": "Service Unavailable - can be raised while attempting to access the external authority",
             "content": {
               "text/plain": {
                 "schema": {
@@ -665,10 +828,398 @@
           }
         }
       }
+    },
+    "/fetch/linked_data/{vocab}": {
+      "get": {
+        "operationId": "GET_fetchURIFromAuthority",
+        "summary": "Get a single term from an authority given the term's URI.  Generally there are no additional parameters.  See the authority's configuration file to be sure.  Some authorities support `lang` which can be used to filter the language of returned strings.  NOTE: The authorities provided with QA do not support fetch by URI.  See more authority configs at: https://github.com/LD4P/linked_data_authorities",
+        "tags": [
+          "Fetch Term"
+        ],
+        "parameters": [
+          {
+            "description": "Name of the authority's configuration file.",
+            "in": "path",
+            "name": "vocab",
+            "required": true,
+            "schema": {
+              "default": "loc",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The URI for the term being retrieved.",
+            "in": "query",
+            "name": "uri",
+            "required": true,
+            "schema": {
+              "default": "http://id.loc.gov/authorities/genreForms/gf2011026141",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The format of the returned result.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "default": "json",
+              "type": "string",
+              "enum": [
+                "json",
+                "jsonld"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully accessed authority and received term.",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "description": "CORS header will be * if CORS headers are enabled",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/linked_data_term_json_result"
+                }
+              },
+              "application/ld+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/linked_data_term_jsonld_result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - occurs when required params are missing (e.g. uri)",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": ""
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": ""
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error - can be raised while attempting to access the external authority OR during processing of results when results are not a valid RDF Format",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": ""
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable - can be raised while attempting to access the external authority",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": ""
+                }
+              }
+            }
+          }
+        }
+      },
+      "options": {
+        "summary": "CORS preflight request",
+        "operationId": "OPTIONS_fetchFromAuthority",
+        "tags": [
+          "Fetch Term"
+        ],
+        "parameters": [
+          {
+            "description": "Name of the authority's configuration file.",
+            "in": "path",
+            "name": "vocab",
+            "required": true,
+            "schema": {
+              "default": "loc",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID or URI for the term being retrieved.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "default": "http://id.loc.gov/authorities/genreForms/gf2011026141",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Perform CORS preflight for fetching a term from an authority",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "description": "CORS header will be * if CORS headers are enabled",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Methods": {
+                "description": "Indicates which method a future CORS request to the same resource might use.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": ""
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "OPTIONS action is not implement when CORS headers are not enabled",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": ""
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/fetch/linked_data/{vocab}/{subauthority}": {
+      "get": {
+        "operationId": "GET_fetchByURIFromSubauthority",
+        "summary": "Get a single term from a subauthority in an authority given the term's URI.  Generally there are no additional parameters.  See the authority's configuration file to be sure.  Some authorities support `lang` which can be used to filter the language of returned strings.  NOTE: There currently aren't any authorities configured that support subauthorities and access terms using a URI instead of an ID.  The default values in this example show what you might see but DO NOT WORK with the current LOC config.",
+        "tags": [
+          "Fetch Term"
+        ],
+        "parameters": [
+          {
+            "description": "Name of the authority's configuration file.",
+            "in": "path",
+            "name": "vocab",
+            "required": true,
+            "schema": {
+              "default": "loc",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Name of the subauthority.",
+            "in": "path",
+            "name": "subauthority",
+            "required": true,
+            "schema": {
+              "default": "names",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The URI for the term being retrieved.",
+            "in": "query",
+            "name": "uri",
+            "required": true,
+            "schema": {
+              "default": "http://id.loc.gov/authorities/names/n92016188",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The format of the returned result.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "default": "json",
+              "type": "string",
+              "enum": [
+                "json",
+                "jsonld"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully accessed subauthority in the authority and received term.",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "description": "CORS header will be * if CORS headers are enabled",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/linked_data_term_json_result"
+                }
+              },
+              "application/ld+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/linked_data_term_jsonld_result"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - occurs when required params are missing (e.g. uri)",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": ""
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": ""
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error - can be raised while attempting to access the external authority OR during processing of results when results are not a valid RDF Format",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": ""
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable - can be raised while attempting to access the external authority",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": ""
+                }
+              }
+            }
+          }
+        }
+      },
+      "options": {
+        "summary": "CORS preflight request",
+        "operationId": "OPTIONS_fetchFromSubauthority",
+        "tags": [
+          "Fetch Term"
+        ],
+        "parameters": [
+          {
+            "description": "Name of the authority's configuration file.",
+            "in": "path",
+            "name": "vocab",
+            "required": true,
+            "schema": {
+              "default": "loc",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Name of the subauthority.",
+            "in": "path",
+            "name": "subauthority",
+            "required": true,
+            "schema": {
+              "default": "names",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The URI for the term being retrieved.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "default": "http://id.loc.gov/authorities/names/n92016188",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Perform CORS preflight for fetching a term from a subauthority in an authority",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "description": "CORS header will be * if CORS headers are enabled",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Methods": {
+                "description": "Indicates which method a future CORS request to the same resource might use.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": ""
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "OPTIONS action is not implement when CORS headers are not enabled",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": ""
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
     "schemas": {
+      "linked_data_authorities_list_result": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
       "linked_data_query_results": {
         "type": "array",
         "items": {
@@ -693,7 +1244,7 @@
           }
         }
       },
-      "linked_data_term": {
+      "linked_data_term_json_result": {
         "required": [
           "id",
           "uri",
@@ -737,10 +1288,28 @@
             "type": "object",
           }
         }
+      },
+      "linked_data_term_jsonld_result": {
+        "required": [
+          "@context",
+          "@graph"
+        ],
+        "properties": {
+          "@context": {
+            "type": "object"
+          },
+          "@graph": {
+            "type": "object"
+          }
+        }
       }
     }
   },
   "tags": [
+    {
+      "name": "Authority Management",
+      "description": "Services managing all authorities."
+    },
     {
       "name": "Search Query",
       "description": "Services sending a search query to an authority to retrieve multiple results."

--- a/lib/generators/qa/install/templates/config/initializers/qa.rb
+++ b/lib/generators/qa/install/templates/config/initializers/qa.rb
@@ -4,4 +4,10 @@ Qa.config do |config|
   # More information on CORS headers at: https://fetch.spec.whatwg.org/#cors-protocol
   # config.enable_cors_headers
   # config.disable_cors_headers
+
+  # Provide a token that allows reloading of linked data authorities through the controller
+  # action '/reload/linked_data/authorities?auth_token=YOUR_AUTH_TOKEN_DEFINED_HERE' without
+  # requiring a restart of rails. By default, reloading through the browser is not allowed
+  # when the token is nil or blank.  Change to any string to control who has access to reload.
+  # config.authorized_reload_token = YOUR_AUTH_TOKEN_DEFINED_HERE
 end

--- a/lib/qa/authorities/linked_data.rb
+++ b/lib/qa/authorities/linked_data.rb
@@ -3,6 +3,7 @@ module Qa::Authorities
     extend ActiveSupport::Autoload
     autoload :GenericAuthority
     autoload :RdfHelper
+    autoload :AuthorityService
     autoload :SearchQuery
     autoload :FindTerm
     autoload :Config

--- a/lib/qa/authorities/linked_data/authority_service.rb
+++ b/lib/qa/authorities/linked_data/authority_service.rb
@@ -1,0 +1,47 @@
+# This module has the primary QA search method.  It also includes methods to process the linked data results and convert
+# them into the expected QA json results format.
+module Qa::Authorities
+  module LinkedData
+    class AuthorityService
+      # Load or reload the linked data configuration files
+      def self.load_authorities
+        auth_cfg = {}
+        # load QA configured linked data authorities
+        Dir[File.join(Qa::Engine.root, 'config', 'authorities', 'linked_data', '*.json')].each do |fn|
+          auth = File.basename(fn, '.json').upcase.to_sym
+          json = File.read(File.expand_path(fn, __FILE__))
+          cfg = JSON.parse(json).deep_symbolize_keys
+          auth_cfg[auth] = cfg
+        end
+
+        # load app configured linked data authorities and overrides
+        Dir[Rails.root.join('config', 'authorities', 'linked_data', '*.json')].each do |fn|
+          auth = File.basename(fn, '.json').upcase.to_sym
+          json = File.read(File.expand_path(fn, __FILE__))
+          cfg = JSON.parse(json).deep_symbolize_keys
+          auth_cfg[auth] = cfg
+        end
+        Qa.config.linked_data_authority_configs = auth_cfg
+      end
+
+      # Get the list of names of the loaded authorities
+      # @return [Array<String>] all loaded authority configurations
+      def self.authority_configs
+        Qa.config.linked_data_authority_configs
+      end
+
+      # Get the configuration for an authority
+      # @param [String] name of the authority
+      # @return [Array<String>] configuration for the specified authority
+      def self.authority_config(authname)
+        authority_configs[authname]
+      end
+
+      # Get the list of names of the loaded authorities
+      # @return [Array<String>] names of the authority config files that are currently loaded
+      def self.authority_names
+        authority_configs.keys.sort
+      end
+    end
+  end
+end

--- a/lib/qa/authorities/linked_data/config.rb
+++ b/lib/qa/authorities/linked_data/config.rb
@@ -44,7 +44,7 @@ module Qa::Authorities
       # Return the full configuration for an authority
       # @return [String] the authority configuration
       def auth_config
-        @authority_config ||= LINKED_DATA_AUTHORITIES_CONFIG[@authority_name]
+        @authority_config ||= Qa::Authorities::LinkedData::AuthorityService.authority_config(@authority_name)
         raise Qa::InvalidLinkedDataAuthority, "Unable to initialize linked data authority '#{@authority_name}'" if @authority_config.nil?
         @authority_config
       end

--- a/lib/qa/authorities/linked_data/generic_authority.rb
+++ b/lib/qa/authorities/linked_data/generic_authority.rb
@@ -22,7 +22,13 @@ module Qa::Authorities
         @auth_config = Qa::Authorities::LinkedData::Config.new(auth_name)
       end
 
-      include WebServiceBase
+      def reload_authorities
+        @authorities_service.load_authorities
+      end
+
+      def authorities_service
+        @authorities_service ||= Qa::Authorities::LinkedData::AuthorityService
+      end
 
       def search_service
         @search_service ||= Qa::Authorities::LinkedData::SearchQuery.new(search_config)
@@ -34,6 +40,7 @@ module Qa::Authorities
 
       delegate :search, to: :search_service
       delegate :find, to: :item_service
+      delegate :load_authorities, :authority_names, to: :authorities_service
 
       private
 

--- a/lib/qa/configuration.rb
+++ b/lib/qa/configuration.rb
@@ -12,5 +12,23 @@ module Qa
     def disable_cors_headers
       @cors_headers_enabled = false
     end
+
+    # Provide a token that allows reloading of linked data authorities through the controller
+    # action '/reload/linked_data/authorities?auth_token=YOUR_AUTH_TOKEN_DEFINED_HERE' without
+    # requiring a restart of rails. By default, reloading through the browser is not allowed
+    # when the token is nil or blank.  Change to your approved token string in
+    # config/initializers/qa.rb.
+    attr_writer :authorized_reload_token
+    def authorized_reload_token
+      @authorized_reload_token ||= nil
+    end
+
+    def valid_authority_reload_token?(token)
+      return false if token.blank? || authorized_reload_token.blank?
+      token == authorized_reload_token
+    end
+
+    # Hold linked data authority configs
+    attr_accessor :linked_data_authority_configs
   end
 end

--- a/spec/fixtures/authorities/linked_data/lod_term_uri_param_config.json
+++ b/spec/fixtures/authorities/linked_data/lod_term_uri_param_config.json
@@ -1,0 +1,27 @@
+{
+  "term": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type":    "IriTemplate",
+      "template": "http://localhost/test_default/term?uri={?term_uri}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "term_uri",
+          "property": "hydra:freetextQuery",
+          "required": true
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "term_id": "term_uri"
+    },
+    "term_id": "URI",
+    "results": {
+      "id_predicate":       "http://id.loc.gov/vocabulary/identifiers/lccn",
+      "label_predicate":    "http://www.w3.org/2004/02/skos/core#prefLabel"
+    }
+  },
+  "search": {}
+}

--- a/spec/lib/authorities/linked_data/authority_service_spec.rb
+++ b/spec/lib/authorities/linked_data/authority_service_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe Qa::Authorities::LinkedData::AuthorityService do
+  let(:auth_names) do
+    [:AGROVOC,
+     :LOC,
+     :LOD_ENCODING_CONFIG,
+     :LOD_FULL_CONFIG,
+     :LOD_LANG_DEFAULTS,
+     :LOD_LANG_MULTI_DEFAULTS,
+     :LOD_LANG_NO_DEFAULTS,
+     :LOD_LANG_PARAM,
+     :LOD_MIN_CONFIG,
+     :LOD_SEARCH_ONLY_CONFIG,
+     :LOD_SORT,
+     :LOD_TERM_ID_PARAM_CONFIG,
+     :LOD_TERM_ONLY_CONFIG,
+     :LOD_TERM_URI_PARAM_CONFIG,
+     :OCLC_FAST]
+  end
+
+  describe '#authority_configs' do
+    let(:result) { described_class.authority_configs }
+    it 'returns all authorities' do
+      expect(result).to be_kind_of(Hash)
+      expect(result.keys).to match_array auth_names
+      expect(result.values.first).to be_kind_of(Hash)
+      expect(result.values.first).to have_key(:term)
+      expect(result.values.first).to have_key(:search)
+    end
+  end
+
+  describe '#authority_config' do
+    let(:result) { described_class.authority_config(:LOD_FULL_CONFIG) }
+    it 'returns a single authority' do
+      expect(result).to be_kind_of(Hash)
+      expect(result).to have_key(:term)
+      expect(result).to have_key(:search)
+    end
+  end
+
+  describe '#authority_names' do
+    it "returns a list of all authorities' names" do
+      expect(described_class.authority_names).to eq auth_names
+    end
+  end
+end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -1,0 +1,58 @@
+RSpec.describe Qa::Configuration do
+  subject { described_class.new }
+
+  it { is_expected.to respond_to(:cors_headers?) }
+  it { is_expected.to respond_to(:enable_cors_headers) }
+  it { is_expected.to respond_to(:disable_cors_headers) }
+  it { is_expected.to respond_to(:authorized_reload_token=) }
+  it { is_expected.to respond_to(:authorized_reload_token) }
+  it { is_expected.to respond_to(:valid_authority_reload_token?) }
+
+  describe '#enable_cors_headers' do
+    it 'turns on cors headers support' do
+      subject.enable_cors_headers
+      expect(subject.cors_headers?).to be true
+    end
+  end
+
+  describe '#disable_cors_headers' do
+    it 'turns off cors headers support' do
+      subject.disable_cors_headers
+      expect(subject.cors_headers?).to be false
+    end
+  end
+
+  describe '#valid_authority_reload_token?' do
+    it 'defaults to invalid' do
+      expect(subject.valid_authority_reload_token?('any value')).to be false
+    end
+
+    context 'when token is set to blank' do
+      before do
+        subject.authorized_reload_token = ''
+      end
+
+      it 'returns false if token matches' do
+        expect(subject.valid_authority_reload_token?('')).to be false
+      end
+
+      it "returns false if token doesn't match" do
+        expect(subject.valid_authority_reload_token?('any value')).to be false
+      end
+    end
+
+    context 'when token has a value' do
+      before do
+        subject.authorized_reload_token = 'A_TOKEN'
+      end
+
+      it 'returns true if the passed in token matches' do
+        expect(subject.valid_authority_reload_token?('A_TOKEN')).to be true
+      end
+
+      it 'returns false if the passed in token does not match' do
+        expect(subject.valid_authority_reload_token?('BAD TOKEN')).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
* list - returns a list of the loaded linked data authorities
* reload - reload linked data configurations (does not require restart of rails server)
* fetch - retrieve a single linked data term by passing URI as a parameter