### PR TITLE
allow a linked data term request to return content as json-ld

### DIFF
--- a/app/controllers/qa/linked_data_terms_controller.rb
+++ b/app/controllers/qa/linked_data_terms_controller.rb
@@ -41,7 +41,7 @@ class Qa::LinkedDataTermsController < ::ApplicationController
   # @see Qa::Authorities::LinkedData::FindTerm#find
   def show # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     begin
-      term = @authority.find(id, subauth: subauthority, language: language, replacements: replacement_params)
+      term = @authority.find(id, subauth: subauthority, language: language, replacements: replacement_params, jsonld: jsonld?)
     rescue Qa::TermNotFound
       logger.warn "Term Not Found - Fetch term #{id} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
       head :not_found
@@ -61,7 +61,8 @@ class Qa::LinkedDataTermsController < ::ApplicationController
       return
     end
     cors_allow_origin_header(response)
-    render json: term
+    content_type = jsonld? ? 'application/ld+json' : 'application/json'
+    render json: term, content_type: content_type
   end
 
   private
@@ -137,5 +138,15 @@ class Qa::LinkedDataTermsController < ::ApplicationController
 
     def subauth_warn_msg
       subauthority.nil? ? "" : " sub-authority #{subauthority} in"
+    end
+
+    def format
+      return 'json' unless params.key?(:format)
+      return 'json' if params[:format].blank?
+      params[:format]
+    end
+
+    def jsonld?
+      format == 'jsonld'
     end
 end

--- a/lib/qa/authorities/linked_data/find_term.rb
+++ b/lib/qa/authorities/linked_data/find_term.rb
@@ -33,13 +33,14 @@ module Qa::Authorities
       #     "http://schema.org/name":["Cornell University","Ithaca (N.Y.). Cornell University"],
       #     "http://www.w3.org/2004/02/skos/core#altLabel":["Ithaca (N.Y.). Cornell University"],
       #     "http://schema.org/sameAs":["http://id.loc.gov/authorities/names/n79021621","https://viaf.org/viaf/126293486"] } }
-      def find(id, language: nil, replacements: {}, subauth: nil)
+      def find(id, language: nil, replacements: {}, subauth: nil, jsonld: false)
         raise Qa::InvalidLinkedDataAuthority, "Unable to initialize linked data term sub-authority #{subauth}" unless subauth.nil? || term_subauthority?(subauth)
         language ||= term_config.term_language
         url = term_config.term_url_with_replacements(id, subauth, replacements)
         Rails.logger.info "QA Linked Data term url: #{url}"
         graph = get_linked_data(url)
         return "{}" unless graph.size.positive?
+        return graph.dump(:jsonld, standard_prefixes: true) if jsonld
         parse_term_authority_response(id, graph, language)
       end
 

--- a/spec/controllers/linked_data_terms_controller_spec.rb
+++ b/spec/controllers/linked_data_terms_controller_spec.rb
@@ -324,9 +324,27 @@ describe Qa::LinkedDataTermsController, type: :controller do
           stub_request(:get, 'http://artemide.art.uniroma2.it:8081/agrovoc/rest/v1/data?uri=http://aims.fao.org/aos/agrovoc/c_9513')
             .to_return(status: 200, body: webmock_fixture('lod_agrovoc_term_found.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
         end
-        it 'succeeds' do
+
+        it 'succeeds and defaults to json content type' do
           get :show, params: { id: 'c_9513', vocab: 'AGROVOC' }
           expect(response).to be_successful
+          expect(response.content_type).to eq 'application/json'
+        end
+
+        context 'and it was requested as json' do
+          it 'succeeds and returns term data as json content type' do
+            get :show, params: { id: 'c_9513', vocab: 'AGROVOC', format: 'json' }
+            expect(response).to be_successful
+            expect(response.content_type).to eq 'application/json'
+          end
+        end
+
+        context 'and it was requested as jsonld' do
+          it 'succeeds and returns term data as jsonld content type' do
+            get :show, params: { id: 'c_9513', vocab: 'AGROVOC', format: 'jsonld' }
+            expect(response).to be_successful
+            expect(response.content_type).to eq 'application/ld+json'
+          end
         end
       end
     end
@@ -337,9 +355,10 @@ describe Qa::LinkedDataTermsController, type: :controller do
           stub_request(:get, 'http://id.loc.gov/authorities/subjects/sh85118553')
             .to_return(status: 200, body: webmock_fixture('lod_loc_term_found.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
         end
-        it 'succeeds' do
+        it 'succeeds and defaults to json content type' do
           get :show, params: { id: 'sh85118553', vocab: 'LOC', subauthority: 'subjects' }
           expect(response).to be_successful
+          expect(response.content_type).to eq 'application/json'
         end
       end
     end


### PR DESCRIPTION
For backward compatibility, term data continues to return as json by default.  To request as json-ld, append parameter `format=jsonld` to the end of the request URL.

Ex. http://localhost:3000/qa/show/linked_data/oclc_fast/1914919?format=jsonld