### PR TITLE
update ruby/rails matrix for travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
+  - 2.4.5
+  - 2.5.3
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
   matrix:
     - "RAILS_VERSION=5.0.7"
     - "RAILS_VERSION=5.1.6"
-    - "RAILS_VERSION=5.2.1"
+    - "RAILS_VERSION=5.2.2"
 
 before_install:
   - gem update --system


### PR DESCRIPTION
The latest version of bundler does not work with ruby 2.3.7 causing Travis to fail.  Other Samvera gems do not include this version of ruby in their Travis test matrix, so it is being removed.  Other versions of ruby and rails were updated to the latest in their minor versioning track.