### PR TITLE
Move rdf_helper methods to graph_service

### DIFF
--- a/app/services/qa/linked_data/graph_service.rb
+++ b/app/services/qa/linked_data/graph_service.rb
@@ -1,0 +1,77 @@
+# Extend the RDF graph to include additional processing methods.
+module Qa
+  module LinkedData
+    class GraphService
+      attr_reader :graph
+
+      # Retrieve linked data from specified url
+      # @param [String] url from which to retrieve linked data
+      # @param [String | Symbol | Array<String|Symbol>] language for filtering graph (e.g. "en" or :en or ["en", "fr"] or [:en, :fr])
+      # @returns [RDF::Graph] graph of linked data
+      def initialize(url:)
+        @graph = RDF::Graph.load(url)
+      rescue IOError => e
+        process_error(e, url)
+      end
+
+      # Apply filters to the graph
+      # @param language [String | Symbol | Array<String|Symbol>] will keep any statement whose object's language matches the language filter
+      #          (only applies to statements that respond to language) (e.g. "en" or :en or ["en", "fr"] or [:en, :fr])
+      # @param remove_blanknode_subjects [Boolean] will remove any statement whose subject is a blanknode, if true
+      def filter(language: nil, remove_blanknode_subjects: false)
+        return unless @graph.present?
+        return unless language.present? || remove_blanknode_subjects
+        language = normalize_language(language)
+        @graph.each do |st|
+          @graph.delete(st) if filter_out_blanknode(remove_blanknode_subjects, st.subject) || filter_out_language(language, st.object)
+        end
+      end
+
+      private
+
+        def filter_out_blanknode(remove, subj)
+          remove && subj.anonymous?
+        end
+
+        def filter_out_language(language, obj)
+          return false if language.blank?
+          return false unless obj.respond_to?(:language)
+          return false if obj.language.blank?
+          !language.include?(obj.language)
+        end
+
+        def process_error(e, url)
+          uri = URI(url)
+          raise RDF::FormatError, "Unknown RDF format of results returned by #{uri}. (RDF::FormatError)  You may need to include gem 'linkeddata'." if e.is_a? RDF::FormatError
+          response_code = ioerror_code(e)
+          case response_code
+          when '404'
+            raise Qa::TermNotFound, "#{uri} Not Found - Term may not exist at LOD Authority. (HTTPNotFound - 404)"
+          when '500'
+            raise Qa::ServiceError, "#{uri.hostname} on port #{uri.port} is not responding.  Try again later. (HTTPServerError - 500)"
+          when '503'
+            raise Qa::ServiceUnavailable, "#{uri.hostname} on port #{uri.port} is not responding.  Try again later. (HTTPServiceUnavailable - 503)"
+          else
+            raise Qa::ServiceError, "Unknown error for #{uri.hostname} on port #{uri.port}.  Try again later. (Cause - #{e.message})"
+          end
+        end
+
+        def ioerror_code(e)
+          msg = e.message
+          return 'format' if msg.start_with? "Unknown RDF format"
+          a = msg.size - 4
+          z = msg.size - 2
+          msg[a..z]
+        end
+
+        # Normalize language
+        # @param [String | Symbol | Array] language for filtering graph (e.g. "en" OR :en OR ["en", "fr"] OR [:en, :fr])
+        # @returns [Array<Symbol>] an array of languages encoded as symbols (e.g. [:en] OR [:en, :fr])
+        def normalize_language(language)
+          return language if language.blank?
+          language = [language] unless language.is_a? Array
+          language.map(&:to_sym)
+        end
+    end
+  end
+end

--- a/lib/qa/authorities/linked_data/search_query.rb
+++ b/lib/qa/authorities/linked_data/search_query.rb
@@ -29,15 +29,19 @@ module Qa::Authorities
         language ||= search_config.language
         url = search_config.url_with_replacements(query, subauth, replacements)
         Rails.logger.info "QA Linked Data search url: #{url}"
-        graph = get_linked_data(url)
-        parse_search_authority_response(graph, language)
+        graph = load_graph(url: url, language: language)
+        parse_search_authority_response(graph)
       end
 
       private
 
-        def parse_search_authority_response(graph, language)
-          graph = filter_language(graph, language) unless language.nil?
-          graph = filter_out_blanknodes(graph)
+        def load_graph(url:, language:)
+          graph_service = Qa::LinkedData::GraphService.new(url: url)
+          graph_service.filter(language: language, remove_blanknode_subjects: true)
+          graph_service.graph
+        end
+
+        def parse_search_authority_response(graph)
           results = extract_preds(graph, preds_for_search)
           consolidated_results = consolidate_search_results(results)
           json_results = convert_search_to_json(consolidated_results)

--- a/spec/controllers/linked_data_terms_controller_spec.rb
+++ b/spec/controllers/linked_data_terms_controller_spec.rb
@@ -437,6 +437,17 @@ describe Qa::LinkedDataTermsController, type: :controller do
             expect(JSON.parse(response.body).keys).to match_array ["@context", "@graph"]
           end
         end
+
+        context 'blank nodes not included in predicates list' do
+          before do
+            stub_request(:get, 'http://localhost/test_default/term?uri=http://test.org/530369wbn')
+              .to_return(status: 200, body: webmock_fixture('lod_term_with_blanknode_objects.nt'), headers: { 'Content-Type' => 'application/n-triples' })
+          end
+          it 'succeeds' do
+            get :fetch, params: { uri: 'http://test.org/530369wbn', vocab: 'LOD_TERM_URI_PARAM_CONFIG' }
+            expect(response).to be_successful
+          end
+        end
       end
 
       context 'when cors headers are enabled' do

--- a/spec/fixtures/lod_search_with_blanknode_subjects.nt
+++ b/spec/fixtures/lod_search_with_blanknode_subjects.nt
@@ -1,0 +1,12 @@
+<http://id.worldcat.org/fast/530369> <http://purl.org/dc/terms/identifier> "530369" .
+<http://id.worldcat.org/fast/530369> <http://schema.org/name> "Cornell University" .
+<http://id.worldcat.org/fast/530369> <http://schema.org/sameAs> _:b0 .
+_:b0 <http://www.w3.org/2000/01/rdf-schema#label> "Cornell University" .
+<http://id.worldcat.org/fast/5140> <http://purl.org/dc/terms/identifier> "5140" .
+<http://id.worldcat.org/fast/5140> <http://schema.org/name> "Cornell, Joseph" .
+<http://id.worldcat.org/fast/5140> <http://schema.org/sameAs> _:b1 .
+_:b1 <http://www.w3.org/2000/01/rdf-schema#label> "Cornell, Joseph" .
+<http://id.worldcat.org/fast/557490> <http://purl.org/dc/terms/identifier> "557490" .
+<http://id.worldcat.org/fast/557490> <http://schema.org/name> "New York State School of Industrial and Labor Relations" .
+<http://id.worldcat.org/fast/557490> <http://schema.org/sameAs> _:b2 .
+_:b2 <http://www.w3.org/2000/01/rdf-schema#label> "New York State School of Industrial and Labor Relations" .

--- a/spec/fixtures/lod_term_with_blanknode_objects.nt
+++ b/spec/fixtures/lod_term_with_blanknode_objects.nt
@@ -1,0 +1,8 @@
+<http://test.org/530369wbn> <http://purl.org/dc/terms/identifier> "530369" .
+<http://test.org/530369wbn> <http://www.w3.org/2004/02/skos/core#inScheme> <http://id.worldcat.org/fast/ontology/1.0/#fast> .
+<http://test.org/530369wbn> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://schema.org/Organization> .
+<http://test.org/530369wbn> <http://www.w3.org/2004/02/skos/core#prefLabel> "Cornell University" .
+<http://test.org/530369wbn> <http://schema.org/name> "Cornell University" .
+<http://test.org/530369wbn> <http://www.w3.org/2004/02/skos/core#altLabel> "Ithaca (N.Y.). Cornell University" .
+<http://test.org/530369wbn> <http://schema.org/sameAs> _:b0 .
+_:b0 <http://www.w3.org/2000/01/rdf-schema#label> "Cornell University" .

--- a/spec/services/linked_data/graph_service_spec.rb
+++ b/spec/services/linked_data/graph_service_spec.rb
@@ -1,0 +1,196 @@
+require 'spec_helper'
+
+RSpec.describe Qa::LinkedData::GraphService do
+  describe '#initialize' do
+    subject { described_class.new(url: url).graph }
+    let(:url) { 'http://experimental.worldcat.org/fast/search?maximumRecords=3&query=cql.any%20all%20%22cornell%22&sortKeys=usage' }
+
+    context 'when graph can be loaded' do
+      before do
+        stub_request(:get, 'http://experimental.worldcat.org/fast/search?maximumRecords=3&query=cql.any%20all%20%22cornell%22&sortKeys=usage')
+          .to_return(status: 200, body: webmock_fixture('lod_oclc_all_query_3_results.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
+      end
+
+      it 'builds a graph with many statements' do
+        expect(subject).to be_kind_of RDF::Graph
+        expect(subject.statements.size).to be > 10
+      end
+    end
+
+    context 'when term is not found' do
+      let(:url) { 'http://experimental.worldcat.org/fast/search?maximumRecords=3&query=cql.any%20all%20%22cornell%22&sortKeys=usage' }
+
+      before do
+        stub_request(:get, 'http://experimental.worldcat.org/fast/search?maximumRecords=3&query=cql.any%20all%20%22cornell%22&sortKeys=usage')
+          .to_return(status: 404)
+      end
+
+      it 'raises error' do
+        expect { described_class.new(url: url) }.to raise_error(Qa::TermNotFound, "#{url} Not Found - Term may not exist at LOD Authority. (HTTPNotFound - 404)")
+      end
+    end
+
+    context 'when service error' do
+      subject { described_class.new(url: url) }
+
+      let(:url) { 'http://experimental.worldcat.org/fast/search?maximumRecords=3&query=cql.any%20all%20%22cornell%22&sortKeys=usage' }
+      let(:uri) { URI(url) }
+
+      before do
+        stub_request(:get, 'http://experimental.worldcat.org/fast/search?maximumRecords=3&query=cql.any%20all%20%22cornell%22&sortKeys=usage')
+          .to_return(status: 500)
+      end
+
+      it 'raises error' do
+        expect { subject }.to raise_error(Qa::ServiceError, "#{uri.hostname} on port #{uri.port} is not responding.  Try again later. (HTTPServerError - 500)")
+      end
+    end
+
+    context 'when service unavailable' do
+      subject { described_class.new(url: url) }
+
+      let(:url) { 'http://experimental.worldcat.org/fast/search?maximumRecords=3&query=cql.any%20all%20%22cornell%22&sortKeys=usage' }
+      let(:uri) { URI(url) }
+
+      before do
+        stub_request(:get, 'http://experimental.worldcat.org/fast/search?maximumRecords=3&query=cql.any%20all%20%22cornell%22&sortKeys=usage')
+          .to_return(status: 503)
+      end
+
+      it 'raises error' do
+        expect { subject }.to raise_error(Qa::ServiceUnavailable, "#{uri.hostname} on port #{uri.port} is not responding.  Try again later. (HTTPServiceUnavailable - 503)")
+      end
+    end
+
+    context "when error isn't specifically handled" do
+      subject { described_class.new(url: url) }
+
+      let(:url) { 'http://experimental.worldcat.org/fast/search?maximumRecords=3&query=cql.any%20all%20%22cornell%22&sortKeys=usage' }
+      let(:uri) { URI(url) }
+
+      before do
+        stub_request(:get, 'http://experimental.worldcat.org/fast/search?maximumRecords=3&query=cql.any%20all%20%22cornell%22&sortKeys=usage')
+          .to_return(status: 504)
+      end
+
+      it 'raises error' do
+        expect { subject }.to raise_error(Qa::ServiceError, "Unknown error for #{uri.hostname} on port #{uri.port}.  Try again later. (Cause - <#{url}>: (504))")
+      end
+    end
+  end
+
+  describe '#filter' do
+    context 'with language filter' do
+      subject { service.graph }
+
+      let(:url) { 'http://authority.with.language/search?query=foo' }
+      let(:service) { described_class.new(url: url) }
+
+      let(:en_dried_milk) { RDF::Literal.new("dried milk", language: :en) }
+      let(:fr_dried_milk) { RDF::Literal.new("lait en poudre", language: :fr) }
+      let(:de_dried_milk) { RDF::Literal.new("getrocknete Milch", language: :de) }
+
+      let(:en_buttermilk) { RDF::Literal.new("buttermilk", language: :en) }
+      let(:fr_buttermilk) { RDF::Literal.new("Babeurre", language: :fr) }
+      let(:de_buttermilk) { RDF::Literal.new("Buttermilch", language: :de) }
+
+      let(:en_condensed_milk) { RDF::Literal.new("condensed milk", language: :en) }
+      let(:fr_condensed_milk) { RDF::Literal.new("lait condensé", language: :fr) }
+      let(:de_condensed_milk) { RDF::Literal.new("Kondensmilch", language: :de) }
+
+      before do
+        stub_request(:get, 'http://authority.with.language/search?query=foo')
+          .to_return(status: 200, body: webmock_fixture('lod_lang_search_enfrde.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
+        service.filter(language: language)
+      end
+
+      context 'and one language passed in as string' do
+        let(:language) { "en" }
+
+        it 'returns the graph with only the English subset of triples' do
+          expect(subject.has_object?(en_dried_milk)).to be true
+          expect(subject.has_object?(en_buttermilk)).to be true
+          expect(subject.has_object?(en_condensed_milk)).to be true
+
+          expect(subject.has_object?(fr_dried_milk)).to be false
+          expect(subject.has_object?(fr_buttermilk)).to be false
+          expect(subject.has_object?(fr_condensed_milk)).to be false
+
+          expect(subject.has_object?(de_dried_milk)).to be false
+          expect(subject.has_object?(de_buttermilk)).to be false
+          expect(subject.has_object?(de_condensed_milk)).to be false
+        end
+      end
+
+      context 'when one language passed in as symbol' do
+        let(:language) { :fr }
+
+        it 'returns the graph with only the French subset of triples' do
+          expect(subject.has_object?(en_dried_milk)).to be false
+          expect(subject.has_object?(en_buttermilk)).to be false
+          expect(subject.has_object?(en_condensed_milk)).to be false
+
+          expect(subject.has_object?(fr_dried_milk)).to be true
+          expect(subject.has_object?(fr_buttermilk)).to be true
+          expect(subject.has_object?(fr_condensed_milk)).to be true
+
+          expect(subject.has_object?(de_dried_milk)).to be false
+          expect(subject.has_object?(de_buttermilk)).to be false
+          expect(subject.has_object?(de_condensed_milk)).to be false
+        end
+      end
+
+      context 'when multiple languages passed in as strings in an array' do
+        let(:language) { ["en", "fr"] }
+
+        it 'returns the graph with English and French subset of triples' do
+          expect(subject.has_object?(en_dried_milk)).to be true
+          expect(subject.has_object?(en_buttermilk)).to be true
+          expect(subject.has_object?(en_condensed_milk)).to be true
+
+          expect(subject.has_object?(fr_dried_milk)).to be true
+          expect(subject.has_object?(fr_buttermilk)).to be true
+          expect(subject.has_object?(fr_condensed_milk)).to be true
+
+          expect(subject.has_object?(de_dried_milk)).to be false
+          expect(subject.has_object?(de_buttermilk)).to be false
+          expect(subject.has_object?(de_condensed_milk)).to be false
+        end
+      end
+
+      context 'when multiple languages passed in as symbols in an array' do
+        let(:language) { [:en, :de] }
+
+        it 'returns the graph with English and German subset of triples' do
+          expect(subject.has_object?(en_dried_milk)).to be true
+          expect(subject.has_object?(en_buttermilk)).to be true
+          expect(subject.has_object?(en_condensed_milk)).to be true
+
+          expect(subject.has_object?(fr_dried_milk)).to be false
+          expect(subject.has_object?(fr_buttermilk)).to be false
+          expect(subject.has_object?(fr_condensed_milk)).to be false
+
+          expect(subject.has_object?(de_dried_milk)).to be true
+          expect(subject.has_object?(de_buttermilk)).to be true
+          expect(subject.has_object?(de_condensed_milk)).to be true
+        end
+      end
+    end
+  end
+
+  # describe '.filter_out_subject_blanknodes' do
+  #   let(:url) { 'http://experimental.worldcat.org/fast/search?maximumRecords=3&query=cql.any%20all%20%22cornell%22&sortKeys=usage' }
+  #   let(:graph) { described_class.graph(url) }
+  #
+  #   before do
+  #     stub_request(:get, 'http://experimental.worldcat.org/fast/search?maximumRecords=3&query=cql.any%20all%20%22cornell%22&sortKeys=usage')
+  #       .to_return(status: 200, body: webmock_fixture('lod_search_with_blanknode_subjects.nt'), headers: { 'Content-Type' => 'application/n-triples' })
+  #   end
+  #
+  #   it 'removes statements where the subject is a blanknode' do
+  #     expect(graph.size).to be 12
+  #     filtered_graph = described_class.filter_out_subject_blanknodes(graph)
+  #     expect(filtered_graph.size).to be 9
+  #   end
+  # end
+end


### PR DESCRIPTION
If acceptable, this replaces PR #184.  It is taking a slightly different approach on the replacement service based on feedback.

-----------------

A major refactoring of the linked data processing code is underway. The first step in the process is to extract out include code from find_term and search_query processing into separate isolated services. Work will be committed in multiple PRs to facilitate the review process and avoiding a single massive commit.

This is PR creates the first extracted service. It collects together only methods that process rdf in the new rdf_service. These were originally included through the rdf_helper module.

There are a few methods remaining in rdf_helper that will be resolved in a later refactor PR. The remaining ones will either go away or belong in another place.