### PR TITLE
Fix deprecation

### DIFF
--- a/lib/qa/authorities/loc/generic_authority.rb
+++ b/lib/qa/authorities/loc/generic_authority.rb
@@ -24,8 +24,8 @@ module Qa::Authorities
     end
 
     def build_query_url(q)
-      escaped_query = CGI.escape(q)
-      authority_fragment = "#{Loc.get_url_for_authority(subauthority)}#{CGI.escape(subauthority)}"
+      escaped_query = get_escaped_val(q)
+      authority_fragment = "#{Loc.get_url_for_authority(subauthority)}#{get_escaped_val(subauthority)}"
       "http://id.loc.gov/search/?q=#{escaped_query}&q=#{authority_fragment}&format=json"
     end
 

--- a/lib/qa/authorities/loc/generic_authority.rb
+++ b/lib/qa/authorities/loc/generic_authority.rb
@@ -24,8 +24,8 @@ module Qa::Authorities
     end
 
     def build_query_url(q)
-      escaped_query = URI.escape(q)
-      authority_fragment = Loc.get_url_for_authority(subauthority) + URI.escape(subauthority)
+      escaped_query = CGI.escape(q)
+      authority_fragment = "#{Loc.get_url_for_authority(subauthority)}#{CGI.escape(subauthority)}"
       "http://id.loc.gov/search/?q=#{escaped_query}&q=#{authority_fragment}&format=json"
     end
 

--- a/lib/qa/authorities/web_service_base.rb
+++ b/lib/qa/authorities/web_service_base.rb
@@ -1,5 +1,6 @@
 require 'faraday'
-require 'rubygems' #Require ruby gems in case this requires backwards compatibility for pre 1.9.0
+require 'rubygems'
+# Require ruby gems in case this requires backwards compatibility for pre 1.9.0
 module Qa::Authorities
   ##
   # Mix-in to retreive and parse JSON content from the web with Faraday.
@@ -36,13 +37,11 @@ module Qa::Authorities
     end
 
     def get_escaped_val(val)
-      escaped_val = ""
       if ::Gem::Version.new(RUBY_VERSION) < ::Gem::Version.new('2.4.0')
-        escaped_val = URI.escape(val)
+        URI.escape(val)
       else
-        escaped_val = CGI.escape(val)
+        CGI.escape(val)
       end
-      escaped_val
     end
   end
 end

--- a/lib/qa/authorities/web_service_base.rb
+++ b/lib/qa/authorities/web_service_base.rb
@@ -1,5 +1,5 @@
 require 'faraday'
-
+require 'rubygems' #Require ruby gems in case this requires backwards compatibility for pre 1.9.0
 module Qa::Authorities
   ##
   # Mix-in to retreive and parse JSON content from the web with Faraday.
@@ -33,6 +33,16 @@ module Qa::Authorities
     # @return [Faraday::Response]
     def response(url)
       Faraday.get(url) { |req| req.headers['Accept'] = 'application/json' }
+    end
+
+    def get_escaped_val(val)
+      escaped_val = ""
+      if ::Gem::Version.new(RUBY_VERSION) < ::Gem::Version.new('2.4.0')
+        escaped_val = URI.escape(val)
+      else
+        escaped_val = CGI.escape(val)
+      end
+      escaped_val
     end
   end
 end

--- a/qa.gemspec
+++ b/qa.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rspec-rails'
-  s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'swagger-docs'
   s.add_development_dependency 'webmock'


### PR DESCRIPTION
I'm currently refactoring one of our gems and qa v2.2. However when running the tests I kept getting 

```/home/bbarber/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/qa-3.0.0/lib/qa/authorities/loc/generic_authority.rb:27:in `build_query_u
rl': warning: URI.escape is obsolete
/home/bbarber/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/qa-3.0.0/lib/qa/authorities/loc/generic_authority.rb:28:in `build_query_url'
: warning: URI.escape is obsolete
/home/bbarber/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/qa-3.0.0/lib/qa/authorities/loc/generic_authority.rb:27:in `build_query_url'
: warning: URI.escape is obsolete
/home/bbarber/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/gems/qa-3.0.0/lib/qa/authorities/loc/generic_authority.rb:28:in `build_query_url'
: warning: URI.escape is obsolete```

I bumped the version up in my `gemspec` to the latest release and found i was getting the same warnings in my tests 

Doing further research online I found on the ruby docs [here](https://ruby-doc.org/stdlib-2.4.0/libdoc/uri/rdoc/URI/Escape.html)  That as of 2.4.0 this method has been deprecated and is now obsolete. Since I am running on 2.4.5 I first was able to make a monkey patch in the gem. But my colleague advised me to inform the Samvera community about this. I also removed a duplicate declaration of `simplecov` that was listed in both the `gemspec` and the `Gemfile`

I was able to set up engine cart and run the specs and all of them passed.  I created a method in the web_service_base module that will maintain backwards compatibility for earlier ruby versions but for anyone using 2.4.0 and above it will use `CGI.escape` instead of `URI.escape`.