### PR TITLE
Refactor sort process into a service

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,6 +11,7 @@ RSpec/ExampleLength:
 Metrics/ClassLength:
   Exclude:
     - 'app/controllers/qa/linked_data_terms_controller.rb'
+    - 'app/services/qa/linked_data/deep_sort_service.rb'
     - 'lib/qa/authorities/linked_data/find_term.rb'
     - 'lib/qa/authorities/linked_data/search_query.rb'
     - 'lib/qa/authorities/linked_data/config/term_config.rb'

--- a/app/models/qa/iri_template/url_config.rb
+++ b/app/models/qa/iri_template/url_config.rb
@@ -22,7 +22,7 @@ module Qa
 
       # Selective extract substitution variable-value pairs from the provided substitutions.
       # @param [Hash, ActionController::Parameters] full set of passed in substitution values
-      # @returns [HashWithIndifferentAccess] Only variable-value pairs for variables defined in the variable mapping.
+      # @return [HashWithIndifferentAccess] Only variable-value pairs for variables defined in the variable mapping.
       def extract_substitutions(substitutions)
         selected_substitutions = HashWithIndifferentAccess.new
         mapping.each do |m|

--- a/app/services/qa/linked_data/authority_url_service.rb
+++ b/app/services/qa/linked_data/authority_url_service.rb
@@ -8,7 +8,7 @@ module Qa
       # @param action [Symbol] action with valid values :search or :term
       # @param action_request [String] the request the user is making of the authority (e.g. query text or term id/uri)
       # @param substitutions [Hash] variable-value pairs to substitute into the URL template
-      # @returns a valid URL the submits the action request to the external authority
+      # @return a valid URL the submits the action request to the external authority
       def self.build_url(action_config:, action:, action_request:, substitutions: {}, subauthority: nil)
         action_validation(action)
         url_config = Qa::IriTemplate::UrlConfig.new(action_url(action_config, action))

--- a/app/services/qa/linked_data/deep_sort_service.rb
+++ b/app/services/qa/linked_data/deep_sort_service.rb
@@ -1,0 +1,239 @@
+# Provide service for for sorting an array of hash based on the values at a specified key in the hash.
+module Qa
+  module LinkedData
+    class DeepSortService
+      # @params [Array<Hash<Symbol,Array<RDF::Literal>>>] the array of hashes to sort
+      # @params [sort_key] the key in the hash on whose value the array will be sorted
+      # @returns instance of this class
+      # @example the_array parameter
+      #   [
+      #     {:uri=>[#<RDF::URI:0x3fcff54a829c URI:http://id.loc.gov/authorities/names/n2010043281>],
+      #      :id=>[#<RDF::Literal:0x3fcff4a367b4("n 2010043281")>],
+      #      :label=>[#<RDF::Literal:0x3fcff54a9a98("Valli, Sabrina"@en)>],
+      #      :altlabel=>[],
+      #      :sort=>[#<RDF::Literal:0x3fcff54b4c18("2")>]},
+      #     {:uri=>[#<RDF::URI:0x3fcff54a829c URI:http://id.loc.gov/authorities/names/n201002344>],
+      #      :id=>[#<RDF::Literal:0x3fcff4a367b4("n 201002344")>],
+      #      :label=>[#<RDF::Literal:0x3fcff54a9a98("Cornell, Joseph"@en)>],
+      #      :altlabel=>[],
+      #      :sort=>[#<RDF::Literal:0x3fcff54b4c18("1")>]}
+      #   ]
+      def initialize(the_array, sort_key, preferred_language = :en)
+        @sortable_elements = the_array.map { |element| DeepSortElement.new(element, sort_key, preferred_language) }
+      end
+
+      # Sort an array of hash on the specified sort key.  The value in the hash at sort key is expected to be an array
+      # with one or more values that are RDF::Literals that translate to a number (e.g. 2), a string number (e.g. "3"),
+      # a string (e.g. "hello"), or a language qualified string (e.g. "hello"@en).
+      # The sort occurs in the following precedence.
+      # * preference for numeric sort (if only one value each and both are integers or a string that can be converted to an integer)
+      # * single value sort (if only one value each and at least one is not an integer)
+      # * multiple values sort (if either has multiple values)
+      # @returns the sorted array
+      # @example returned sorted array
+      #   [
+      #     {:uri=>[#<RDF::URI:0x3fcff54a829c URI:http://id.loc.gov/authorities/names/n201002344>],
+      #      :id=>[#<RDF::Literal:0x3fcff4a367b4("n 201002344")>],
+      #      :label=>[#<RDF::Literal:0x3fcff54a9a98("Cornell, Joseph"@en)>],
+      #      :altlabel=>[],
+      #      :sort=>[#<RDF::Literal:0x3fcff54b4c18("1")>]},
+      #     {:uri=>[#<RDF::URI:0x3fcff54a829c URI:http://id.loc.gov/authorities/names/n2010043281>],
+      #      :id=>[#<RDF::Literal:0x3fcff4a367b4("n 2010043281")>],
+      #      :label=>[#<RDF::Literal:0x3fcff54a9a98("Valli, Sabrina"@en)>],
+      #      :altlabel=>[],
+      #      :sort=>[#<RDF::Literal:0x3fcff54b4c18("2")>]}
+      #   ]
+      def sort
+        @sortable_elements.sort.map(&:element)
+      end
+
+      class DeepSortElement
+        attr_reader :element, :literals, :preferred_language
+        private :preferred_language
+
+        delegate :size, to: :@literals
+
+        def initialize(element, sort_key, preferred_language)
+          element[sort_key] = Qa::LinkedData::LanguageSortService.new(element[sort_key], preferred_language).sort
+          @element = element
+          @literals = element[sort_key]
+          @preferred_language = preferred_language
+          @includes_preferred_language = includes_preferred_language?
+          @all_same_language = all_same_language?
+        end
+
+        def <=>(other)
+          return numeric_comparator(other) if integer? && other.integer?
+          return single_value_comparator(other) if single? && other.single?
+          multiple_value_comparator(other)
+        end
+
+        # @returns true if there is a single literal that is an integer or a string that can be converted to an integer; otherwise, false
+        def integer?
+          return false unless single?
+          (/\A[-+]?\d+\z/ === literal.to_s) # rubocop:disable Style/CaseEquality
+        end
+
+        def integer(idx = 0)
+          Integer(literal(idx).to_s)
+        end
+
+        # @returns true if there is only one value; otherwise, false
+        def single?
+          @single ||= literals.size == 1
+        end
+
+        def literal(idx = 0)
+          literals[idx]
+        end
+
+        def downcase_string(idx = 0)
+          to_downcase(literal(idx))
+        end
+
+        def language(literal = literals.first)
+          return literal.language if literal.respond_to?(:language)
+          nil
+        end
+
+        def includes_preferred_language?
+          return @includes_preferred_language if @includes_preferred_language.present?
+          # literals are sorted by language with preferred language first in the list
+          @includes_preferred_language = (language == preferred_language)
+        end
+
+        def all_same_language?
+          return @all_same_language if @all_same_language.present?
+          # literals are sorted by language, so if first = last, then all are the same
+          @all_same_language = (language(literals.first) == language(literals.last))
+        end
+
+        def languages
+          filtered_literals_by_language.keys
+        end
+
+        def filtered_literals(filter_language)
+          filtered_literals_by_language.fetch(filter_language, [])
+        end
+
+        private
+
+          # If both test values are single value and both are integers, do a numeric sort
+          def numeric_comparator(other)
+            integer <=> other.integer
+          end
+
+          # If both test values are single value and at least one is not numeric, do a string sort taking language into consideration
+          # * sort values if neither has a language marker or they both have the same language marker
+          # * otherwise, sort language markers
+          def single_value_comparator(other)
+            return downcase_string <=> other.downcase_string if same_language?(literal, other.literal)
+            compare_languages(language, other.language)
+          end
+
+          def compare_languages(lang, other_lang)
+            return -1 if preferred_language? lang
+            return 1 if preferred_language? other_lang
+            return -1 if other_lang.blank?
+            return 1 if lang.blank?
+            lang <=> other_lang
+          end
+
+          # If at least one of the test values has multiple values, sort the multiple values taking language into consideration
+          # * if both lists have all the same language or no language markers at all, just sort the lists and compare each element
+          # * if either list has the preferred language, try to sort the two lists by element after filtering for the preferred language
+          # * otherwise, sort by language until there is a difference
+          def multiple_value_comparator(other)
+            return single_language_list_comparator(other) if all_same_language? && other.all_same_language?
+            return specified_language_list_comparator(other, preferred_language) if includes_preferred_language? && other.includes_preferred_language?
+            multi_language_list_comparator(other)
+          end
+
+          def single_language_list_comparator(other)
+            list_comparator(literals, other.literals)
+          end
+
+          def specified_language_list_comparator(other, lang)
+            filtered = filtered_literals(lang)
+            other_filtered = other.filtered_literals(lang)
+            return -1 if !filtered.empty? && other_filtered.empty?
+            return 1 if filtered.empty? && !other_filtered.empty?
+            list_comparator(filtered, other_filtered)
+          end
+
+          # Walk through language sorted lists
+          # * for each language, determine how closely the list of terms matches
+          # * prioritize the list that gets the most low values
+          def multi_language_list_comparator(other)
+            combined_languages = languages.concat(other.languages).uniq
+            by_language_comparisons = {}
+            combined_languages.each do |lang|
+              cmp = list_comparator(filtered_literals(lang), other.filtered_literals(lang))
+              by_language_comparisons[lang] = cmp
+            end
+            cmp_sum = by_language_comparisons.values.sum
+            return 1 if cmp_sum.positive?
+            return -1 if cmp_sum.negative?
+            0
+          end
+
+          def list_comparator(list, other_list)
+            # if an element doesn't have any terms in a language, the other element sorts lower
+            return -1 if other_list.empty?
+            return 1 if list.empty?
+            shorter_list_size = [list.size, other_list.size].min
+            cmp = 0
+            0.upto(shorter_list_size - 1) do |idx|
+              cmp = to_downcase(list[idx]) <=> to_downcase(other_list[idx])
+              return cmp unless cmp.zero?
+            end
+            return cmp if list.size == other_list.size
+            other_list.size < list.size ? 1 : -1 # didn't find any diffs, shorter list is considered lower
+          end
+
+          def same_language?(lit, other_lit)
+            return false if only_one_has_language_marker?(lit, other_lit)
+            return true if neither_have_language_markers?(lit, other_lit)
+            lit.language == other_lit.language
+          end
+
+          def neither_have_language_markers?(lit, other_lit)
+            !language?(lit) && !language?(other_lit)
+          end
+
+          def only_one_has_language_marker?(lit, other_lit)
+            (!language?(lit) && language?(other_lit)) || (language?(lit) && !language?(other_lit))
+          end
+
+          def language?(lit)
+            lang = lit.language if lit.respond_to?(:language)
+            lang.present?
+          end
+
+          def preferred_language?(lang)
+            preferred_language.present? ? lang == preferred_language : false
+          end
+
+          def to_downcase(lit)
+            lit.to_s.downcase
+          end
+
+          def filtered_literals_by_language
+            @filtered_literals_by_language ||= create_all_filters
+          end
+
+          def create_all_filters
+            bins = {}
+            0.upto(size - 1) do |idx|
+              lang = language(literals[idx])
+              filter = bins.fetch(lang, [])
+              filter << literal(idx)
+              bins[lang] = filter
+            end
+            bins
+          end
+      end
+      private_constant :DeepSortElement
+    end
+  end
+end

--- a/app/services/qa/linked_data/graph_service.rb
+++ b/app/services/qa/linked_data/graph_service.rb
@@ -5,7 +5,7 @@ module Qa
       class << self
         # Retrieve linked data from specified url
         # @param [String] url from which to retrieve linked data
-        # @returns [RDF::Graph] graph of linked data
+        # @return [RDF::Graph] graph of linked data
         def load_graph(url:)
           RDF::Graph.load(url)
         rescue IOError => e
@@ -17,7 +17,7 @@ module Qa
         # @param language [String | Symbol | Array<String|Symbol>] will keep any statement whose object's language matches the language filter
         #          (only applies to statements that respond to language) (e.g. "en" or :en or ["en", "fr"] or [:en, :fr])
         # @param remove_blanknode_subjects [Boolean] will remove any statement whose subject is a blanknode, if true
-        # @returns [RDF::Graph] a new instance of graph with statements not matching the filters removed
+        # @return [RDF::Graph] a new instance of graph with statements not matching the filters removed
         def filter(graph:, language: nil, remove_blanknode_subjects: false)
           return graph unless graph.present?
           return graph unless language.present? || remove_blanknode_subjects
@@ -33,7 +33,7 @@ module Qa
         # @param graph [RDF::Graph] the graph to search
         # @param subject [RDF::URI] the URI of the subject
         # @param predicate [RDF::URI] the URI of the predicate
-        # @returns [Array] all object values for the subject-predicate pair
+        # @return [Array] all object values for the subject-predicate pair
         def object_values(graph:, subject:, predicate:)
           values = []
           graph.query([subject, predicate, :object]) do |statement|
@@ -81,7 +81,7 @@ module Qa
 
           # Normalize language
           # @param [String | Symbol | Array] language for filtering graph (e.g. "en" OR :en OR ["en", "fr"] OR [:en, :fr])
-          # @returns [Array<Symbol>] an array of languages encoded as symbols (e.g. [:en] OR [:en, :fr])
+          # @return [Array<Symbol>] an array of languages encoded as symbols (e.g. [:en] OR [:en, :fr])
           def normalize_language(language)
             return language if language.blank?
             language = [language] unless language.is_a? Array

--- a/app/services/qa/linked_data/language_sort_service.rb
+++ b/app/services/qa/linked_data/language_sort_service.rb
@@ -1,0 +1,81 @@
+# Service to sort an array of literals by language and within language.
+module Qa
+  module LinkedData
+    class LanguageSortService
+      LANGUAGE_LOCALE_KEY_FOR_NO_LANGUAGE = :NO_LANGUAGE
+
+      attr_reader :literals, :preferred_language
+      attr_reader :languages, :bins
+      private :literals, :preferred_language, :languages, :bins
+      # private :literals, :preferred_language, :languages, :languages=, :bins, :bins=
+
+      # @param [Array<RDF::Literals>] string literals to sort
+      # @param [Symbol] preferred language to appear first in the list; defaults to no preference
+      # @return instance of this class
+      def initialize(literals, preferred_language = nil)
+        @literals = literals
+        @preferred_language = preferred_language
+        @languages = []
+        @bins = {}
+      end
+
+      # Sort the literals stored in this instance of the service
+      # @return sorted version of literals
+      def sort
+        return literals unless literals.present?
+        return @sorted_literals if @sorted_literals.present?
+        parse_into_language_bins
+        sort_languages
+        sort_language_bins
+        @sorted_literals = construct_sorted_literals
+      end
+
+      private
+
+        def construct_sorted_literals
+          sorted_literals = []
+          0.upto(languages.size - 1) { |idx| sorted_literals.concat(bins[languages[idx]]) }
+          sorted_literals
+        end
+
+        def language(literal)
+          language = literal.language if literal.respond_to?(:language)
+          language.present? ? language : LANGUAGE_LOCALE_KEY_FOR_NO_LANGUAGE
+        end
+
+        def move_no_language_to_end
+          return unless languages.include?(LANGUAGE_LOCALE_KEY_FOR_NO_LANGUAGE)
+          languages.delete(LANGUAGE_LOCALE_KEY_FOR_NO_LANGUAGE)
+          languages << LANGUAGE_LOCALE_KEY_FOR_NO_LANGUAGE
+        end
+
+        def move_preferred_language_to_front
+          return unless preferred_language.present? && languages.include?(preferred_language)
+          languages.delete(preferred_language)
+          languages.insert(0, preferred_language)
+        end
+
+        def parse_into_language_bins
+          0.upto(literals.size - 1) do |idx|
+            lang = language(literals[idx])
+            languages << lang
+            bin = bins.fetch(lang, [])
+            bin << literals[idx]
+            bins[lang] = bin
+          end
+          @language = languages
+          @bins = bins
+        end
+
+        def sort_languages
+          languages.sort!.uniq!
+          move_preferred_language_to_front
+          move_no_language_to_end
+        end
+
+        def sort_language_bins
+          bins.each_value { |bin| bin.sort_by! { |literal| literal.to_s.downcase } }
+        end
+    end
+  end
+end

--- a/lib/qa/authorities/linked_data/rdf_helper.rb
+++ b/lib/qa/authorities/linked_data/rdf_helper.rb
@@ -39,10 +39,9 @@ module Qa::Authorities
         end
 
         def sort_string_by_language(str_literals)
-          return str_literals if str_literals.nil? || str_literals.size <= 0
-          str_literals.sort! { |a, b| a.language <=> b.language }
-          str_literals.collect!(&:to_s)
-          str_literals.uniq!
+          return str_literals if str_literals.blank?
+          str_literals = Qa::LinkedData::LanguageSortService.new(str_literals).sort
+          str_literals.map!(&:to_s).uniq!
           str_literals.delete_if { |s| s.nil? || s.length <= 0 }
         end
     end

--- a/spec/lib/authorities/linked_data/search_query_spec.rb
+++ b/spec/lib/authorities/linked_data/search_query_spec.rb
@@ -99,8 +99,8 @@ RSpec.describe Qa::Authorities::LinkedData::SearchQuery do
             json_results = [{ label: "[#{term_b}, #{term_c}]", sort: [term_b, term_c] },
                             { label: "[#{term_b}]", sort: [term_b] },
                             { label: "[#{term_b}, #{term_a}]", sort: [term_b, term_a] }]
-            expected_results = [{ label: "[#{term_b}]" },
-                                { label: "[#{term_b}, #{term_a}]" },
+            expected_results = [{ label: "[#{term_b}, #{term_a}]" },
+                                { label: "[#{term_b}]" },
                                 { label: "[#{term_b}, #{term_c}]" }]
             expect(instance.send(:sort_search_results, json_results)).to eq expected_results
           end
@@ -111,8 +111,8 @@ RSpec.describe Qa::Authorities::LinkedData::SearchQuery do
             json_results = [{ label: "[#{term_b}, #{term_d}, #{term_c}]", sort: [term_b, term_d, term_c] },
                             { label: "[#{term_a}, #{term_c}]", sort: [term_a, term_c] },
                             { label: "[#{term_b}, #{term_d}, #{term_a}]", sort: [term_b, term_d, term_a] }]
-            expected_results = [{ label: "[#{term_a}, #{term_c}]" },
-                                { label: "[#{term_b}, #{term_d}, #{term_a}]" },
+            expected_results = [{ label: "[#{term_b}, #{term_d}, #{term_a}]" },
+                                { label: "[#{term_a}, #{term_c}]" },
                                 { label: "[#{term_b}, #{term_d}, #{term_c}]" }]
             expect(instance.send(:sort_search_results, json_results)).to eq expected_results
           end

--- a/spec/services/linked_data/deep_sort_service_spec.rb
+++ b/spec/services/linked_data/deep_sort_service_spec.rb
@@ -1,0 +1,260 @@
+require 'spec_helper'
+
+RSpec.describe Qa::LinkedData::DeepSortService do
+  describe "#deep_sort" do
+    subject { described_class.new(the_array, :sort, preferred_language).sort }
+
+    let(:preferred_language) { nil }
+
+    context 'as numeric sort' do
+      context 'when sort values are integers' do
+        let(:term_1) { RDF::Literal.new(1) }
+        let(:term_2) { RDF::Literal.new(15) }
+        let(:term_3) { RDF::Literal.new(20) }
+        let(:the_array) do
+          [{ sort: [term_2] },
+           { sort: [term_3] },
+           { sort: [term_1] }]
+        end
+
+        it "does numeric sort" do
+          expected_results = [{ sort: [term_1] },
+                              { sort: [term_2] },
+                              { sort: [term_3] }]
+          expect(subject).to eq expected_results
+        end
+      end
+
+      context 'when sort values are string representations of integers' do
+        let(:term_1) { RDF::Literal.new('1') }
+        let(:term_2) { RDF::Literal.new('15') }
+        let(:term_3) { RDF::Literal.new('20') }
+        let(:the_array) do
+          [{ sort: [term_2] },
+           { sort: [term_3] },
+           { sort: [term_1] }]
+        end
+
+        it "does numeric sort" do
+          expected_results = [{ sort: [term_1] },
+                              { sort: [term_2] },
+                              { sort: [term_3] }]
+          expect(subject).to eq expected_results
+        end
+      end
+
+      context 'when sort values are a mix of integer representations' do
+        let(:term_1) { RDF::Literal.new(1) }
+        let(:term_2) { RDF::Literal.new('15') }
+        let(:term_3) { RDF::Literal.new(20) }
+        let(:term_4) { RDF::Literal.new('201') }
+        let(:the_array) do
+          [{ sort: [term_2] },
+           { sort: [term_3] },
+           { sort: [term_1] },
+           { sort: [term_4] }]
+        end
+
+        it "does numeric sort" do
+          expected_results = [{ sort: [term_1] },
+                              { sort: [term_2] },
+                              { sort: [term_3] },
+                              { sort: [term_4] }]
+          expect(subject).to eq expected_results
+        end
+      end
+    end
+
+    context 'as single value sort' do
+      context 'when sort values do not have the language markers' do
+        let(:term_1) { RDF::Literal.new("apple") }
+        let(:term_2) { RDF::Literal.new("Banana") }
+        let(:term_3) { RDF::Literal.new("carrot") }
+        let(:the_array) do
+          [{ sort: [term_2] },
+           { sort: [term_3] },
+           { sort: [term_1] }]
+        end
+
+        it 'does alpha sort ignoring case' do
+          expected_results = [{ sort: [term_1] },
+                              { sort: [term_2] },
+                              { sort: [term_3] }]
+          expect(subject).to eq expected_results
+        end
+      end
+
+      context 'when sort values all have the same language marker' do
+        let(:term_1) { RDF::Literal.new("apple", language: :en) }
+        let(:term_2) { RDF::Literal.new("Banana", language: :en) }
+        let(:term_3) { RDF::Literal.new("carrot", language: :en) }
+        let(:the_array) do
+          [{ sort: [term_2] },
+           { sort: [term_3] },
+           { sort: [term_1] }]
+        end
+
+        it 'does alpha sort ignoring case' do
+          expected_results = [{ sort: [term_1] },
+                              { sort: [term_2] },
+                              { sort: [term_3] }]
+          expect(subject).to eq expected_results
+        end
+      end
+
+      context 'when sort values all have different language markers and no preferred language' do
+        let(:term_1) { RDF::Literal.new("Kuh", language: :de) }
+        let(:term_2) { RDF::Literal.new("Rind", language: :de) }
+        let(:term_3) { RDF::Literal.new("bovine", language: :en) }
+        let(:term_4) { RDF::Literal.new("cow", language: :en) }
+        let(:term_5) { RDF::Literal.new("vache", language: :fr) }
+        let(:term_6) { RDF::Literal.new("mucca") }
+        let(:term_7) { RDF::Literal.new("vaca") }
+        let(:the_array) do
+          [{ sort: [term_5] },
+           { sort: [term_7] },
+           { sort: [term_2] },
+           { sort: [term_6] },
+           { sort: [term_1] },
+           { sort: [term_4] },
+           { sort: [term_3] }]
+        end
+
+        it 'does alpha sort of languages and alpha sort of terms within each language' do
+          expected_results = [{ sort: [term_1] },
+                              { sort: [term_2] },
+                              { sort: [term_3] },
+                              { sort: [term_4] },
+                              { sort: [term_5] },
+                              { sort: [term_6] },
+                              { sort: [term_7] }]
+          expect(subject).to eq expected_results
+        end
+      end
+
+      context 'when sort values all have different language markers and has preferred language' do
+        let(:preferred_language) { :en }
+
+        let(:term_1) { RDF::Literal.new("bovine", language: :en) }
+        let(:term_2) { RDF::Literal.new("cow", language: :en) }
+        let(:term_3) { RDF::Literal.new("Kuh", language: :de) }
+        let(:term_4) { RDF::Literal.new("Rind", language: :de) }
+        let(:term_5) { RDF::Literal.new("vache", language: :fr) }
+        let(:term_6) { RDF::Literal.new("mucca") }
+        let(:term_7) { RDF::Literal.new("vaca") }
+        let(:the_array) do
+          [{ sort: [term_5] },
+           { sort: [term_7] },
+           { sort: [term_2] },
+           { sort: [term_6] },
+           { sort: [term_1] },
+           { sort: [term_4] },
+           { sort: [term_3] }]
+        end
+
+        it 'does alpha sort of languages shifting perferred language to the front and alpha sort of terms within each language' do
+          expected_results = [{ sort: [term_1] },
+                              { sort: [term_2] },
+                              { sort: [term_3] },
+                              { sort: [term_4] },
+                              { sort: [term_5] },
+                              { sort: [term_6] },
+                              { sort: [term_7] }]
+          expect(subject).to eq expected_results
+        end
+      end
+    end
+
+    context 'as multiple value sort' do
+      context 'when all the terms in both lists have no language markers' do
+        let(:term_1) { RDF::Literal.new("apple") }
+        let(:term_2) { RDF::Literal.new("Banana") }
+        let(:term_3) { RDF::Literal.new("carrot") }
+        let(:term_4) { RDF::Literal.new("Woof Woof") }
+        let(:the_array) do
+          [{ sort: [term_2, term_1] },
+           { sort: [term_3, term_2] },
+           { sort: [term_1, term_3, term_4, term_2] }]
+        end
+
+        it 'does alpha sort ignoring case' do
+          expected_results = [{ sort: [term_1, term_2] },
+                              { sort: [term_1, term_2, term_3, term_4] },
+                              { sort: [term_2, term_3] }]
+          expect(subject).to eq expected_results
+        end
+      end
+
+      context 'when all the terms in both lists have the same language markers' do
+        let(:term_1) { RDF::Literal.new("bovine", language: :en) }
+        let(:term_2) { RDF::Literal.new("Cow", language: :en) }
+        let(:term_3) { RDF::Literal.new("hefer", language: :en) }
+        let(:term_4) { RDF::Literal.new("Moo Moo", language: :en) }
+        let(:the_array) do
+          [{ sort: [term_2, term_1] },
+           { sort: [term_3, term_2] },
+           { sort: [term_1, term_3, term_4, term_2] }]
+        end
+
+        it 'does alpha sort ignoring case' do
+          expected_results = [{ sort: [term_1, term_2] },
+                              { sort: [term_1, term_2, term_3, term_4] },
+                              { sort: [term_2, term_3] }]
+          expect(subject).to eq expected_results
+        end
+      end
+
+      context 'when terms exist in both lists that match the preferred language' do
+        let(:preferred_language) { :en }
+
+        let(:term_1) { RDF::Literal.new("bovine", language: :en) }
+        let(:term_2) { RDF::Literal.new("cow", language: :en) }
+        let(:term_3) { RDF::Literal.new("heffer", language: :en) }
+        let(:term_4) { RDF::Literal.new("Kuh", language: :de) }
+        let(:term_5) { RDF::Literal.new("Rind", language: :de) }
+        let(:term_6) { RDF::Literal.new("vache", language: :fr) }
+        let(:term_7) { RDF::Literal.new("mucca") }
+        let(:term_8) { RDF::Literal.new("vaca") }
+        let(:the_array) do
+          [{ sort: [term_4, term_5, term_2, term_1] },
+           { sort: [term_3, term_5, term_4, term_7, term_2] },
+           { sort: [term_1, term_6, term_4, term_2, term_5, term_8, term_7, term_3] }]
+        end
+
+        it 'does alpha sort ignoring case on the preferred language only' do
+          expected_results = [{ sort: [term_1, term_2, term_4, term_5] },
+                              { sort: [term_1, term_2, term_3, term_4, term_5, term_6, term_7, term_8] },
+                              { sort: [term_2, term_3, term_4, term_5, term_7] }]
+          expect(subject).to eq expected_results
+        end
+      end
+
+      context 'when there is complete chaos under heaven and all things are rotten' do
+        let(:preferred_language) { :en }
+
+        let(:term_1) { RDF::Literal.new("Kuh", language: :de) }
+        let(:term_2) { RDF::Literal.new("Rind", language: :de) }
+        let(:term_3) { RDF::Literal.new("hembra", language: :es) }
+        let(:term_4) { RDF::Literal.new("res vacuna", language: :es) }
+        let(:term_5) { RDF::Literal.new("vaca", language: :es) }
+        let(:term_6) { RDF::Literal.new("vache", language: :fr) }
+        let(:term_7) { RDF::Literal.new("ko") }
+        let(:term_8) { RDF::Literal.new("mucca") }
+        let(:the_array) do
+          [{ sort: [term_4, term_5, term_2, term_1] }, # res vacuna, vaca, Rind, Kuh
+           { sort: [term_3, term_5, term_4, term_7, term_2] }, # hembra, vaca, res vacuna, ko, Rind
+           { sort: [term_3, term_6, term_5] }, # hembra, vache, vaca
+           { sort: [term_1, term_6, term_4, term_2, term_5, term_8, term_7, term_3] }] # Kuh, vache, res vacuna, Rind, vaca, mucca, ko, hembra
+        end
+
+        it 'does alpha sort ignoring case on the preferred language only' do
+          expected_results = [{ sort: [term_1, term_2, term_3, term_4, term_5, term_6, term_7, term_8] }, # Kuh, Rind, hembra, res vacuna, vaca, vache, ko, mucca
+                              { sort: [term_2, term_3, term_4, term_5, term_7] }, # Kuh, Rind, res vacuna, vaca
+                              { sort: [term_3, term_5, term_6] }, # hembra, vaca, vache
+                              { sort: [term_1, term_2, term_4, term_5] }] # Rind, hembra, res vacuna, vaca, mucca
+          expect(subject).to eq expected_results
+        end
+      end
+    end
+  end
+end

--- a/spec/services/linked_data/language_sort_service_spec.rb
+++ b/spec/services/linked_data/language_sort_service_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+RSpec.describe Qa::LinkedData::LanguageSortService do
+  describe "#sort" do
+    subject { described_class.new(terms, preferred_language).sort }
+
+    let(:preferred_language) { nil }
+
+    context 'when sort values all have the same language marker' do
+      let(:term_1) { RDF::Literal.new("apple", language: :en) }
+      let(:term_2) { RDF::Literal.new("Banana", language: :en) }
+      let(:term_3) { RDF::Literal.new("carrot", language: :en) }
+      let(:terms) { [term_2, term_3, term_1] }
+
+      it "does alpha sort ignoring case" do
+        expected_results = [term_1, term_2, term_3]
+        expect(subject).to eq expected_results
+      end
+    end
+
+    # Sort the literals within their languages. (e.g. 'Kuh':de, 'Rind':de, 'bovine':en, 'cow':en, 'vache':fr, 'vaca')
+    context 'when sort values have the different language markers' do
+      let(:term_1) { RDF::Literal.new("Kuh", language: :de) }
+      let(:term_2) { RDF::Literal.new("Rind", language: :de) }
+      let(:term_3) { RDF::Literal.new("bovine", language: :en) }
+      let(:term_4) { RDF::Literal.new("cow", language: :en) }
+      let(:term_5) { RDF::Literal.new("vache", language: :fr) }
+      let(:term_6) { RDF::Literal.new("mucca") }
+      let(:term_7) { RDF::Literal.new("vaca") }
+      let(:terms) { [term_5, term_7, term_2, term_6, term_1, term_4, term_3] }
+
+      it "does alpha sort ignoring case" do
+        expected_results = [term_1, term_2, term_3, term_4, term_5, term_6, term_7]
+        expect(subject).to eq expected_results
+      end
+    end
+
+    # Sort the literals within their languages giving preference to one language. (e.g. 'bovine':en, 'cow':en, 'Kuh':de, 'Rind':de, 'vache':fr, 'vaca')
+    context 'when some of the sort values have the preferred language' do
+      let(:preferred_language) { :en }
+
+      let(:term_1) { RDF::Literal.new("bovine", language: :en) }
+      let(:term_2) { RDF::Literal.new("cow", language: :en) }
+      let(:term_3) { RDF::Literal.new("heffer", language: :en) }
+      let(:term_4) { RDF::Literal.new("Kuh", language: :de) }
+      let(:term_5) { RDF::Literal.new("Rind", language: :de) }
+      let(:term_6) { RDF::Literal.new("vache", language: :fr) }
+      let(:term_7) { RDF::Literal.new("mucca") }
+      let(:term_8) { RDF::Literal.new("vaca") }
+      let(:terms) { [term_7, term_5, term_3, term_2, term_1, term_6, term_4, term_8] }
+
+      it "does alpha sort ignoring case" do
+        expected_results = [term_1, term_2, term_3, term_4, term_5, term_6, term_7, term_8]
+        expect(subject).to eq expected_results
+      end
+    end
+  end
+end


### PR DESCRIPTION
The sort process is complex.  The tests for deep_sort_service lays out the various potential sorting scenarios.  Precedence on sort...

* numeric sort, if both are integers
* simple alpha sort of one term, if both are single value
* same language list comparison, if all terms in a list are the same language or no language
* preferred language comparison only, if both lists have the at least one term in the preferred language
* calculate the comparator value for every language individually and sum to get a relative comparison of two multi-language lists (Best I could come up with.  I am open to suggestions.  In most cases, if not all, one of the earlier comparators will be selected.  This is the junk drawer of multi-lingual sorting.)