### PR TITLE
Add Qa config for a default language for flitering and sorting

### DIFF
--- a/app/services/qa/linked_data/deep_sort_service.rb
+++ b/app/services/qa/linked_data/deep_sort_service.rb
@@ -18,7 +18,7 @@ module Qa
       #      :altlabel=>[],
       #      :sort=>[#<RDF::Literal:0x3fcff54b4c18("1")>]}
       #   ]
-      def initialize(the_array, sort_key, preferred_language = :en)
+      def initialize(the_array, sort_key, preferred_language = nil)
         @sortable_elements = the_array.map { |element| DeepSortElement.new(element, sort_key, preferred_language) }
       end
 
@@ -91,9 +91,9 @@ module Qa
           to_downcase(literal(idx))
         end
 
-        def language(literal = literals.first)
-          return literal.language if literal.respond_to?(:language)
-          nil
+        def language(lit = literals.first)
+          return nil unless Qa::LinkedData::LanguageService.literal_has_language_marker? lit
+          lit.language
         end
 
         def includes_preferred_language?
@@ -206,8 +206,7 @@ module Qa
           end
 
           def language?(lit)
-            lang = lit.language if lit.respond_to?(:language)
-            lang.present?
+            Qa::LinkedData::LanguageService.literal_has_language_marker? lit
           end
 
           def preferred_language?(lang)

--- a/app/services/qa/linked_data/graph_service.rb
+++ b/app/services/qa/linked_data/graph_service.rb
@@ -14,17 +14,16 @@ module Qa
 
         # Create a new graph with statements filtered out
         # @param graph [RDF::Graph] the original graph to be filtered
-        # @param language [String | Symbol | Array<String|Symbol>] will keep any statement whose object's language matches the language filter
-        #          (only applies to statements that respond to language) (e.g. "en" or :en or ["en", "fr"] or [:en, :fr])
+        # @param language [Array<Symbol>] will keep any statement whose object's language matches the language filter
+        #          (only applies to statements that respond to language) (e.g. [:fr] or [:en, :fr])
         # @param remove_blanknode_subjects [Boolean] will remove any statement whose subject is a blanknode, if true
         # @return [RDF::Graph] a new instance of graph with statements not matching the filters removed
         def filter(graph:, language: nil, remove_blanknode_subjects: false)
           return graph unless graph.present?
           return graph unless language.present? || remove_blanknode_subjects
-          filtered_graph = graph
-          language = normalize_language(language)
-          filtered_graph.each do |st|
-            filtered_graph.delete(st) if filter_out_blanknode(remove_blanknode_subjects, st.subject) || filter_out_language(language, st.object)
+          filtered_graph = deep_copy(graph: graph)
+          filtered_graph.statements.each do |st|
+            filtered_graph.delete(st) if filter_out_blanknode(remove_blanknode_subjects, st.subject) || filter_out_language(graph, language, st)
           end
           filtered_graph
         end
@@ -42,17 +41,39 @@ module Qa
           values
         end
 
+        def deep_copy(graph:)
+          new_graph = RDF::Graph.new
+          graph.statements.each do |st|
+            new_graph.insert(st.dup)
+          end
+        end
+
         private
 
           def filter_out_blanknode(remove, subj)
             remove && subj.anonymous?
           end
 
-          def filter_out_language(language, obj)
+          # Filter out language based on...
+          # * do not remove if the object literal does not respond to :language
+          # * do not remove if the object literal does not have a language marker
+          # * do not remove if the object has the targeted language marker
+          # * do not remove if none of the other objects with this statement's predicate have the targeted language marker
+          def filter_out_language(graph, language, statement)
             return false if language.blank?
-            return false unless obj.respond_to?(:language)
-            return false if obj.language.blank?
-            !language.include?(obj.language)
+            return false unless Qa::LinkedData::LanguageService.literal_has_language_marker?(statement.object)
+            objects = object_values(graph: graph, subject: statement.subject, predicate: statement.predicate)
+            return false unless at_least_one_object_has_language?(objects, language)
+            !language.include?(statement.object.language)
+          end
+
+          def at_least_one_object_has_language?(objects, language)
+            objects.each do |obj|
+              next unless Qa::LinkedData::LanguageService.literal_has_language_marker?(obj)
+              next unless language.include? obj.language
+              return true
+            end
+            false
           end
 
           def process_error(e, url)
@@ -77,15 +98,6 @@ module Qa
             a = msg.size - 4
             z = msg.size - 2
             msg[a..z]
-          end
-
-          # Normalize language
-          # @param [String | Symbol | Array] language for filtering graph (e.g. "en" OR :en OR ["en", "fr"] OR [:en, :fr])
-          # @return [Array<Symbol>] an array of languages encoded as symbols (e.g. [:en] OR [:en, :fr])
-          def normalize_language(language)
-            return language if language.blank?
-            language = [language] unless language.is_a? Array
-            language.map(&:to_sym)
           end
       end
     end

--- a/app/services/qa/linked_data/language_service.rb
+++ b/app/services/qa/linked_data/language_service.rb
@@ -1,0 +1,30 @@
+# Service to determine which language to use for sorting and filtering.
+module Qa
+  module LinkedData
+    class LanguageService
+      class << self
+        def preferred_language(user_language: nil, authority_language: nil)
+          return normalize_language(user_language) if user_language.present?
+          return normalize_language(authority_language) if authority_language.present?
+          normalize_language(Qa.config.default_language)
+        end
+
+        def literal_has_language_marker?(literal)
+          return false unless literal.respond_to?(:language)
+          literal.language.present?
+        end
+
+        private
+
+          # Normalize language
+          # @param [String | Symbol | Array] language for filtering graph (e.g. "en" OR :en OR ["en", "fr"] OR [:en, :fr])
+          # @return [Array<Symbol>] an array of languages encoded as symbols (e.g. [:en] OR [:en, :fr])
+          def normalize_language(language)
+            return language if language.blank?
+            language = [language] unless language.is_a? Array
+            language.map(&:to_sym)
+          end
+      end
+    end
+  end
+end

--- a/app/services/qa/linked_data/language_sort_service.rb
+++ b/app/services/qa/linked_data/language_sort_service.rb
@@ -39,8 +39,8 @@ module Qa
         end
 
         def language(literal)
-          language = literal.language if literal.respond_to?(:language)
-          language.present? ? language : LANGUAGE_LOCALE_KEY_FOR_NO_LANGUAGE
+          return LANGUAGE_LOCALE_KEY_FOR_NO_LANGUAGE unless Qa::LinkedData::LanguageService.literal_has_language_marker? literal
+          literal.language
         end
 
         def move_no_language_to_end

--- a/lib/generators/qa/install/templates/config/initializers/qa.rb
+++ b/lib/generators/qa/install/templates/config/initializers/qa.rb
@@ -10,4 +10,8 @@ Qa.config do |config|
   # requiring a restart of rails. By default, reloading through the browser is not allowed
   # when the token is nil or blank.  Change to any string to control who has access to reload.
   # config.authorized_reload_token = 'YOUR_AUTH_TOKEN_DEFINED_HERE'
+
+  # For linked data access, specify default language for sorting and selection.  The default is only used if a language is not
+  # specified in the authority's configuration file and not passed in as a parameter.  (e.g. :en, [:en], or [:en, :fr])
+  # config.default_language = :en
 end

--- a/lib/qa/authorities/linked_data/search_query.rb
+++ b/lib/qa/authorities/linked_data/search_query.rb
@@ -11,7 +11,7 @@ module Qa::Authorities
       end
 
       attr_reader :search_config, :graph, :language
-      private :language
+      private :graph, :language
 
       delegate :subauthority?, :supports_sort?, to: :search_config
 
@@ -27,8 +27,7 @@ module Qa::Authorities
       #     {"uri":"http://id.worldcat.org/fast/409667","id":"409667","label":"Cornell, Ezra, 1807-1874"} ]
       def search(query, language: nil, replacements: {}, subauth: nil)
         raise Qa::InvalidLinkedDataAuthority, "Unable to initialize linked data search sub-authority #{subauth}" unless subauth.nil? || subauthority?(subauth)
-        language ||= search_config.language
-        @language = language
+        @language = Qa::LinkedData::LanguageService.preferred_language(user_language: language, authority_language: search_config.language)
         url = Qa::LinkedData::AuthorityUrlService.build_url(action_config: search_config, action: :search, action_request: query, substitutions: replacements, subauthority: subauth)
         Rails.logger.info "QA Linked Data search url: #{url}"
         load_graph(url: url)

--- a/lib/qa/configuration.rb
+++ b/lib/qa/configuration.rb
@@ -30,5 +30,12 @@ module Qa
 
     # Hold linked data authority configs
     attr_accessor :linked_data_authority_configs
+
+    # For linked data access, specify default language for sorting and selection.  The default is only used if a language is not
+    # specified in the authority's configuration file and not passed in as a parameter.  (e.g. :en, [:en], or [:en, :fr])
+    attr_writer :default_language
+    def default_language
+      @default_language ||= :en
+    end
   end
 end

--- a/spec/fixtures/authorities/linked_data/lod_lang_defaults.json
+++ b/spec/fixtures/authorities/linked_data/lod_lang_defaults.json
@@ -18,7 +18,7 @@
       "term_id": "term_id"
     },
     "term_id": "ID",
-    "language": [ "en" ],
+    "language": [ "fr" ],
     "results": {
       "id_predicate":       "http://id.loc.gov/vocabulary/identifiers/lccn",
       "label_predicate":    "http://www.w3.org/2004/02/skos/core#prefLabel",
@@ -43,7 +43,7 @@
     "qa_replacement_patterns": {
       "query": "query"
     },
-    "language": [ "en" ],
+    "language": [ "fr" ],
     "results": {
       "id_predicate":       "http://purl.org/dc/terms/identifier",
       "label_predicate":    "http://www.w3.org/2004/02/skos/core#prefLabel",

--- a/spec/fixtures/lod_lang_search_filtering.nt
+++ b/spec/fixtures/lod_lang_search_filtering.nt
@@ -1,0 +1,11 @@
+<http://id.worldcat.org/fast/530369> <http://purl.org/dc/terms/identifier> "530369" .
+<http://id.worldcat.org/fast/530369> <http://www.w3.org/2004/02/skos/core#prefLabel> "buttermilk"@en
+<http://id.worldcat.org/fast/530369> <http://www.w3.org/2004/02/skos/core#prefLabel> "Babeurre"@fr
+<http://id.worldcat.org/fast/530369> <http://www.w3.org/2004/02/skos/core#prefLabel> "Buttermilch"
+<http://id.worldcat.org/fast/5140> <http://purl.org/dc/terms/identifier> "5140" .
+<http://id.worldcat.org/fast/5140> <http://www.w3.org/2004/02/skos/core#prefLabel> "dried milk"@en
+<http://id.worldcat.org/fast/5140> <http://www.w3.org/2004/02/skos/core#prefLabel> "lait en poudre"@fr
+<http://id.worldcat.org/fast/5140> <http://www.w3.org/2004/02/skos/core#prefLabel> "getrocknete Milch"@de
+<http://id.worldcat.org/fast/557490> <http://purl.org/dc/terms/identifier> "557490" .
+<http://id.worldcat.org/fast/557490> <http://www.w3.org/2004/02/skos/core#prefLabel> "condensed milk"@en
+<http://id.worldcat.org/fast/557490> <http://www.w3.org/2004/02/skos/core#prefLabel> "Kondensmilch"@de

--- a/spec/lib/authorities/linked_data/generic_authority_spec.rb
+++ b/spec/lib/authorities/linked_data/generic_authority_spec.rb
@@ -69,50 +69,75 @@ RSpec.describe Qa::Authorities::LinkedData::GenericAuthority do
     describe "language processing" do
       context "when filtering #search results" do
         context "and lang NOT passed in" do
-          context "and NO default defined in config" do
-            let(:lod_lang_no_defaults) { described_class.new(:LOD_LANG_NO_DEFAULTS) }
-            let :results do
-              stub_request(:get, "http://localhost/test_no_default/search?query=milk")
-                .to_return(status: 200, body: webmock_fixture("lod_lang_search_enfr.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
-              lod_lang_no_defaults.search('milk')
+          context "and NO language defined in authority config" do
+            context "and NO language defined in Qa config" do
+              let(:lod_lang_no_defaults) { described_class.new(:LOD_LANG_NO_DEFAULTS) }
+              let :results do
+                stub_request(:get, "http://localhost/test_no_default/search?query=milk")
+                  .to_return(status: 200, body: webmock_fixture("lod_lang_search_enfr.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
+                lod_lang_no_defaults.search('milk')
+              end
+
+              before do
+                Qa.config.default_language = []
+              end
+
+              after do
+                Qa.config.default_language = :en
+              end
+
+              it "is not filtered" do
+                expect(results.first[:label]).to eq('[buttermilk, Babeurre] (yummy, délicieux)')
+                expect(results.second[:label]).to eq('[condensed milk, lait condensé] (creamy, crémeux)')
+                expect(results.third[:label]).to eq('[dried milk, lait en poudre] (powdery, poudreux)')
+              end
             end
-            it "is not filtered" do
-              expect(results.first[:label]).to eq('[buttermilk, Babeurre] (yummy, délicieux)')
-              expect(results.second[:label]).to eq('[condensed milk, lait condensé] (creamy, crémeux)')
-              expect(results.third[:label]).to eq('[dried milk, lait en poudre] (powdery, poudreux)')
+
+            context "and default_language is defined in Qa config" do
+              let(:lod_lang_no_defaults) { described_class.new(:LOD_LANG_NO_DEFAULTS) }
+              let :results do
+                stub_request(:get, "http://localhost/test_no_default/search?query=milk")
+                  .to_return(status: 200, body: webmock_fixture("lod_lang_search_enfr.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
+                lod_lang_no_defaults.search('milk')
+              end
+              it "filters using Qa configured default" do
+                expect(results.first[:label]).to eq('buttermilk (yummy)')
+                expect(results.second[:label]).to eq('condensed milk (creamy)')
+                expect(results.third[:label]).to eq('dried milk (powdery)')
+              end
             end
           end
 
-          context "and default IS defined in config" do
+          context "and language IS defined in authority config" do
             let(:lod_lang_defaults) { described_class.new(:LOD_LANG_DEFAULTS) }
             let :results do
               stub_request(:get, "http://localhost/test_default/search?query=milk")
                 .to_return(status: 200, body: webmock_fixture("lod_lang_search_enfr.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
               lod_lang_defaults.search('milk')
             end
-            it "is filtered to default" do
-              expect(results.first[:label]).to eq('buttermilk (yummy)')
-              expect(results.second[:label]).to eq('condensed milk (creamy)')
-              expect(results.third[:label]).to eq('dried milk (powdery)')
+            it "is filtered to authority defined language" do
+              expect(results.first[:label]).to eq('Babeurre (délicieux)')
+              expect(results.second[:label]).to eq('lait condensé (crémeux)')
+              expect(results.third[:label]).to eq('lait en poudre (poudreux)')
             end
           end
         end
 
-        context "and multiple defaults ARE defined in config" do
+        context "and multiple languages ARE defined in authority config" do
           let(:lod_lang_multi_defaults) { described_class.new(:LOD_LANG_MULTI_DEFAULTS) }
           let :results do
             stub_request(:get, "http://localhost/test_default/search?query=milk")
               .to_return(status: 200, body: webmock_fixture("lod_lang_search_enfrde.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
             lod_lang_multi_defaults.search('milk')
           end
-          it "is filtered to default" do
+          it "is filtered to authority defined languages" do
             expect(results.first[:label]).to eq('[buttermilk, Babeurre] (yummy, délicieux)')
             expect(results.second[:label]).to eq('[condensed milk, lait condensé] (creamy, crémeux)')
             expect(results.third[:label]).to eq('[dried milk, lait en poudre] (powdery, poudreux)')
           end
         end
 
-        context "and lang IS passed in" do
+        context "and language IS passed in to search" do
           let(:lod_lang_defaults) { described_class.new(:LOD_LANG_DEFAULTS) }
           let :results do
             stub_request(:get, "http://localhost/test_default/search?query=milk")
@@ -313,46 +338,71 @@ RSpec.describe Qa::Authorities::LinkedData::GenericAuthority do
     describe "language processing" do
       context "when filtering #find result" do
         context "and lang NOT passed in" do
-          context "and NO default defined in config" do
-            let(:lod_lang_no_defaults) { described_class.new(:LOD_LANG_NO_DEFAULTS) }
-            let :results do
-              stub_request(:get, "http://localhost/test_no_default/term/c_9513")
-                .to_return(status: 200, body: webmock_fixture("lod_lang_term_enfr.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
-              lod_lang_no_defaults.find('c_9513')
+          context "and NO language defined in authority config" do
+            context "and NO language defined in Qa config" do
+              let(:lod_lang_no_defaults) { described_class.new(:LOD_LANG_NO_DEFAULTS) }
+              let :results do
+                stub_request(:get, "http://localhost/test_no_default/term/c_9513")
+                  .to_return(status: 200, body: webmock_fixture("lod_lang_term_enfr.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
+                lod_lang_no_defaults.find('c_9513')
+              end
+
+              before do
+                Qa.config.default_language = []
+              end
+
+              after do
+                Qa.config.default_language = :en
+              end
+
+              it "is not filtered" do
+                expect(results[:label]).to eq ['buttermilk', 'Babeurre']
+                expect(results[:altlabel]).to eq ['yummy', 'délicieux']
+                expect(results["predicates"]["http://www.w3.org/2004/02/skos/core#prefLabel"]).to include("buttermilk", "Babeurre")
+                expect(results["predicates"]["http://www.w3.org/2004/02/skos/core#altLabel"]).to include("yummy", "délicieux")
+              end
             end
-            it "is not filtered" do
-              expect(results[:label]).to eq ['buttermilk', 'Babeurre']
-              expect(results[:altlabel]).to eq ['yummy', 'délicieux']
-              expect(results["predicates"]["http://www.w3.org/2004/02/skos/core#prefLabel"]).to include("buttermilk", "Babeurre")
-              expect(results["predicates"]["http://www.w3.org/2004/02/skos/core#altLabel"]).to include("yummy", "délicieux")
+            context "and default_language is defined in Qa config" do
+              let(:lod_lang_no_defaults) { described_class.new(:LOD_LANG_NO_DEFAULTS) }
+              let :results do
+                stub_request(:get, "http://localhost/test_no_default/term/c_9513")
+                  .to_return(status: 200, body: webmock_fixture("lod_lang_term_enfr.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
+                lod_lang_no_defaults.find('c_9513')
+              end
+              it "filters using Qa configured default for summary but not for predicates list" do
+                expect(results[:label]).to eq ['buttermilk']
+                expect(results[:altlabel]).to eq ['yummy']
+                expect(results["predicates"]["http://www.w3.org/2004/02/skos/core#prefLabel"]).to include("buttermilk", "Babeurre")
+                expect(results["predicates"]["http://www.w3.org/2004/02/skos/core#altLabel"]).to include("yummy", "délicieux")
+              end
             end
           end
-          context "and default IS defined in config" do
+          context "and language IS defined in authority config" do
             let(:lod_lang_defaults) { described_class.new(:LOD_LANG_DEFAULTS) }
             let :results do
               stub_request(:get, "http://localhost/test_default/term/c_9513")
                 .to_return(status: 200, body: webmock_fixture("lod_lang_term_enfr.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
               lod_lang_defaults.find('c_9513')
             end
-            it "is filtered to default" do
-              expect(results[:label]).to eq ['buttermilk']
-              expect(results[:altlabel]).to eq ['yummy']
-              expect(results["predicates"]["http://www.w3.org/2004/02/skos/core#prefLabel"]).to eq ['buttermilk']
-              expect(results["predicates"]["http://www.w3.org/2004/02/skos/core#altLabel"]).to eq ['yummy']
+            it "filters using authority configured language for summary but not for predicates list" do
+              expect(results[:label]).to eq ['Babeurre']
+              expect(results[:altlabel]).to eq ['délicieux']
+              expect(results["predicates"]["http://www.w3.org/2004/02/skos/core#prefLabel"]).to include("buttermilk", "Babeurre")
+              expect(results["predicates"]["http://www.w3.org/2004/02/skos/core#altLabel"]).to include("yummy", "délicieux")
             end
           end
-          context "and multiple defaults ARE defined in config" do
+          context "and multiple languages ARE defined in authority config" do
             let(:lod_lang_multi_defaults) { described_class.new(:LOD_LANG_MULTI_DEFAULTS) }
             let :results do
               stub_request(:get, "http://localhost/test_default/term/c_9513")
                 .to_return(status: 200, body: webmock_fixture("lod_lang_term_enfrde.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
               lod_lang_multi_defaults.find('c_9513')
             end
-            it "is filtered to default" do
+            it "filters using authority configured languages for summary but not for predicates list" do
               expect(results[:label]).to eq ['buttermilk', 'Babeurre']
               expect(results[:altlabel]).to eq ['yummy', 'délicieux']
-              expect(results["predicates"]["http://www.w3.org/2004/02/skos/core#prefLabel"]).to include("buttermilk", "Babeurre")
-              expect(results["predicates"]["http://www.w3.org/2004/02/skos/core#altLabel"]).to include("yummy", "délicieux")
+              expect(results["predicates"]["http://www.w3.org/2004/02/skos/core#prefLabel"]).to include("buttermilk", "Babeurre", "Buttermilch")
+              expect(results["predicates"]["http://www.w3.org/2004/02/skos/core#altLabel"]).to include("yummy", "délicieux", "lecker")
             end
           end
         end
@@ -367,8 +417,8 @@ RSpec.describe Qa::Authorities::LinkedData::GenericAuthority do
           it "is filtered to specified language" do
             expect(results[:label]).to eq ['Babeurre']
             expect(results[:altlabel]).to eq ['délicieux']
-            expect(results["predicates"]["http://www.w3.org/2004/02/skos/core#prefLabel"]).to eq ['Babeurre']
-            expect(results["predicates"]["http://www.w3.org/2004/02/skos/core#altLabel"]).to eq ['délicieux']
+            expect(results["predicates"]["http://www.w3.org/2004/02/skos/core#prefLabel"]).to include("buttermilk", "Babeurre")
+            expect(results["predicates"]["http://www.w3.org/2004/02/skos/core#altLabel"]).to include("yummy", "délicieux")
           end
         end
 
@@ -381,7 +431,7 @@ RSpec.describe Qa::Authorities::LinkedData::GenericAuthority do
           end
           it "is filtered to specified language" do
             expect(results[:label]).to eq ['Babeurre']
-            expect(results["predicates"]["http://www.w3.org/2004/02/skos/core#prefLabel"]).to eq ['Babeurre']
+            expect(results["predicates"]["http://www.w3.org/2004/02/skos/core#prefLabel"]).to include("buttermilk", "Babeurre")
           end
         end
 

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -1,12 +1,7 @@
+require 'spec_helper'
+
 RSpec.describe Qa::Configuration do
   subject { described_class.new }
-
-  it { is_expected.to respond_to(:cors_headers?) }
-  it { is_expected.to respond_to(:enable_cors_headers) }
-  it { is_expected.to respond_to(:disable_cors_headers) }
-  it { is_expected.to respond_to(:authorized_reload_token=) }
-  it { is_expected.to respond_to(:authorized_reload_token) }
-  it { is_expected.to respond_to(:valid_authority_reload_token?) }
 
   describe '#enable_cors_headers' do
     it 'turns on cors headers support' do
@@ -52,6 +47,24 @@ RSpec.describe Qa::Configuration do
 
       it 'returns false if the passed in token does not match' do
         expect(subject.valid_authority_reload_token?('BAD TOKEN')).to be false
+      end
+    end
+  end
+
+  describe '#default_language' do
+    context 'when NOT configured' do
+      it 'returns :en as the default language' do
+        expect(subject.default_language).to be :en
+      end
+    end
+
+    context 'when configured' do
+      before do
+        subject.default_language = [:fr]
+      end
+
+      it 'returns the configured default language' do
+        expect(subject.default_language).to match_array [:fr]
       end
     end
   end

--- a/spec/services/linked_data/language_service_spec.rb
+++ b/spec/services/linked_data/language_service_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+RSpec.describe Qa::LinkedData::LanguageService do
+  describe '.preferred_language' do
+    subject { described_class.preferred_language(user_language: user_language, authority_language: authority_language) }
+
+    let(:user_language) { nil }
+    let(:authority_language) { nil }
+
+    context 'when neither user nor authority language are passed in' do
+      it 'returns default language from Qa configuration' do
+        expect(subject).to match_array [:en]
+      end
+    end
+
+    context 'when authority language is passed in and user language is NOT passed in' do
+      let(:authority_language) { :fr }
+
+      it 'returns authority language' do
+        expect(subject).to match_array [:fr]
+      end
+    end
+
+    context 'when user and authority language are passed in' do
+      let(:user_language) { :de }
+      let(:authority_language) { :fr }
+
+      it 'returns user language' do
+        expect(subject).to match_array [:de]
+      end
+    end
+
+    context 'when multiple languages' do
+      let(:user_language) { [:de, :fr] }
+
+      it 'returns multiple languages' do
+        expect(subject).to match_array [:de, :fr]
+      end
+    end
+  end
+
+  describe '.literal_has_language_marker?' do
+    subject { described_class.literal_has_language_marker? literal }
+
+    context "when doesn't respond to language" do
+      let(:literal) { RDF::Literal.new(123) }
+      it 'returns false' do
+        expect(subject).to eq false
+      end
+    end
+
+    context "when doesn't have language marker" do
+      let(:literal) { RDF::Literal.new('String without language') }
+      it 'returns false' do
+        expect(subject).to eq false
+      end
+    end
+
+    context "when has language marker" do
+      let(:literal) { RDF::Literal.new('String with language', language: :en) }
+      it 'returns true' do
+        expect(subject).to eq true
+      end
+    end
+  end
+end


### PR DESCRIPTION
The default language can be set to nil to have all languages returned.

This modifies the filter algorithm to include literals not matching the preferred language in the case where there are no literals matching the preferred language for a predicate.  Better to return the non-preferred language value than no value at all.