### PR TITLE
Move AuthorityService to app/services

### DIFF
--- a/app/controllers/qa/linked_data_terms_controller.rb
+++ b/app/controllers/qa/linked_data_terms_controller.rb
@@ -18,16 +18,16 @@ class Qa::LinkedDataTermsController < ::ApplicationController
 
   # Return a list of supported authority names
   # get "/list/linked_data/authorities"
-  # @see Qa::Authorities::LinkedData::AuthorityService#authority_names
+  # @see Qa::LinkedData::AuthorityService#authority_names
   def list
-    render json: Qa::Authorities::LinkedData::AuthorityService.authority_names.to_json
+    render json: Qa::LinkedData::AuthorityService.authority_names.to_json
   end
 
   # Reload authority configurations
   # get "/reload/linked_data/authorities?auth_token=YOUR_AUTH_TOKEN_DEFINED_HERE"
-  # @see Qa::Authorities::LinkedData::AuthorityService#load_authorities
+  # @see Qa::LinkedData::AuthorityService#load_authorities
   def reload
-    Qa::Authorities::LinkedData::AuthorityService.load_authorities
+    Qa::LinkedData::AuthorityService.load_authorities
     list
   end
 

--- a/app/services/qa/linked_data/authority_service.rb
+++ b/app/services/qa/linked_data/authority_service.rb
@@ -1,6 +1,5 @@
-# This module has the primary QA search method.  It also includes methods to process the linked data results and convert
-# them into the expected QA json results format.
-module Qa::Authorities
+# This module loads linked data authorities and provides access to their configurations.
+module Qa
   module LinkedData
     class AuthorityService
       # Load or reload the linked data configuration files
@@ -32,7 +31,7 @@ module Qa::Authorities
 
       # Get the configuration for an authority
       # @param [String] name of the authority
-      # @return [Array<String>] configuration for the specified authority
+      # @return [Hash] configuration for the specified authority
       def self.authority_config(authname)
         authority_configs[authname]
       end

--- a/config/initializers/linked_data_authorities.rb
+++ b/config/initializers/linked_data_authorities.rb
@@ -1,1 +1,1 @@
-Qa::Authorities::LinkedData::AuthorityService.load_authorities
+Qa::LinkedData::AuthorityService.load_authorities

--- a/lib/qa/authorities/linked_data.rb
+++ b/lib/qa/authorities/linked_data.rb
@@ -3,7 +3,6 @@ module Qa::Authorities
     extend ActiveSupport::Autoload
     autoload :GenericAuthority
     autoload :RdfHelper
-    autoload :AuthorityService
     autoload :SearchQuery
     autoload :FindTerm
     autoload :Config

--- a/lib/qa/authorities/linked_data/config.rb
+++ b/lib/qa/authorities/linked_data/config.rb
@@ -44,7 +44,7 @@ module Qa::Authorities
       # Return the full configuration for an authority
       # @return [String] the authority configuration
       def auth_config
-        @authority_config ||= Qa::Authorities::LinkedData::AuthorityService.authority_config(@authority_name)
+        @authority_config ||= Qa::LinkedData::AuthorityService.authority_config(@authority_name)
         raise Qa::InvalidLinkedDataAuthority, "Unable to initialize linked data authority '#{@authority_name}'" if @authority_config.nil?
         @authority_config
       end

--- a/lib/qa/authorities/linked_data/generic_authority.rb
+++ b/lib/qa/authorities/linked_data/generic_authority.rb
@@ -27,7 +27,7 @@ module Qa::Authorities
       end
 
       def authorities_service
-        @authorities_service ||= Qa::Authorities::LinkedData::AuthorityService
+        @authorities_service ||= Qa::LinkedData::AuthorityService
       end
 
       def search_service

--- a/spec/controllers/linked_data_terms_controller_spec.rb
+++ b/spec/controllers/linked_data_terms_controller_spec.rb
@@ -82,7 +82,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
   describe '#list' do
     let(:expected_results) { ['Auth1', 'Auth2', 'Auth3'] }
     before do
-      allow(Qa::Authorities::LinkedData::AuthorityService).to receive(:authority_names).and_return(expected_results)
+      allow(Qa::LinkedData::AuthorityService).to receive(:authority_names).and_return(expected_results)
     end
     it 'returns list of authorities' do
       get :list

--- a/spec/lib/authorities/linked_data/authority_service_spec.rb
+++ b/spec/lib/authorities/linked_data/authority_service_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Qa::Authorities::LinkedData::AuthorityService do
+describe Qa::LinkedData::AuthorityService do
   let(:auth_names) do
     [:LOC,
      :LOD_ENCODING_CONFIG,


### PR DESCRIPTION
There are no code changes.  The class name of the service did change...

**FROM:**  Qa::Authorities::LinkedData::AuthorityService
**TO:**  Qa::LinkedData::AuthorityService