### PR TITLE
add ability to encode the variable value

### DIFF
--- a/app/models/qa/iri_template/variable_map.rb
+++ b/app/models/qa/iri_template/variable_map.rb
@@ -1,29 +1,30 @@
 # Provide access to iri template variable map configuration.
 # See https://www.hydra-cg.com/spec/latest/core/#templated-links for information on IRI Templated Links - Variable Mapping.
 # TODO: It would be good to find a more complete resource describing templated links.
+require 'erb'
+
 module Qa
   module IriTemplate
     class VariableMap
+      include ERB::Util
+
       TYPE = "IriTemplateMapping".freeze
       attr_reader :variable
       attr_reader :default
+      private :default
 
       # @param [Hash] map configuration hash for the variable map
-      # @option map [String] :variable name of the variable in the template (e.g. {?query} has the name 'query')
-      # @option map [String] :property always "hydra:freetextQuery" # TODO what other values are supported and what do they mean
-      # @option map [True | False] :required is this variable required
-      # @option map [String] :default value to use if a value is not provided in the request
+      # @option map [String] :variable (required) name of the variable in the template (e.g. {?query} has the name 'query')
+      # @option map [String] :property (optional) always "hydra:freetextQuery" # TODO what other values are supported and what do they mean
+      # @option map [Boolean] :required (required) is this variable required
+      # @option map [String] :default (optional) value to use if a value is not provided in the request (default: '')
+      # @option map [Boolean] :encode (optional) whether to url_encode the value (default: false)
       def initialize(map)
         @variable = extract_variable(config: map)
         @required = extract_required(config: map)
         @default = extract_default(config: map)
+        @encode = extract_encode(config: map)
         @property = map.fetch(:property, 'hydra:freetextQuery')
-      end
-
-      # Is this variable required?
-      # @returns true if required; otherwise, false
-      def required?
-        @required
       end
 
       # TODO: When implementing more complex query substitution, simple_value is used when template url specifies variable as {var_name}.
@@ -31,9 +32,11 @@ module Qa
       # @param [Object] value to use if it exists
       # @returns the value to use (e.g. 'fr')
       def simple_value(sub_value = nil)
-        return sub_value.to_s if sub_value.present?
-        raise Qa::IriTemplate::MissingParameter, "#{variable} is required, but missing" if required?
-        default
+        raise Qa::IriTemplate::MissingParameter, "#{variable} is required, but missing" if sub_value.blank? && required?
+        return default if sub_value.blank?
+        sub_value = sub_value.to_s
+        sub_value = url_encode(sub_value).gsub(".", "%2E") if encode?
+        sub_value
       end
 
       # TODO: When implementing more complex query substitution, parameter_value is used when template url specifies variable as {?var_name}.
@@ -47,6 +50,18 @@ module Qa
       # end
 
       private
+
+        # Is this variable required?
+        # @returns true if required; otherwise, false
+        def required?
+          @required
+        end
+
+        # Should the variable's value be encoded?
+        # @returns true if should encode; otherwise, false
+        def encode?
+          @encode
+        end
 
         # Extract the variable name from the config
         # @param config [Hash] configuration (json) holding the variable map
@@ -71,6 +86,15 @@ module Qa
         # @return [String] default value to use for the variable; defaults to empty string
         def extract_default(config:)
           config.fetch(:default, '').to_s
+        end
+
+        # Extract whether the value should be encoded
+        # @param config [Hash] configuration (json) holding the variable map
+        # @return [True | False] encode as true or false
+        def extract_encode(config:)
+          encode = config.fetch(:encode, false)
+          raise Qa::InvalidConfiguration, 'encode must be true or false' unless encode == true || encode == false
+          encode
         end
     end
   end

--- a/spec/models/iri_template/variable_map_spec.rb
+++ b/spec/models/iri_template/variable_map_spec.rb
@@ -16,8 +16,6 @@ RSpec.describe Qa::IriTemplate::VariableMap do
     it { is_expected.to respond_to :variable }
     it { is_expected.to respond_to :simple_value }
     # it { is_expected.to respond_to :parameter_value }
-    it { is_expected.to respond_to :required? }
-    it { is_expected.to respond_to :default }
   end
 
   describe '#initialize' do
@@ -45,46 +43,6 @@ RSpec.describe Qa::IriTemplate::VariableMap do
   describe '#variable' do
     it 'returns the configured variable' do
       expect(subject.variable).to eq 'subauth'
-    end
-  end
-
-  describe '#required' do
-    context 'when map variable is required' do
-      before do
-        map[:required] = true
-      end
-
-      it 'returns true when map variable is required' do
-        expect(subject.required?).to be true
-      end
-    end
-
-    context 'when map variable is required' do
-      before do
-        map[:required] = false
-      end
-
-      it 'returns false when map variable is not required' do
-        expect(subject.required?).to be false
-      end
-    end
-  end
-
-  describe '#default' do
-    context 'when default is not defined' do
-      it 'returns empty string' do
-        expect(subject.default).to eq ''
-      end
-    end
-
-    context 'when default is defined' do
-      before do
-        map[:default] = 'personal_name'
-      end
-
-      it 'returns configured default value' do
-        expect(subject.default).to eq 'personal_name'
-      end
     end
   end
 
@@ -131,6 +89,16 @@ RSpec.describe Qa::IriTemplate::VariableMap do
 
       it 'returns passed in sub_value' do
         expect(subject.simple_value('corporate_name')).to eq 'corporate_name'
+      end
+    end
+
+    context 'when sub_value should be encoded' do
+      before do
+        map[:encode] = true
+      end
+
+      it 'returns encoded sub_value' do
+        expect(subject.simple_value('http://example.org/over/the_rainbow')).to eq 'http%3A%2F%2Fexample%2Eorg%2Fover%2Fthe_rainbow'
       end
     end
   end


### PR DESCRIPTION
Encoding is primarily used to encode URIs that are part of the URL path instead of being a parameter.  But the generalized processing allows any variable to be marked as requiring URL encoding.

Also making all methods private unless they are needed in other classes.  In this refactor, that effect #default and #required?

The encoding support was in the original term_url_with_replacements which is obsolete with PR #187.  That functionality should have been pulled into variable maps then.  This PR incorporates this functionality in a broader way that allows any variable to be encoded based on configurations.