### PR TITLE
Create models for IRI templates and use IRI template service to build URLs

### DIFF
--- a/app/models/qa/iri_template/url_config.rb
+++ b/app/models/qa/iri_template/url_config.rb
@@ -1,0 +1,56 @@
+# Provide access to iri template configuration.
+module Qa
+  module IriTemplate
+    class UrlConfig
+      TYPE = "IriTemplate".freeze
+      CONTEXT = "http://www.w3.org/ns/hydra/context.jsonld".freeze
+      attr_reader :template # [String] the URL template with variables for substitution (required)
+      attr_reader :variable_representation # [String] always "BasicRepresentation" # TODO what other values are supported and what do they mean
+      attr_reader :mapping # [Array<Qa::IriTempalte::VariableMap>] array of maps for use with a template (required)
+
+      # @param [Hash] url_template configuration hash for the iri template
+      # @option url_template [String] :template the URL template with variables for substitution (required)
+      # @option url_template [String] :variable_representation always "BasicRepresentation" # TODO what other values are supported and what do they mean
+      # @option url_template [Array<Hash>] :mapping array of maps for use with a template (required)
+      def initialize(url_config)
+        @template = extract_template(config: url_config)
+        @mapping = extract_mapping(config: url_config)
+        @variable_representation = url_config.fetch(:variable_representation, 'BasicRepresentation')
+      end
+
+      # Selective extract substitution variable-value pairs from the provided substitutions.
+      # @param [Hash, ActionController::Parameters] full set of passed in substitution values
+      # @returns [HashWithIndifferentAccess] Only variable-value pairs for variables defined in the variable mapping.
+      def extract_substitutions(substitutions)
+        selected_substitutions = HashWithIndifferentAccess.new
+        mapping.each do |m|
+          selected_substitutions[m.variable] = substitutions[m.variable] if substitutions.key? m.variable
+        end
+        selected_substitutions
+      end
+
+      private
+
+        # Extract the url template from the config
+        # @param config [Hash] configuration (json) holding the template to be extracted
+        # @param var [Symbol] key identifying the template in the configuration
+        # @return [String] url template for accessing the authority
+        def extract_template(config:, var: :template)
+          template = config.fetch(var, nil)
+          raise Qa::InvalidConfiguration, "template is required" unless template
+          template
+        end
+
+        # Initialize the variable maps
+        # @param config [Hash] configuration (json) holding the variable maps to be extracted
+        # @param var [Symbol] key identifying the variable mapping array in the configuration
+        # @return [Array<IriTemplate::Map>] array of the variable maps
+        def extract_mapping(config:, var: :mapping)
+          mapping = config.fetch(var, nil)
+          raise Qa::InvalidConfiguration, "mapping is required" unless mapping
+          raise Qa::InvalidConfiguration, "mapping must include at least one map" if mapping.empty?
+          mapping.collect { |m| Qa::IriTemplate::VariableMap.new(m) }
+        end
+    end
+  end
+end

--- a/app/models/qa/iri_template/url_config.rb
+++ b/app/models/qa/iri_template/url_config.rb
@@ -1,4 +1,6 @@
 # Provide access to iri template configuration.
+# See https://www.hydra-cg.com/spec/latest/core/#templated-links for information on IRI Templated Links.
+# TODO: It would be good to find a more complete resource describing templated links.
 module Qa
   module IriTemplate
     class UrlConfig
@@ -8,10 +10,10 @@ module Qa
       attr_reader :variable_representation # [String] always "BasicRepresentation" # TODO what other values are supported and what do they mean
       attr_reader :mapping # [Array<Qa::IriTempalte::VariableMap>] array of maps for use with a template (required)
 
-      # @param [Hash] url_template configuration hash for the iri template
-      # @option url_template [String] :template the URL template with variables for substitution (required)
-      # @option url_template [String] :variable_representation always "BasicRepresentation" # TODO what other values are supported and what do they mean
-      # @option url_template [Array<Hash>] :mapping array of maps for use with a template (required)
+      # @param [Hash] url_config configuration hash for the iri template
+      # @option url_config [String] :template the URL template with variables for substitution (required)
+      # @option url_config [String] :variable_representation always "BasicRepresentation" # TODO what other values are supported and what do they mean
+      # @option url_config [Array<Hash>] :mapping array of maps for use with a template (required)
       def initialize(url_config)
         @template = extract_template(config: url_config)
         @mapping = extract_mapping(config: url_config)
@@ -32,21 +34,19 @@ module Qa
       private
 
         # Extract the url template from the config
-        # @param config [Hash] configuration (json) holding the template to be extracted
-        # @param var [Symbol] key identifying the template in the configuration
+        # @param config [Hash] configuration holding the template to be extracted
         # @return [String] url template for accessing the authority
-        def extract_template(config:, var: :template)
-          template = config.fetch(var, nil)
+        def extract_template(config:)
+          template = config.fetch(:template, nil)
           raise Qa::InvalidConfiguration, "template is required" unless template
           template
         end
 
         # Initialize the variable maps
-        # @param config [Hash] configuration (json) holding the variable maps to be extracted
-        # @param var [Symbol] key identifying the variable mapping array in the configuration
+        # @param config [Hash] configuration holding the variable maps to be extracted
         # @return [Array<IriTemplate::Map>] array of the variable maps
-        def extract_mapping(config:, var: :mapping)
-          mapping = config.fetch(var, nil)
+        def extract_mapping(config:)
+          mapping = config.fetch(:mapping, nil)
           raise Qa::InvalidConfiguration, "mapping is required" unless mapping
           raise Qa::InvalidConfiguration, "mapping must include at least one map" if mapping.empty?
           mapping.collect { |m| Qa::IriTemplate::VariableMap.new(m) }

--- a/app/models/qa/iri_template/variable_map.rb
+++ b/app/models/qa/iri_template/variable_map.rb
@@ -1,0 +1,79 @@
+# Provide access to iri template variable map configuration.
+module Qa
+  module IriTemplate
+    class VariableMap
+      TYPE = "IriTemplateMapping".freeze
+      attr_reader :variable
+      attr_reader :default
+
+      # @param [Hash] map configuration hash for the variable map
+      # @option map [String] :variable name of the variable in the template (e.g. {?query} has the name 'query')
+      # @option map [String] :property always "hydra:freetextQuery" # TODO what other values are supported and what do they mean
+      # @option map [True | False] :required is this variable required
+      # @option map [String] :default value to use if a value is not provided in the request
+      def initialize(map)
+        @variable = extract_variable(config: map)
+        @required = extract_required(config: map)
+        @default = extract_default(config: map)
+        @property = map.fetch(:property, 'hydra:freetextQuery')
+      end
+
+      # Is this variable required?
+      # @returns true if required; otherwise, false
+      def required?
+        @required
+      end
+
+      # TODO: When implementing more complex query substitution, simple_value is used when template url specifies variable as {var_name}.
+      # Value to use in substitution, using default if one isn't passed in
+      # @param [Object] value to use if it exists
+      # @returns the value to use (e.g. 'fr')
+      def simple_value(sub_value = nil)
+        return sub_value.to_s if sub_value.present?
+        return default if default.present?
+        raise Qa::IriTemplate::MissingParameter, "#{variable} is required, but missing" if required?
+        ''
+      end
+
+      # TODO: When implementing more complex query substitution, parameter_value is used when template url specifies variable as {?var_name}.
+      # # Parameter and value to use in substitution, using default is one isn't passed in
+      # # @param [Object] value to use if it exists
+      # # @returns the parameter and value to use (e.g. 'language=fr')
+      # def parameter_value(sub_value = nil)
+      #   simple_value = simple_value(sub_value)
+      #   return '' if simple_value.blank?
+      #   param_value = "#{variable}=#{simple_value}"
+      # end
+
+      private
+
+        # Extract the variable name from the config
+        # @param config [Hash] configuration (json) holding the variable map
+        # @param var [Symbol] key identifying the variable in the configuration
+        # @return [String] variable for substitution in the url tmeplate
+        def extract_variable(config:, var: :variable)
+          varname = config.fetch(var, nil)
+          raise Qa::InvalidConfiguration, 'variable is required' unless varname
+          varname
+        end
+
+        # Extract the variable name from the config
+        # @param config [Hash] configuration (json) holding the variable map
+        # @param var [Symbol] key in the configuration identifying whether the variable is required
+        # @return [True | False] required as true or false
+        def extract_required(config:, var: :required)
+          required = config.fetch(var, nil)
+          raise Qa::InvalidConfiguration, 'required must be true or false' unless required == true || required == false
+          required
+        end
+
+        # Extract the default value from the config ignoring defaults for required variables
+        # @param config [Hash] configuration (json) holding the variable map
+        # @param var [Symbol] key identifying the default value in the configuration
+        # @return [String] default value to use for the variable; nil if variable is required
+        def extract_default(config:, var: :default)
+          config.fetch(var, '').to_s
+        end
+    end
+  end
+end

--- a/app/models/qa/iri_template/variable_map.rb
+++ b/app/models/qa/iri_template/variable_map.rb
@@ -1,4 +1,6 @@
 # Provide access to iri template variable map configuration.
+# See https://www.hydra-cg.com/spec/latest/core/#templated-links for information on IRI Templated Links - Variable Mapping.
+# TODO: It would be good to find a more complete resource describing templated links.
 module Qa
   module IriTemplate
     class VariableMap
@@ -30,9 +32,8 @@ module Qa
       # @returns the value to use (e.g. 'fr')
       def simple_value(sub_value = nil)
         return sub_value.to_s if sub_value.present?
-        return default if default.present?
         raise Qa::IriTemplate::MissingParameter, "#{variable} is required, but missing" if required?
-        ''
+        default
       end
 
       # TODO: When implementing more complex query substitution, parameter_value is used when template url specifies variable as {?var_name}.
@@ -49,30 +50,27 @@ module Qa
 
         # Extract the variable name from the config
         # @param config [Hash] configuration (json) holding the variable map
-        # @param var [Symbol] key identifying the variable in the configuration
         # @return [String] variable for substitution in the url tmeplate
-        def extract_variable(config:, var: :variable)
-          varname = config.fetch(var, nil)
+        def extract_variable(config:)
+          varname = config.fetch(:variable, nil)
           raise Qa::InvalidConfiguration, 'variable is required' unless varname
           varname
         end
 
         # Extract the variable name from the config
         # @param config [Hash] configuration (json) holding the variable map
-        # @param var [Symbol] key in the configuration identifying whether the variable is required
         # @return [True | False] required as true or false
-        def extract_required(config:, var: :required)
-          required = config.fetch(var, nil)
+        def extract_required(config:)
+          required = config.fetch(:required, nil)
           raise Qa::InvalidConfiguration, 'required must be true or false' unless required == true || required == false
           required
         end
 
-        # Extract the default value from the config ignoring defaults for required variables
+        # Extract the default value from the config
         # @param config [Hash] configuration (json) holding the variable map
-        # @param var [Symbol] key identifying the default value in the configuration
-        # @return [String] default value to use for the variable; nil if variable is required
-        def extract_default(config:, var: :default)
-          config.fetch(var, '').to_s
+        # @return [String] default value to use for the variable; defaults to empty string
+        def extract_default(config:)
+          config.fetch(:default, '').to_s
         end
     end
   end

--- a/app/services/qa/iri_template_service.rb
+++ b/app/services/qa/iri_template_service.rb
@@ -1,0 +1,34 @@
+# Provide service for constructing the external access URL for an authority.
+module Qa
+  class IriTemplateService
+    # Construct an url from an IriTemplate making identified substitutions
+    # @param url_config [Qa::IriTemplate::UrlConfig] configuration (json) holding the template and variable mappings
+    # @param substitutions [HashWithIndifferentAccess] name-value pairs to substitute into the url template
+    # @return [String] url with substitutions
+    def self.build_url(url_config:, substitutions:)
+      # TODO: This is a very simple approach using direct substitution into the template string.
+      #   Better would be to...
+      #     * pattern {var_name} = simple value substitution in place of pattern produces 'value'
+      #     * pattern {?var_name} = parameter substitution in place of pattern produces 'var_name=value'
+      #     * patterns without a substitution are not included in the resulting URL
+      #     * appropriately adds '?' or '&'
+      #     * ensure proper escaping of values (e.g. value="A simple string" which is encoded as A%20simple%20string)
+      #   Even more advanced would be to...
+      #     * support BasicRepresentation (which is what it does now)
+      #     * support ExplicitRepresentation
+      #        * literal encoding for values (e.g. value="A simple string" becomes %22A%20simple%20string%22)
+      #        * language encoding for values (e.g. value="A simple string" becomes value="A simple string"@en which is encoded as %22A%20simple%20string%22%40en)
+      #        * type encoding for values (e.g. value=5.5 becomes value="5.5"^^http://www.w3.org/2001/XMLSchema#decimal which is encoded
+      #                                         as %225.5%22%5E%5Ehttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23decimal)
+      # Fuller implementations parse the template into component parts and then build the URL by adding parts in as applicable.
+      url = url_config.template
+      url_config.mapping.each do |m|
+        key = m.variable
+        url = url.gsub("{?#{key}}", m.simple_value(substitutions[key])) # Incorrectly applies pattern {?var_name} to produce substitution 'value'
+        # url.gsub("{#{key}}", m.simple_value(substitutions[key]))  # TODO: pattern {var_name} should produce substitution 'value'
+        # url.gsub("{?#{key}}", m.parameter_value(substitutions[key])) # TODO: pattern {?var_name} should produce substitution 'var_name=value'
+      end
+      url
+    end
+  end
+end

--- a/app/services/qa/iri_template_service.rb
+++ b/app/services/qa/iri_template_service.rb
@@ -1,4 +1,4 @@
-# Provide service for constructing the external access URL for an authority.
+# Provide service for building a URL based on an IRI Templated Link and its variable mappings based on provided substitutions.
 module Qa
   class IriTemplateService
     # Construct an url from an IriTemplate making identified substitutions

--- a/app/services/qa/linked_data/authority_url_service.rb
+++ b/app/services/qa/linked_data/authority_url_service.rb
@@ -10,9 +10,7 @@ module Qa
       # @param substitutions [Hash] variable-value pairs to substitute into the URL template
       # @returns a valid URL the submits the action request to the external authority
       def self.build_url(action_config:, action:, action_request:, substitutions: {}, subauthority: nil)
-        # auth_config = Qa::Authorities::LinkedData::Config.new(authority)
         action_validation(action)
-        # action_config = action_config(auth_config, action)
         url_config = Qa::IriTemplate::UrlConfig.new(action_url(action_config, action))
         selected_substitutions = url_config.extract_substitutions(substitutions)
         selected_substitutions[action_request_variable(action_config, action)] = action_request

--- a/app/services/qa/linked_data/authority_url_service.rb
+++ b/app/services/qa/linked_data/authority_url_service.rb
@@ -1,0 +1,62 @@
+# Provide service for constructing the external access URL for an authority.
+module Qa
+  module LinkedData
+    class AuthorityUrlService
+      # Build a url for an authority/subauthority for the specified action.
+      # @param authority [Symbol] name of a registered authority
+      # @param subauthority [String] name of a subauthority
+      # @param action [Symbol] action with valid values :search or :term
+      # @param action_request [String] the request the user is making of the authority (e.g. query text or term id/uri)
+      # @param substitutions [Hash] variable-value pairs to substitute into the URL template
+      # @returns a valid URL the submits the action request to the external authority
+      def self.build_url(action_config:, action:, action_request:, substitutions: {}, subauthority: nil)
+        # auth_config = Qa::Authorities::LinkedData::Config.new(authority)
+        action_validation(action)
+        # action_config = action_config(auth_config, action)
+        url_config = Qa::IriTemplate::UrlConfig.new(action_url(action_config, action))
+        selected_substitutions = url_config.extract_substitutions(substitutions)
+        selected_substitutions[action_request_variable(action_config, action)] = action_request
+        selected_substitutions[action_subauth_variable(action_config, action)] = action_subauth_variable_value(action_config, subauthority, action) if subauthority.present?
+
+        Qa::IriTemplateService.build_url(url_config: url_config, substitutions: selected_substitutions)
+      end
+
+      def self.action_validation(action)
+        return if [:search, :term].include? action
+        raise Qa::UnsupportedAction, "#{action} Not Supported - Action must be one of the supported actions (e.g. :term, :search)"
+      end
+      private_class_method :action_validation
+
+      # TODO: elr - rename search and term config methods to be the same to avoid all the ternary checks
+      def self.action_url(auth_config, action)
+        action == :search ? auth_config.url : auth_config.term_url
+      end
+      private_class_method :action_url
+
+      def self.action_request_variable(action_config, action)
+        key = action == :search ? :query : :term_id
+        action == :search ? action_config.qa_replacement_patterns[key] : action_config.term_qa_replacement_patterns[key]
+      end
+      private_class_method :action_request_variable
+
+      def self.action_subauth_variable(action_config, action)
+        action == :search ? action_config.qa_replacement_patterns[:subauth] : action_config.term_qa_replacement_patterns[:subauth]
+      end
+      private_class_method :action_subauth_variable
+
+      def self.action_subauth_variable_value(action_config, subauthority, action)
+        case action
+        when :search
+          pattern = action_subauth_variable(action_config, action)
+          default = action_config.url_mappings[pattern.to_sym][:default]
+          action_config.subauthorities[subauthority.to_sym] || default
+        when :term
+          pattern = action_subauth_variable(action_config, action)
+          default = action_config.term_url_mappings[pattern.to_sym][:default]
+          action_config.term_subauthorities[subauthority.to_sym] || default
+        end
+      end
+      private_class_method :action_subauth_variable_value
+    end
+  end
+end

--- a/lib/qa.rb
+++ b/lib/qa.rb
@@ -42,6 +42,9 @@ module Qa
   # Raised when a configuration parameter is incorrect or is required and missing
   class InvalidConfiguration < ArgumentError; end
 
+  # Raised when a request is made for an unsupported action (e.g. :search, :term are supported)
+  class UnsupportedAction < ArgumentError; end
+
   # Raised when a linked data request to a server returns a 503 error
   class ServiceUnavailable < ArgumentError; end
 
@@ -50,4 +53,9 @@ module Qa
 
   # Raised when the server returns 404 for a find term request
   class TermNotFound < ArgumentError; end
+
+  # Raised when a required mapping parameter is missing while building an IRI Template
+  module IriTemplate
+    class MissingParameter < StandardError; end
+  end
 end

--- a/lib/qa/authorities/linked_data/find_term.rb
+++ b/lib/qa/authorities/linked_data/find_term.rb
@@ -36,7 +36,7 @@ module Qa::Authorities
       def find(id, language: nil, replacements: {}, subauth: nil, jsonld: false)
         raise Qa::InvalidLinkedDataAuthority, "Unable to initialize linked data term sub-authority #{subauth}" unless subauth.nil? || term_subauthority?(subauth)
         language ||= term_config.term_language
-        url = term_config.term_url_with_replacements(id, subauth, replacements)
+        url = Qa::LinkedData::AuthorityUrlService.build_url(action_config: term_config, action: :term, action_request: id, substitutions: replacements, subauthority: subauth)
         Rails.logger.info "QA Linked Data term url: #{url}"
         graph = load_graph(url: url, language: language)
         return "{}" unless graph.size.positive?

--- a/lib/qa/authorities/linked_data/search_query.rb
+++ b/lib/qa/authorities/linked_data/search_query.rb
@@ -27,7 +27,7 @@ module Qa::Authorities
       def search(query, language: nil, replacements: {}, subauth: nil)
         raise Qa::InvalidLinkedDataAuthority, "Unable to initialize linked data search sub-authority #{subauth}" unless subauth.nil? || subauthority?(subauth)
         language ||= search_config.language
-        url = search_config.url_with_replacements(query, subauth, replacements)
+        url = Qa::LinkedData::AuthorityUrlService.build_url(action_config: search_config, action: :search, action_request: query, substitutions: replacements, subauthority: subauth)
         Rails.logger.info "QA Linked Data search url: #{url}"
         graph = load_graph(url: url, language: language)
         parse_search_authority_response(graph)

--- a/spec/models/iri_template/url_config_spec.rb
+++ b/spec/models/iri_template/url_config_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+
+RSpec.describe Qa::IriTemplate::UrlConfig do
+  let(:url_template) do
+    {
+      "@context" => "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type" => "IriTemplate",
+      "template" => "http://localhost/test_default/search?subauth={?subauth}&query={?query}&param1={?param1}&param2={?param2}",
+      "variableRepresentation" => "BasicRepresentation",
+      "mapping" => [
+        {
+          "@type" => "IriTemplateMapping",
+          "variable" => "query",
+          "property" => "hydra:freetextQuery",
+          "required" => true
+        },
+        {
+          "@type" => "IriTemplateMapping",
+          "variable" => "subauth",
+          "property" => "hydra:freetextQuery",
+          "required" => false,
+          "default" => "search_sub1_name"
+        },
+        {
+          "@type" => "IriTemplateMapping",
+          "variable" => "param1",
+          "property" => "hydra:freetextQuery",
+          "required" => false,
+          "default" => "delta"
+        },
+        {
+          "@type" => "IriTemplateMapping",
+          "variable" => "param2",
+          "property" => "hydra:freetextQuery",
+          "required" => false,
+          "default" => "echo"
+        }
+      ]
+    }.with_indifferent_access
+  end
+
+  describe 'model attributes' do
+    subject { described_class.new(url_template) }
+
+    it { is_expected.to respond_to :template }
+    it { is_expected.to respond_to :variable_representation }
+    it { is_expected.to respond_to :mapping }
+  end
+
+  describe '#initialize' do
+    context 'when missing template' do
+      before do
+        allow(url_template).to receive(:fetch).with(:template, nil).and_return(nil)
+      end
+
+      it 'raises an error' do
+        expect { described_class.new(url_template) }.to raise_error(Qa::InvalidConfiguration, 'template is required')
+      end
+    end
+
+    context 'when missing mapping' do
+      before do
+        allow(url_template).to receive(:fetch).with(:template, nil).and_return("http://localhost/test_default/search?subauth={?subauth}&query={?query}&param1={?param1}&param2={?param2}")
+        allow(url_template).to receive(:fetch).with(:mapping, nil).and_return(nil)
+      end
+
+      it 'raises an error' do
+        expect { described_class.new(url_template) }.to raise_error(Qa::InvalidConfiguration, 'mapping is required')
+      end
+    end
+
+    context 'when no maps defined' do
+      before do
+        allow(url_template).to receive(:fetch).with(:template, nil).and_return("http://localhost/test_default/search?subauth={?subauth}&query={?query}&param1={?param1}&param2={?param2}")
+        allow(url_template).to receive(:fetch).with(:mapping, nil).and_return([])
+      end
+
+      it 'raises an error' do
+        expect { described_class.new(url_template) }.to raise_error(Qa::InvalidConfiguration, 'mapping must include at least one map')
+      end
+    end
+  end
+
+  describe '#template' do
+    subject { described_class.new(url_template) }
+
+    it 'returns the configured url template' do
+      expect(subject.template).to eq 'http://localhost/test_default/search?subauth={?subauth}&query={?query}&param1={?param1}&param2={?param2}'
+    end
+  end
+
+  describe '#mapping' do
+    subject { described_class.new(url_template) }
+
+    it 'returns an array of variable maps' do
+      mapping = subject.mapping
+      expect(mapping).to be_kind_of Array
+      expect(mapping.size).to eq 4
+      expect(mapping.first).to be_kind_of Qa::IriTemplate::VariableMap
+    end
+  end
+end

--- a/spec/models/iri_template/url_config_spec.rb
+++ b/spec/models/iri_template/url_config_spec.rb
@@ -3,40 +3,40 @@ require 'spec_helper'
 RSpec.describe Qa::IriTemplate::UrlConfig do
   let(:url_template) do
     {
-      "@context" => "http://www.w3.org/ns/hydra/context.jsonld",
-      "@type" => "IriTemplate",
-      "template" => "http://localhost/test_default/search?subauth={?subauth}&query={?query}&param1={?param1}&param2={?param2}",
-      "variableRepresentation" => "BasicRepresentation",
-      "mapping" => [
+      :"@context" => "http://www.w3.org/ns/hydra/context.jsonld",
+      :"@type" => "IriTemplate",
+      template: "http://localhost/test_default/search?subauth={?subauth}&query={?query}&param1={?param1}&param2={?param2}",
+      variableRepresentation: "BasicRepresentation",
+      mapping: [
         {
-          "@type" => "IriTemplateMapping",
-          "variable" => "query",
-          "property" => "hydra:freetextQuery",
-          "required" => true
+          :"@type" => "IriTemplateMapping",
+          variable: "query",
+          property: "hydra:freetextQuery",
+          required: true
         },
         {
-          "@type" => "IriTemplateMapping",
-          "variable" => "subauth",
-          "property" => "hydra:freetextQuery",
-          "required" => false,
-          "default" => "search_sub1_name"
+          :"@type" => "IriTemplateMapping",
+          variable: "subauth",
+          property: "hydra:freetextQuery",
+          required: false,
+          default: "search_sub1_name"
         },
         {
-          "@type" => "IriTemplateMapping",
-          "variable" => "param1",
-          "property" => "hydra:freetextQuery",
-          "required" => false,
-          "default" => "delta"
+          :"@type" => "IriTemplateMapping",
+          variable: "param1",
+          property: "hydra:freetextQuery",
+          required: false,
+          default: "delta"
         },
         {
-          "@type" => "IriTemplateMapping",
-          "variable" => "param2",
-          "property" => "hydra:freetextQuery",
-          "required" => false,
-          "default" => "echo"
+          :"@type" => "IriTemplateMapping",
+          variable: "param2",
+          property: "hydra:freetextQuery",
+          required: false,
+          default: "echo"
         }
       ]
-    }.with_indifferent_access
+    }
   end
 
   describe 'model attributes' do

--- a/spec/models/iri_template/variable_map_spec.rb
+++ b/spec/models/iri_template/variable_map_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe Qa::IriTemplate::VariableMap do
 
   let(:map) do
     {
-      "@type" => "IriTemplateMapping",
-      "property" => "hydra:freetextQuery",
-      "variable" => "subauth",
-      "required" => true
-    }.with_indifferent_access
+      :"@type" => "IriTemplateMapping",
+      property: "hydra:freetextQuery",
+      variable: "subauth",
+      required: true
+    }
   end
 
   describe 'model attributes' do
@@ -114,6 +114,7 @@ RSpec.describe Qa::IriTemplate::VariableMap do
 
       context 'and default is defined' do
         before do
+          map[:required] = false
           map[:default] = 'personal_name'
         end
 

--- a/spec/models/iri_template/variable_map_spec.rb
+++ b/spec/models/iri_template/variable_map_spec.rb
@@ -1,0 +1,136 @@
+require 'spec_helper'
+
+RSpec.describe Qa::IriTemplate::VariableMap do
+  subject { described_class.new(map) }
+
+  let(:map) do
+    {
+      "@type" => "IriTemplateMapping",
+      "property" => "hydra:freetextQuery",
+      "variable" => "subauth",
+      "required" => true
+    }.with_indifferent_access
+  end
+
+  describe 'model attributes' do
+    it { is_expected.to respond_to :variable }
+    it { is_expected.to respond_to :simple_value }
+    # it { is_expected.to respond_to :parameter_value }
+    it { is_expected.to respond_to :required? }
+    it { is_expected.to respond_to :default }
+  end
+
+  describe '#initialize' do
+    context 'when variable is missing' do
+      before do
+        map.delete(:variable)
+      end
+
+      it 'raises an error' do
+        expect { described_class.new(map) }.to raise_error(Qa::InvalidConfiguration, 'variable is required')
+      end
+    end
+
+    context 'when invalid required value' do
+      before do
+        map[:required] = 'BAD_REQUIRED'
+      end
+
+      it 'raises an error' do
+        expect { described_class.new(map) }.to raise_error(Qa::InvalidConfiguration, 'required must be true or false')
+      end
+    end
+  end
+
+  describe '#variable' do
+    it 'returns the configured variable' do
+      expect(subject.variable).to eq 'subauth'
+    end
+  end
+
+  describe '#required' do
+    context 'when map variable is required' do
+      before do
+        map[:required] = true
+      end
+
+      it 'returns true when map variable is required' do
+        expect(subject.required?).to be true
+      end
+    end
+
+    context 'when map variable is required' do
+      before do
+        map[:required] = false
+      end
+
+      it 'returns false when map variable is not required' do
+        expect(subject.required?).to be false
+      end
+    end
+  end
+
+  describe '#default' do
+    context 'when default is not defined' do
+      it 'returns empty string' do
+        expect(subject.default).to eq ''
+      end
+    end
+
+    context 'when default is defined' do
+      before do
+        map[:default] = 'personal_name'
+      end
+
+      it 'returns configured default value' do
+        expect(subject.default).to eq 'personal_name'
+      end
+    end
+  end
+
+  describe '#simple_value' do
+    context 'when sub_value is not passed in' do
+      context 'and default is not defined' do
+        context 'and variable is required' do
+          before do
+            map[:required] = true
+          end
+
+          it 'raises error' do
+            expect { subject.simple_value }.to raise_error(StandardError, 'subauth is required, but missing')
+          end
+        end
+
+        context 'and variable is not required' do
+          before do
+            map[:required] = false
+          end
+
+          it 'returns empty string' do
+            expect(subject.simple_value).to eq ''
+          end
+        end
+      end
+
+      context 'and default is defined' do
+        before do
+          map[:default] = 'personal_name'
+        end
+
+        it 'returns the default' do
+          expect(subject.simple_value).to eq 'personal_name'
+        end
+      end
+    end
+
+    context 'when sub_value is passed in' do
+      before do
+        map[:required] = true
+      end
+
+      it 'returns passed in sub_value' do
+        expect(subject.simple_value('corporate_name')).to eq 'corporate_name'
+      end
+    end
+  end
+end

--- a/spec/services/iri_template_service_spec.rb
+++ b/spec/services/iri_template_service_spec.rb
@@ -3,40 +3,40 @@ require 'spec_helper'
 RSpec.describe Qa::IriTemplateService do
   let(:url_template) do
     {
-      '@context' => 'http://www.w3.org/ns/hydra/context.jsonld',
-      '@type' => 'IriTemplate',
-      'template' => 'http://localhost/test_default/search?subauth={?subauth}&query={?query}&max_records={?max_records}&language={?language}',
-      'variableRepresentation' => 'BasicRepresentation',
-      'mapping' => [
+      :'@context' => 'http://www.w3.org/ns/hydra/context.jsonld',
+      :'@type' => 'IriTemplate',
+      template: 'http://localhost/test_default/search?subauth={?subauth}&query={?query}&max_records={?max_records}&language={?language}',
+      variableRepresentation: 'BasicRepresentation',
+      mapping: [
         {
-          '@type' => 'IriTemplateMapping',
-          'variable' => 'query',
-          'property' => 'hydra:freetextQuery',
-          'required' => true
+          :'@type' => 'IriTemplateMapping',
+          variable: 'query',
+          property: 'hydra:freetextQuery',
+          required: true
         },
         {
-          '@type' => 'IriTemplateMapping',
-          'variable' => 'subauth',
-          'property' => 'hydra:freetextQuery',
-          'required' => false,
-          'default' => 'personal_names'
+          :'@type' => 'IriTemplateMapping',
+          variable: 'subauth',
+          property: 'hydra:freetextQuery',
+          required: false,
+          default: 'personal_names'
         },
         {
-          '@type' => 'IriTemplateMapping',
-          'variable' => 'max_records',
-          'property' => 'hydra:freetextQuery',
-          'required' => false,
-          'default' => 20
+          :'@type' => 'IriTemplateMapping',
+          variable: 'max_records',
+          property: 'hydra:freetextQuery',
+          required: false,
+          default: 20
         },
         {
-          '@type' => 'IriTemplateMapping',
-          'variable' => 'language',
-          'property' => 'hydra:freetextQuery',
-          'required' => false,
-          'default' => 'en'
+          :'@type' => 'IriTemplateMapping',
+          variable: 'language',
+          property: 'hydra:freetextQuery',
+          required: false,
+          default: 'en'
         }
       ]
-    }.with_indifferent_access
+    }
   end
   let(:url_config) { Qa::IriTemplate::UrlConfig.new(url_template) }
 

--- a/spec/services/iri_template_service_spec.rb
+++ b/spec/services/iri_template_service_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+RSpec.describe Qa::IriTemplateService do
+  let(:url_template) do
+    {
+      '@context' => 'http://www.w3.org/ns/hydra/context.jsonld',
+      '@type' => 'IriTemplate',
+      'template' => 'http://localhost/test_default/search?subauth={?subauth}&query={?query}&max_records={?max_records}&language={?language}',
+      'variableRepresentation' => 'BasicRepresentation',
+      'mapping' => [
+        {
+          '@type' => 'IriTemplateMapping',
+          'variable' => 'query',
+          'property' => 'hydra:freetextQuery',
+          'required' => true
+        },
+        {
+          '@type' => 'IriTemplateMapping',
+          'variable' => 'subauth',
+          'property' => 'hydra:freetextQuery',
+          'required' => false,
+          'default' => 'personal_names'
+        },
+        {
+          '@type' => 'IriTemplateMapping',
+          'variable' => 'max_records',
+          'property' => 'hydra:freetextQuery',
+          'required' => false,
+          'default' => 20
+        },
+        {
+          '@type' => 'IriTemplateMapping',
+          'variable' => 'language',
+          'property' => 'hydra:freetextQuery',
+          'required' => false,
+          'default' => 'en'
+        }
+      ]
+    }.with_indifferent_access
+  end
+  let(:url_config) { Qa::IriTemplate::UrlConfig.new(url_template) }
+
+  describe '.build_url' do
+    context 'when all substitutions specified' do
+      let(:substitutions) do
+        HashWithIndifferentAccess.new(
+          query: 'mark twain',
+          subauth: 'corporate_names',
+          max_records: 10,
+          language: 'fr'
+        )
+      end
+
+      it 'returns template with substitutions' do
+        expected_url = 'http://localhost/test_default/search?subauth=corporate_names&query=mark twain&max_records=10&language=fr'
+        expect(described_class.build_url(url_config: url_config, substitutions: substitutions)).to eq expected_url
+      end
+    end
+
+    context 'when minimal substitutions specified' do
+      let(:substitutions) { HashWithIndifferentAccess.new(query: 'mark twain') }
+
+      it 'returns template with substitutions' do
+        expected_url = 'http://localhost/test_default/search?subauth=personal_names&query=mark twain&max_records=20&language=en'
+        expect(described_class.build_url(url_config: url_config, substitutions: substitutions)).to eq expected_url
+      end
+    end
+  end
+end

--- a/spec/services/linked_data/authority_url_service_spec.rb
+++ b/spec/services/linked_data/authority_url_service_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+
+RSpec.describe Qa::LinkedData::AuthorityUrlService do
+  let(:authority) { :OCLC_FAST }
+  let(:search_config) { Qa::Authorities::LinkedData::Config.new(authority).search }
+  let(:term_config) { Qa::Authorities::LinkedData::Config.new(authority).term }
+  let(:action_config) { search_config }
+
+  let(:subauthority) { nil }
+  let(:action) { :search }
+  let(:action_request) { "mark+twain" }
+  let(:substitutions) do
+    {}
+  end
+
+  describe '.build_url' do
+    context 'when authority is not registered' do
+      let(:authority) { :BAD_AUTHORITY }
+
+      it 'raises error' do
+        expected_error = Qa::InvalidLinkedDataAuthority
+        expected_error_message = "Unable to initialize linked data authority 'BAD_AUTHORITY'"
+        expect { described_class.build_url(action_config: action_config, subauthority: subauthority, action: action, action_request: action_request, substitutions: substitutions) }
+          .to raise_error(expected_error, expected_error_message)
+      end
+    end
+
+    # TODO: elr - currently uses the default subauthority if the one passed in isn't supported
+    context 'when subauthority is not supported' do
+      let(:subauthority) { :BAD_SUBAUTHORITY }
+
+      it 'raises error' do
+        skip "Pending better handling of unsupported subauthorities"
+        expected_error = Qa::InvalidLinkedDataAuthority
+        expected_error_message = "Unable to initialize linked data sub-authority BAD_SUBAUTHORITY"
+        expect { described_class.build_url(action_config: action_config, subauthority: subauthority, action: action, action_request: action_request, substitutions: substitutions) }
+          .to raise_error(expected_error, expected_error_message)
+      end
+    end
+
+    context 'when invalid action is specified' do
+      let(:action) { :BAD_ACTION }
+
+      it 'raises error' do
+        expected_error = Qa::UnsupportedAction
+        expected_error_message = "BAD_ACTION Not Supported - Action must be one of the supported actions (e.g. :term, :search)"
+        expect { described_class.build_url(action_config: action_config, subauthority: subauthority, action: action, action_request: action_request, substitutions: substitutions) }
+          .to raise_error(expected_error, expected_error_message)
+      end
+    end
+
+    context 'when action_request is missing' do
+      let(:action_request) { nil }
+
+      it 'raises error' do
+        expected_error = Qa::IriTemplate::MissingParameter
+        expected_error_message = "query is required, but missing"
+        expect { described_class.build_url(action_config: action_config, subauthority: subauthority, action: action, action_request: action_request, substitutions: substitutions) }
+          .to raise_error(expected_error, expected_error_message)
+      end
+    end
+
+    subject do
+      described_class.build_url(action_config: action_config, subauthority: subauthority, action: action, action_request: action_request, substitutions: substitutions)
+    end
+
+    context 'when no errors' do
+      context 'and performing search action' do
+        context 'and all substitutions specified' do
+          let(:substitutions) do
+            HashWithIndifferentAccess.new(
+              maximumRecords: 10,
+              language: 'fr'
+            )
+          end
+          let(:subauthority) { 'personal_name' }
+          let(:action_request) { 'mark twain' }
+
+          it 'returns template with substitutions' do
+            expected_url = 'http://experimental.worldcat.org/fast/search?query=oclc.personalName+all+%22mark twain%22&sortKeys=usage&maximumRecords=10'
+            expect(subject).to eq expected_url
+          end
+        end
+
+        context 'when no substitutions specified' do
+          let(:action_request) { 'mark twain' }
+
+          it 'returns template with substitutions' do
+            expected_url = 'http://experimental.worldcat.org/fast/search?query=cql.any+all+%22mark twain%22&sortKeys=usage&maximumRecords=20'
+            expect(subject).to eq expected_url
+          end
+        end
+      end
+
+      context 'and performing term action' do
+        let(:action) { :term }
+        let(:action_config) { term_config }
+        let(:action_request) { 'n79021164' }
+
+        it 'returns template with substitutions' do
+          expected_url = 'http://id.worldcat.org/fast/n79021164'
+          expect(subject).to eq expected_url
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Working toward better separation between the classes.  The IRI related models and the IRI service that builds the URLs have good separation.  The AuthorityUrlService was put in place as a go between for the authority configuration access and the IRI models and service.  More refactoring will happen later to clean up some of the bleeding of config knowledge into the AuthorityUrlService.