### PR TITLE
add configuration models for additional context

### DIFF
--- a/app/models/qa/iri_template/url_config.rb
+++ b/app/models/qa/iri_template/url_config.rb
@@ -15,9 +15,10 @@ module Qa
       # @option url_config [String] :variable_representation always "BasicRepresentation" # TODO what other values are supported and what do they mean
       # @option url_config [Array<Hash>] :mapping array of maps for use with a template (required)
       def initialize(url_config)
-        @template = extract_template(config: url_config)
-        @mapping = extract_mapping(config: url_config)
-        @variable_representation = url_config.fetch(:variable_representation, 'BasicRepresentation')
+        @url_config = url_config
+        @template = Qa::LinkedData::Config::Helper.fetch_required(url_config, :template, nil)
+        @mapping = extract_mapping
+        @variable_representation = Qa::LinkedData::Config::Helper.fetch(url_config, :variable_representation, 'BasicRepresentation')
       end
 
       # Selective extract substitution variable-value pairs from the provided substitutions.
@@ -33,21 +34,11 @@ module Qa
 
       private
 
-        # Extract the url template from the config
-        # @param config [Hash] configuration holding the template to be extracted
-        # @return [String] url template for accessing the authority
-        def extract_template(config:)
-          template = config.fetch(:template, nil)
-          raise Qa::InvalidConfiguration, "template is required" unless template
-          template
-        end
-
         # Initialize the variable maps
         # @param config [Hash] configuration holding the variable maps to be extracted
         # @return [Array<IriTemplate::Map>] array of the variable maps
-        def extract_mapping(config:)
-          mapping = config.fetch(:mapping, nil)
-          raise Qa::InvalidConfiguration, "mapping is required" unless mapping
+        def extract_mapping
+          mapping = Qa::LinkedData::Config::Helper.fetch_required(@url_config, :mapping, nil)
           raise Qa::InvalidConfiguration, "mapping must include at least one map" if mapping.empty?
           mapping.collect { |m| Qa::IriTemplate::VariableMap.new(m) }
         end

--- a/app/models/qa/iri_template/variable_map.rb
+++ b/app/models/qa/iri_template/variable_map.rb
@@ -13,24 +13,24 @@ module Qa
       attr_reader :default
       private :default
 
-      # @param [Hash] map configuration hash for the variable map
-      # @option map [String] :variable (required) name of the variable in the template (e.g. {?query} has the name 'query')
-      # @option map [String] :property (optional) always "hydra:freetextQuery" # TODO what other values are supported and what do they mean
-      # @option map [Boolean] :required (required) is this variable required
-      # @option map [String] :default (optional) value to use if a value is not provided in the request (default: '')
-      # @option map [Boolean] :encode (optional) whether to url_encode the value (default: false)
-      def initialize(map)
-        @variable = extract_variable(config: map)
-        @required = extract_required(config: map)
-        @default = extract_default(config: map)
-        @encode = extract_encode(config: map)
-        @property = map.fetch(:property, 'hydra:freetextQuery')
+      # @param [Hash] variable_map configuration hash for the variable map
+      # @option variable_map [String] :variable (required) name of the variable in the template (e.g. {?query} has the name 'query')
+      # @option variable_map [String] :property (optional) always "hydra:freetextQuery" # TODO what other values are supported and what do they mean
+      # @option variable_map [Boolean] :required (required) is this variable required
+      # @option variable_map [String] :default (optional) value to use if a value is not provided in the request (default: '')
+      # @option variable_map [Boolean] :encode (optional) whether to url_encode the value (default: false)
+      def initialize(variable_map)
+        @variable = Qa::LinkedData::Config::Helper.fetch_required(variable_map, :variable, nil)
+        @required = Qa::LinkedData::Config::Helper.fetch_boolean(variable_map, :required, nil)
+        @default = Qa::LinkedData::Config::Helper.fetch(variable_map, :default, '').to_s
+        @encode = Qa::LinkedData::Config::Helper.fetch_boolean(variable_map, :encode, false)
+        @property = Qa::LinkedData::Config::Helper.fetch(variable_map, :property, 'hydra:freetextQuery')
       end
 
       # TODO: When implementing more complex query substitution, simple_value is used when template url specifies variable as {var_name}.
       # Value to use in substitution, using default if one isn't passed in
       # @param [Object] value to use if it exists
-      # @returns the value to use (e.g. 'fr')
+      # @return the value to use (e.g. 'fr')
       def simple_value(sub_value = nil)
         raise Qa::IriTemplate::MissingParameter, "#{variable} is required, but missing" if sub_value.blank? && required?
         return default if sub_value.blank?
@@ -42,7 +42,7 @@ module Qa
       # TODO: When implementing more complex query substitution, parameter_value is used when template url specifies variable as {?var_name}.
       # # Parameter and value to use in substitution, using default is one isn't passed in
       # # @param [Object] value to use if it exists
-      # # @returns the parameter and value to use (e.g. 'language=fr')
+      # # @return the parameter and value to use (e.g. 'language=fr')
       # def parameter_value(sub_value = nil)
       #   simple_value = simple_value(sub_value)
       #   return '' if simple_value.blank?
@@ -52,49 +52,15 @@ module Qa
       private
 
         # Is this variable required?
-        # @returns true if required; otherwise, false
+        # @return true if required; otherwise, false
         def required?
           @required
         end
 
         # Should the variable's value be encoded?
-        # @returns true if should encode; otherwise, false
+        # @return true if should encode; otherwise, false
         def encode?
           @encode
-        end
-
-        # Extract the variable name from the config
-        # @param config [Hash] configuration (json) holding the variable map
-        # @return [String] variable for substitution in the url tmeplate
-        def extract_variable(config:)
-          varname = config.fetch(:variable, nil)
-          raise Qa::InvalidConfiguration, 'variable is required' unless varname
-          varname
-        end
-
-        # Extract the variable name from the config
-        # @param config [Hash] configuration (json) holding the variable map
-        # @return [True | False] required as true or false
-        def extract_required(config:)
-          required = config.fetch(:required, nil)
-          raise Qa::InvalidConfiguration, 'required must be true or false' unless required == true || required == false
-          required
-        end
-
-        # Extract the default value from the config
-        # @param config [Hash] configuration (json) holding the variable map
-        # @return [String] default value to use for the variable; defaults to empty string
-        def extract_default(config:)
-          config.fetch(:default, '').to_s
-        end
-
-        # Extract whether the value should be encoded
-        # @param config [Hash] configuration (json) holding the variable map
-        # @return [True | False] encode as true or false
-        def extract_encode(config:)
-          encode = config.fetch(:encode, false)
-          raise Qa::InvalidConfiguration, 'encode must be true or false' unless encode == true || encode == false
-          encode
         end
     end
   end

--- a/app/models/qa/linked_data/config/context_map.rb
+++ b/app/models/qa/linked_data/config/context_map.rb
@@ -1,0 +1,75 @@
+# Defines the external authority predicates used to extract additional context from the graph.
+module Qa
+  module LinkedData
+    module Config
+      class ContextMap
+        attr_reader :properties # [Array<Qa::LinkedData::Config::ContextPropertyMap>] set of property map models
+
+        attr_reader :context_map, :groups
+        private :context_map, :groups
+
+        # @param [Hash] context_map that defines groups and properties for additional context to display during the selection process
+        # @option context_map [Hash] :groups (optional) predefine group ids and labels to be used in the properties section to group properties
+        # @option groups [Hash] key=group_id; value=[Hash] with group_label_i18n and/or group_label_default
+        # @option context_map [Array<Hash>] :properties (optional) property maps defining how to get and display the additional context (if none, context will not be added)
+        # @example
+        #   {
+        #     "groups": {
+        #       "dates": {
+        #         "group_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.dates",
+        #         "group_label_default": "Dates",
+        #       }
+        #     },
+        #     "properties": [
+        #       {
+        #         "property_label_i18n": "qa.linked_data.authority.locgenres_ld4l_cache.authoritative_label",
+        #         "property_label_default": "Authoritative Label",
+        #         "lpath": "madsrdf:authoritativeLabel",
+        #         "selectable": true,
+        #         "drillable": false
+        #       },
+        #       {
+        #         "group_id": "dates",
+        #         "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.birth_date",
+        #         "property_label_default": "Birth",
+        #         "lpath": "madsrdf:identifiesRWO/madsrdf:birthDate/schema:label",
+        #         "selectable": false,
+        #         "drillable": false
+        #       }
+        #     ]
+        #   }
+        def initialize(context_map = {})
+          @context_map = context_map
+          extract_groups
+          extract_properties
+        end
+
+        def group_label(group_id)
+          groups[group_id]
+        end
+
+        private
+
+          def extract_properties
+            @properties = []
+            properties_map = Qa::LinkedData::Config::Helper.fetch(context_map, :properties, {})
+            properties_map.each { |property_map| @properties << ContextPropertyMap.new(property_map) }
+          end
+
+          def extract_groups
+            @groups = {}
+            groups_map = Qa::LinkedData::Config::Helper.fetch(context_map, :groups, {})
+            groups_map.each { |group_id, group_map| add_group(group_id, group_map) }
+          end
+
+          def add_group(group_id, group_map)
+            return if groups.key? group_id
+            i18n_key = Qa::LinkedData::Config::Helper.fetch(group_map, :group_label_i18n, nil)
+            default = Qa::LinkedData::Config::Helper.fetch(group_map, :group_label_default, nil)
+            return groups[group_id] = I18n.t(i18n_key, default) if i18n_key.present?
+            groups[group_id] = default
+          end
+      end
+    end
+  end
+end

--- a/app/models/qa/linked_data/config/context_property_map.rb
+++ b/app/models/qa/linked_data/config/context_property_map.rb
@@ -1,0 +1,58 @@
+# Defines the external authority predicates used to extract additional context from the graph.
+module Qa
+  module LinkedData
+    module Config
+      class ContextPropertyMap
+        attr_reader :group_id, :label, :lpath
+        attr_reader :property_map
+        private :property_map
+
+        # @param [Hash] property_map defining information to return to provide context
+        # @option property_map [String] :group_id (optional) default label to use for a property (default: no label)
+        # @option property_map [String] :property_label_i18n (optional) i18n key to use to get the label for a property (default: property_label_default OR no label if neither are defined)
+        # @option property_map [String] :property_label_default (optional) default label to use for a property (default: no label)
+        # @option property_map [String] :lpath (required) i18n key to use to get the label for a property
+        # @option property_map [Boolean] :selectable (optional) if true, this property can selected as the value (default: false)
+        # @option property_map [Boolean] :drillable (optional) if true, the label for this property can be used to execute a second query allowing navi (default: false)
+        # @example property_map
+        #   {
+        #     "group_id": "dates",
+        #     "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.birth_date",
+        #     "property_label_default": "Birth",
+        #     "lpath": "madsrdf:identifiesRWO/madsrdf:birthDate/schema:label",
+        #     "selectable": false,
+        #     "drillable": false
+        #   }
+        def initialize(property_map = {})
+          @property_map = property_map
+          @group_id = Qa::LinkedData::Config::Helper.fetch_symbol(property_map, :group_id, nil)
+          @label = extract_label
+          @lpath = Qa::LinkedData::Config::Helper.fetch_required(property_map, :lpath, false)
+          @selectable = Qa::LinkedData::Config::Helper.fetch_boolean(property_map, :selectable, false)
+          @drillable = Qa::LinkedData::Config::Helper.fetch_boolean(property_map, :drillable, false)
+        end
+
+        # Can this property be the selected value?
+        # @return true if can be selected; otherwise, false
+        def selectable?
+          @selectable
+        end
+
+        # Can this property be used as a new query
+        # @return true if can be selected; otherwise, false
+        def drillable?
+          @drillable
+        end
+
+        private
+
+          def extract_label
+            i18n_key = Qa::LinkedData::Config::Helper.fetch(property_map, :property_label_i18n, nil)
+            default = Qa::LinkedData::Config::Helper.fetch(property_map, :property_label_default, nil)
+            return I18n.t(i18n_key, default) if i18n_key.present?
+            default
+          end
+      end
+    end
+  end
+end

--- a/app/models/qa/linked_data/config/helper.rb
+++ b/app/models/qa/linked_data/config/helper.rb
@@ -1,0 +1,34 @@
+# Provide helper method for common processing of configurations.
+module Qa
+  module LinkedData
+    module Config
+      class Helper
+        # Fetch a value from a hash map
+        def self.fetch(map, key, default)
+          map.fetch(key, default)
+        end
+
+        # Fetch a boolean value from a hash map throwing an exception if the value is not boolean
+        def self.fetch_boolean(map, key, default)
+          value = map.fetch(key, default)
+          raise Qa::InvalidConfiguration, "#{key} must be true or false" unless value == true || value == false
+          value
+        end
+
+        # Fetch a value from a hash map throwing an exception if the value is blank
+        def self.fetch_required(map, key, default)
+          value = map.fetch(key, default)
+          raise Qa::InvalidConfiguration, "#{key} is required" unless value
+          value
+        end
+
+        # Fetch a value from a hash map throwing an exception if the value is blank
+        def self.fetch_symbol(map, key, default)
+          value = map.fetch(key, default)
+          return value unless value.respond_to? :to_sym
+          value.to_sym
+        end
+      end
+    end
+  end
+end

--- a/app/services/qa/linked_data/deep_sort_service.rb
+++ b/app/services/qa/linked_data/deep_sort_service.rb
@@ -4,7 +4,7 @@ module Qa
     class DeepSortService
       # @params [Array<Hash<Symbol,Array<RDF::Literal>>>] the array of hashes to sort
       # @params [sort_key] the key in the hash on whose value the array will be sorted
-      # @returns instance of this class
+      # @return instance of this class
       # @example the_array parameter
       #   [
       #     {:uri=>[#<RDF::URI:0x3fcff54a829c URI:http://id.loc.gov/authorities/names/n2010043281>],
@@ -29,7 +29,7 @@ module Qa
       # * preference for numeric sort (if only one value each and both are integers or a string that can be converted to an integer)
       # * single value sort (if only one value each and at least one is not an integer)
       # * multiple values sort (if either has multiple values)
-      # @returns the sorted array
+      # @return the sorted array
       # @example returned sorted array
       #   [
       #     {:uri=>[#<RDF::URI:0x3fcff54a829c URI:http://id.loc.gov/authorities/names/n201002344>],
@@ -68,7 +68,7 @@ module Qa
           multiple_value_comparator(other)
         end
 
-        # @returns true if there is a single literal that is an integer or a string that can be converted to an integer; otherwise, false
+        # @return true if there is a single literal that is an integer or a string that can be converted to an integer; otherwise, false
         def integer?
           return false unless single?
           (/\A[-+]?\d+\z/ === literal.to_s) # rubocop:disable Style/CaseEquality
@@ -78,7 +78,7 @@ module Qa
           Integer(literal(idx).to_s)
         end
 
-        # @returns true if there is only one value; otherwise, false
+        # @return true if there is only one value; otherwise, false
         def single?
           @single ||= literals.size == 1
         end

--- a/spec/models/linked_data/config/context_map_spec.rb
+++ b/spec/models/linked_data/config/context_map_spec.rb
@@ -1,0 +1,131 @@
+require 'spec_helper'
+
+RSpec.describe Qa::LinkedData::Config::ContextMap do
+  subject { described_class.new(context_map) }
+
+  before do
+    # simulate the existence of the i18n entries
+    allow(I18n).to receive(:t).and_call_original
+    allow(I18n).to receive(:t).with('qa.linked_data.authority.locnames_ld4l_cache.dates', 'default_Dates').and_return('Dates')
+    allow(I18n).to receive(:t).with('qa.linked_data.authority.locnames_ld4l_cache.authoritative_label', 'default_Authoritative Label').and_return('Authoritative Label')
+    allow(I18n).to receive(:t).with('qa.linked_data.authority.locnames_ld4l_cache.birth_date', 'default_Birth').and_return('Birth')
+    allow(I18n).to receive(:t).with('qa.linked_data.authority.locnames_ld4l_cache.death_date', 'default_Death').and_return('Death')
+  end
+
+  let(:context_map) do
+    {
+      groups: {
+        dates: {
+          group_label_i18n: 'qa.linked_data.authority.locnames_ld4l_cache.dates',
+          group_label_default: 'default_Dates'
+        }
+      },
+      properties: [
+        {
+          property_label_i18n: 'qa.linked_data.authority.locgenres_ld4l_cache.authoritative_label',
+          property_label_default: 'default_Authoritative Label',
+          lpath: 'madsrdf:authoritativeLabel',
+          selectable: true,
+          drillable: false
+        },
+        {
+          group_id: 'dates',
+          property_label_i18n: 'qa.linked_data.authority.locnames_ld4l_cache.birth_date',
+          property_label_default: 'default_Birth',
+          lpath: 'madsrdf:identifiesRWO/madsrdf:birthDate/schema:label',
+          selectable: false,
+          drillable: false
+        },
+        {
+          group_id: 'dates',
+          property_label_i18n: 'qa.linked_data.authority.locnames_ld4l_cache.death_date',
+          property_label_default: 'default_Death',
+          lpath: 'madsrdf:identifiesRWO/madsrdf:deathDate/schema:label',
+          selectable: false,
+          drillable: false
+        }
+      ]
+    }
+  end
+
+  describe '#properties' do
+    it 'returns the configured url template' do
+      expect(subject.properties.size).to eq 3
+      expect(subject.properties.first).to be_kind_of Qa::LinkedData::Config::ContextPropertyMap
+    end
+  end
+
+  describe '#group_label' do
+    context 'when map defines group_label_i18n key' do
+      context 'and i18n translation is defined in locales' do
+        it 'returns the translated text' do
+          expect(subject.group_label(:dates)).to eq 'Dates'
+        end
+      end
+
+      context 'and i18n translation is NOT defined in locales' do
+        context 'and default is defined in the map' do
+          before do
+            allow(I18n).to receive(:t).with('qa.linked_data.authority.locnames_ld4l_cache.dates', 'default_Dates').and_return('default_Dates')
+          end
+
+          it 'returns the default value' do
+            expect(subject.group_label(:dates)).to eq 'default_Dates'
+          end
+        end
+
+        context 'and default is NOT defined in the map' do
+          let(:groups) do
+            {
+              dates: {
+                group_label_i18n: 'qa.linked_data.authority.locnames_ld4l_cache.dates'
+              }
+            }
+          end
+          before do
+            context_map[:groups] = groups
+            allow(I18n).to receive(:t).with('qa.linked_data.authority.locnames_ld4l_cache.dates', nil).and_return(nil)
+          end
+
+          it 'returns nil' do
+            expect(subject.group_label(:dates)).to eq nil
+          end
+        end
+      end
+    end
+
+    context 'when map does NOT define group_label_i18n key' do
+      context 'and default is defined in map' do
+        let(:groups) do
+          {
+            dates: {
+              group_label_default: 'default_Dates'
+            }
+          }
+        end
+        before do
+          context_map[:groups] = groups
+        end
+
+        it 'returns the default value' do
+          expect(subject.group_label(:dates)).to eq 'default_Dates'
+        end
+      end
+
+      context 'and default is NOT defined in map' do
+        let(:groups) do
+          {
+            dates: {}
+          }
+        end
+        before do
+          context_map[:groups] = groups
+        end
+
+        it 'returns nil' do
+          expect(subject.group_label(:dates)).to eq nil
+        end
+      end
+    end
+  end
+end

--- a/spec/models/linked_data/config/context_property_map_spec.rb
+++ b/spec/models/linked_data/config/context_property_map_spec.rb
@@ -1,0 +1,169 @@
+require 'spec_helper'
+
+RSpec.describe Qa::LinkedData::Config::ContextPropertyMap do
+  subject { described_class.new(property_map) }
+
+  let(:property_map) do
+    {
+      group_id: 'dates',
+      property_label_i18n: 'qa.linked_data.authority.locnames_ld4l_cache.birth_date',
+      property_label_default: 'default_Birth',
+      lpath: 'madsrdf:identifiesRWO/madsrdf:birthDate/schema:label',
+      selectable: false,
+      drillable: false
+    }
+  end
+
+  describe 'model attributes' do
+    it { is_expected.to respond_to :lpath }
+  end
+
+  describe '#initialize' do
+    context 'when lpath is missing' do
+      before { property_map.delete(:lpath) }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(Qa::InvalidConfiguration, 'lpath is required')
+      end
+    end
+
+    context 'when invalid selectable value' do
+      before { property_map[:selectable] = 'INVALID' }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(Qa::InvalidConfiguration, 'selectable must be true or false')
+      end
+    end
+
+    context 'when invalid drillable value' do
+      before { property_map[:drillable] = 'INVALID' }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(Qa::InvalidConfiguration, 'drillable must be true or false')
+      end
+    end
+  end
+
+  describe '#selectable?' do
+    context 'when map has selectable: true' do
+      before { property_map[:selectable] = true }
+
+      it 'returns true' do
+        expect(subject.selectable?).to be true
+      end
+    end
+
+    context 'when map has selectable: false' do
+      before { property_map[:selectable] = false }
+
+      it 'returns false' do
+        expect(subject.selectable?).to be false
+      end
+    end
+
+    context 'when selectable: is not defined in the map' do
+      before { property_map.delete(:selectable) }
+
+      it 'returns false' do
+        expect(subject.selectable?).to be false
+      end
+    end
+  end
+
+  describe '#drillable?' do
+    context 'when map has drillable: true' do
+      before { property_map[:drillable] = true }
+
+      it 'returns true' do
+        expect(subject.drillable?).to be true
+      end
+    end
+
+    context 'when map has drillable: false' do
+      before { property_map[:drillable] = false }
+
+      it 'returns false' do
+        expect(subject.drillable?).to be false
+      end
+    end
+
+    context 'when drillable: is not defined in the map' do
+      before { property_map.delete(:drillable) }
+
+      it 'returns false' do
+        expect(subject.drillable?).to be false
+      end
+    end
+  end
+
+  describe '#label' do
+    context 'when map defines property_label_i18n key' do
+      context 'and i18n translation is defined in locales' do
+        before do
+          allow(I18n).to receive(:t).with('qa.linked_data.authority.locnames_ld4l_cache.birth_date', 'default_Birth').and_return('Birth')
+        end
+
+        it 'returns the translated text' do
+          expect(subject.label).to eq 'Birth'
+        end
+      end
+
+      context 'and i18n translation is NOT defined in locales' do
+        context 'and default is defined in the map' do
+          before do
+            allow(I18n).to receive(:t).with('qa.linked_data.authority.locnames_ld4l_cache.birth_date', 'default_Birth').and_return('default_Birth')
+          end
+
+          it 'returns the default value' do
+            expect(subject.label).to eq 'default_Birth'
+          end
+        end
+
+        context 'and default is NOT defined in the map' do
+          before do
+            property_map.delete(:property_label_default)
+            allow(I18n).to receive(:t).with('qa.linked_data.authority.locnames_ld4l_cache.birth_date', nil).and_return(nil)
+          end
+
+          it 'returns nil' do
+            expect(subject.label).to eq nil
+          end
+        end
+      end
+    end
+
+    context 'when map does NOT define property_label_i18n key' do
+      before { property_map.delete(:property_label_i18n) }
+
+      context 'and default is defined in map' do
+        it 'returns the default value' do
+          expect(subject.label).to eq 'default_Birth'
+        end
+      end
+
+      context 'and default is NOT defined in map' do
+        before { property_map.delete(:property_label_default) }
+
+        it 'returns nil' do
+          expect(subject.label).to eq nil
+        end
+      end
+    end
+  end
+
+  describe '#group_id' do
+    context 'when map defines group_id' do
+      it 'returns group_id as a symbol' do
+        expect(subject.group_id).to eq :dates
+      end
+    end
+
+    context 'when map does NOT define group_id' do
+      before { property_map.delete(:group_id) }
+
+      it 'returns nil' do
+        expect(subject.group_id).to eq nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
These are the classes to process the context configuration.  They are not being used yet.

Remaining work:
* In search_config, read in and process the context configuration using these classes
* Add context_mapping_service, which will use these configurations to extract the context from the graph and return the results as json.

This PR also defines generalized helper methods for fetching configs from the config hash.  This includes fetching required configs, boolean configs, and configs values that need to be converted to a symbol.

