### PR TITLE
create url_config and context_map only once

### DIFF
--- a/app/models/qa/linked_data/config/context_map.rb
+++ b/app/models/qa/linked_data/config/context_map.rb
@@ -17,7 +17,7 @@ module Qa
         #     "groups": {
         #       "dates": {
         #         "group_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.dates",
-        #         "group_label_default": "Dates",
+        #         "group_label_default": "Dates"
         #       }
         #     },
         #     "properties": [

--- a/app/services/qa/linked_data/authority_url_service.rb
+++ b/app/services/qa/linked_data/authority_url_service.rb
@@ -2,59 +2,47 @@
 module Qa
   module LinkedData
     class AuthorityUrlService
-      # Build a url for an authority/subauthority for the specified action.
-      # @param authority [Symbol] name of a registered authority
-      # @param subauthority [String] name of a subauthority
-      # @param action [Symbol] action with valid values :search or :term
-      # @param action_request [String] the request the user is making of the authority (e.g. query text or term id/uri)
-      # @param substitutions [Hash] variable-value pairs to substitute into the URL template
-      # @return a valid URL the submits the action request to the external authority
-      def self.build_url(action_config:, action:, action_request:, substitutions: {}, subauthority: nil)
-        action_validation(action)
-        url_config = Qa::IriTemplate::UrlConfig.new(action_url(action_config, action))
-        selected_substitutions = url_config.extract_substitutions(substitutions)
-        selected_substitutions[action_request_variable(action_config, action)] = action_request
-        selected_substitutions[action_subauth_variable(action_config, action)] = action_subauth_variable_value(action_config, subauthority, action) if subauthority.present?
-
-        Qa::IriTemplateService.build_url(url_config: url_config, substitutions: selected_substitutions)
-      end
-
-      def self.action_validation(action)
-        return if [:search, :term].include? action
-        raise Qa::UnsupportedAction, "#{action} Not Supported - Action must be one of the supported actions (e.g. :term, :search)"
-      end
-      private_class_method :action_validation
-
-      # TODO: elr - rename search and term config methods to be the same to avoid all the ternary checks
-      def self.action_url(auth_config, action)
-        action == :search ? auth_config.url : auth_config.term_url
-      end
-      private_class_method :action_url
-
-      def self.action_request_variable(action_config, action)
-        key = action == :search ? :query : :term_id
-        action == :search ? action_config.qa_replacement_patterns[key] : action_config.term_qa_replacement_patterns[key]
-      end
-      private_class_method :action_request_variable
-
-      def self.action_subauth_variable(action_config, action)
-        action == :search ? action_config.qa_replacement_patterns[:subauth] : action_config.term_qa_replacement_patterns[:subauth]
-      end
-      private_class_method :action_subauth_variable
-
-      def self.action_subauth_variable_value(action_config, subauthority, action)
-        case action
-        when :search
-          pattern = action_subauth_variable(action_config, action)
-          default = action_config.url_mappings[pattern.to_sym][:default]
-          action_config.subauthorities[subauthority.to_sym] || default
-        when :term
-          pattern = action_subauth_variable(action_config, action)
-          default = action_config.term_url_mappings[pattern.to_sym][:default]
-          action_config.term_subauthorities[subauthority.to_sym] || default
+      class << self
+        # Build a url for an authority/subauthority for the specified action.
+        # @param authority [Symbol] name of a registered authority
+        # @param subauthority [String] name of a subauthority
+        # @param action [Symbol] action with valid values :search or :term
+        # @param action_request [String] the request the user is making of the authority (e.g. query text or term id/uri)
+        # @param substitutions [Hash] variable-value pairs to substitute into the URL template
+        # @return a valid URL the submits the action request to the external authority
+        def build_url(action_config:, action:, action_request:, substitutions: {}, subauthority: nil)
+          action_validation(action)
+          url_config = action_config.url_config
+          selected_substitutions = url_config.extract_substitutions(combined_substitutions(action_config, action, action_request, substitutions, subauthority))
+          Qa::IriTemplateService.build_url(url_config: url_config, substitutions: selected_substitutions)
         end
+
+        private
+
+          def action_validation(action)
+            return if [:search, :term].include? action
+            raise Qa::UnsupportedAction, "#{action} Not Supported - Action must be one of the supported actions (e.g. :term, :search)"
+          end
+
+          def combined_substitutions(action_config, action, action_request, substitutions, subauthority)
+            substitutions[action_request_variable(action_config, action)] = action_request
+            substitutions[action_subauth_variable(action_config)] = action_subauth_variable_value(action_config, subauthority) if subauthority.present?
+            substitutions
+          end
+
+          def action_request_variable(action_config, action)
+            key = action == :search ? :query : :term_id
+            action_config.qa_replacement_patterns[key]
+          end
+
+          def action_subauth_variable(action_config)
+            action_config.qa_replacement_patterns[:subauth]
+          end
+
+          def action_subauth_variable_value(action_config, subauthority)
+            action_config.subauthorities[subauthority.to_sym]
+          end
       end
-      private_class_method :action_subauth_variable_value
     end
   end
 end

--- a/lib/qa/authorities/linked_data/config/search_config.rb
+++ b/lib/qa/authorities/linked_data/config/search_config.rb
@@ -19,26 +19,10 @@ module Qa::Authorities
         search_config.present?
       end
 
-      # Return search url encoding defined in the configuration for this authority
-      # if it was provided
-      # @return [Hash,NilClass] the configured search url
-      def url
-        search_config[:url]
-      end
-
       # Return search url template defined in the configuration for this authority.
-      # @return [String] the configured search url template
-      def url_template
-        url.fetch(:template)
-      end
-
-      # Return search url parameter mapping defined in the configuration for this authority.
-      # @return [Hash] the configured search url parameter mappings with variable name as key
-      def url_mappings
-        return @url_mappings unless @url_mappings.nil?
-        mappings = Config.config_value(url, :mapping)
-        return {} if mappings.nil?
-        Hash[*mappings.collect { |m| [m[:variable].to_sym, m] }.flatten]
+      # @return [Qa::IriTemplate::UrlConfig] the configured search url template
+      def url_config
+        @url_config ||= Qa::IriTemplate::UrlConfig.new(search_config[:url]) if supports_search?
       end
 
       # Return the preferred language for literal value selection for search query.
@@ -89,31 +73,26 @@ module Qa::Authorities
         Config.predicate_uri(results, :sort_predicate)
       end
 
+      # Does this authority configuration support additional context in search results?
+      # @return [True|False] true if additional context in search results is supported; otherwise, false
+      def supports_context?
+        return true if context_map.present?
+        false
+      end
+
+      # Return the context map if it is defined
+      # @return [Qa::LinkedData::Config::ContextMap] the context map
+      def context_map
+        return @context_map if @context_map.present?
+        context_config = search_config.fetch(:context, {})
+        return nil if context_config.blank?
+        @context_map = Qa::LinkedData::Config::ContextMap.new(context_config)
+      end
+
       # Return parameters that are required for QA api
       # @return [Hash] the configured search url parameter mappings
       def qa_replacement_patterns
         search_config.fetch(:qa_replacement_patterns)
-      end
-
-      # Are there replacement parameters configured for search query?
-      # @return [True|False] true if there are replacement parameters configured for search query; otherwise, false
-      def replacements?
-        replacement_count.positive?
-      end
-
-      # Return the number of possible replacement values to make in the search URL
-      # @return [Integer] the configured number of possible replacements in the search url
-      def replacement_count
-        replacements.size
-      end
-
-      # Return the replacement configurations
-      # @return [Hash] the configurations for search url replacements
-      def replacements
-        return @replacements unless @replacements.nil?
-        @replacements = {}
-        @replacements = url_mappings.select { |k, _v| !qa_replacement_patterns.include?(k) } unless search_config.nil? || url_mappings.nil?
-        @replacements
       end
 
       # Are there subauthorities configured for search query?
@@ -140,16 +119,6 @@ module Qa::Authorities
       def subauthorities
         @subauthorities ||= {} if search_config.nil? || !(search_config.key? :subauthorities)
         @subauthorities ||= search_config.fetch(:subauthorities)
-      end
-
-      # Return the replacement configurations
-      # @return [Hash] the configurations for search url replacements
-      def subauthority_replacement_pattern
-        return {} unless subauthorities?
-        @subauthority_replacement_pattern ||= {} if search_config.nil? || !subauthorities?
-        pattern = qa_replacement_patterns[:subauth]
-        default = url_mappings[pattern.to_sym][:default]
-        @subauthority_replacement_pattern ||= { pattern: pattern, default: default }
       end
     end
   end

--- a/lib/qa/authorities/linked_data/config/term_config.rb
+++ b/lib/qa/authorities/linked_data/config/term_config.rb
@@ -19,25 +19,10 @@ module Qa::Authorities
         term_config.present?
       end
 
-      # Return term url encoding defined in the configuration for this authority.
-      # @return [Hash] the configured term url
-      def term_url
-        Config.config_value(term_config, :url)
-      end
-
       # Return term url template defined in the configuration for this authority.
-      # @return [String] the configured term url template
-      def term_url_template
-        Config.config_value(term_url, :template)
-      end
-
-      # Return term url parameter mapping defined in the configuration for this authority.
-      # @return [Hash] the configured term url parameter mappings with variable name as key
-      def term_url_mappings
-        return @term_url_mappings unless @term_url_mappings.nil?
-        mappings = Config.config_value(term_url, :mapping)
-        return {} if mappings.nil?
-        Hash[*mappings.collect { |m| [m[:variable].to_sym, m] }.flatten]
+      # @return [Qa::IriTemplate::UrlConfig] the configured term url template
+      def url_config
+        @url_config ||= Qa::IriTemplate::UrlConfig.new(term_config[:url]) if supports_term?
       end
 
       # Is the term_id substitution expected to be a URI?
@@ -111,27 +96,7 @@ module Qa::Authorities
       def term_qa_replacement_patterns
         Config.config_value(term_config, :qa_replacement_patterns)
       end
-
-      # Are there replacement parameters configured for term fetch?
-      # @return [Boolean] true if there are replacement parameters configured for term fetch; otherwise, false
-      def term_replacements?
-        term_replacement_count.positive?
-      end
-
-      # Return the number of possible replacement values to make in the term URL
-      # @return [Integer] the configured number of possible replacements in the term url
-      def term_replacement_count
-        term_replacements.size
-      end
-
-      # Return the replacement configurations
-      # @return [Hash] the configurations for term url replacements
-      def term_replacements
-        return @term_replacements unless @term_replacements.nil?
-        @term_replacements = {}
-        @term_replacements = term_url_mappings.select { |k, _v| !term_qa_replacement_patterns.value?(k.to_s) } unless term_config.nil? || term_url_mappings.nil?
-        @term_replacements
-      end
+      alias qa_replacement_patterns term_qa_replacement_patterns
 
       # Are there subauthorities configured for term fetch?
       # @return [True|False] true if there are subauthorities configured term fetch; otherwise, false
@@ -158,15 +123,7 @@ module Qa::Authorities
         @term_subauthorities ||= {} if term_config.nil? || !(term_config.key? :subauthorities)
         @term_subauthorities ||= term_config[:subauthorities]
       end
-
-      # Return the replacement configurations
-      # @return [Hash] the configurations for term url replacements
-      def term_subauthority_replacement_pattern
-        return {} unless term_subauthorities?
-        @term_subauthority_replacement_pattern ||= {} if term_config.nil? || !term_subauthorities?
-        pattern = term_qa_replacement_patterns[:subauth]
-        @term_subauthority_replacement_pattern ||= { pattern: pattern, default: term_url_mappings[pattern.to_sym][:default] }
-      end
+      alias subauthorities term_subauthorities
     end
   end
 end

--- a/spec/fixtures/authorities/linked_data/lod_full_config.json
+++ b/spec/fixtures/authorities/linked_data/lod_full_config.json
@@ -102,6 +102,31 @@
       "altlabel_predicate": "http://www.w3.org/2004/02/skos/core#altLabel",
       "sort_predicate":     "http://www.w3.org/2004/02/skos/core#prefLabel"
     },
+    "context": {
+      "groups": {
+        "dates": {
+          "group_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.dates",
+          "group_label_default": "Dates"
+        }
+      },
+      "properties": [
+        {
+          "property_label_i18n": "qa.linked_data.authority.locgenres_ld4l_cache.authoritative_label",
+          "property_label_default": "Authoritative Label",
+          "lpath": "madsrdf:authoritativeLabel",
+          "selectable": true,
+          "drillable": false
+        },
+        {
+          "group_id": "dates",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.birth_date",
+          "property_label_default": "Birth",
+          "lpath": "madsrdf:identifiesRWO/madsrdf:birthDate/schema:label",
+          "selectable": false,
+          "drillable": false
+        }
+      ]
+    },
     "subauthorities": {
       "search_sub1_key": "search_sub1_name",
       "search_sub2_key": "search_sub2_name",

--- a/spec/lib/authorities/linked_data/config_spec.rb
+++ b/spec/lib/authorities/linked_data/config_spec.rb
@@ -127,6 +127,31 @@ describe Qa::Authorities::LinkedData::Config do
             altlabel_predicate: 'http://www.w3.org/2004/02/skos/core#altLabel',
             sort_predicate: 'http://www.w3.org/2004/02/skos/core#prefLabel'
           },
+          context: {
+            groups: {
+              dates: {
+                group_label_i18n: "qa.linked_data.authority.locnames_ld4l_cache.dates",
+                group_label_default: "Dates"
+              }
+            },
+            properties: [
+              {
+                property_label_i18n: "qa.linked_data.authority.locgenres_ld4l_cache.authoritative_label",
+                property_label_default: "Authoritative Label",
+                lpath: "madsrdf:authoritativeLabel",
+                selectable: true,
+                drillable: false
+              },
+              {
+                group_id: "dates",
+                property_label_i18n: "qa.linked_data.authority.locnames_ld4l_cache.birth_date",
+                property_label_default: "Birth",
+                lpath: "madsrdf:identifiesRWO/madsrdf:birthDate/schema:label",
+                selectable: false,
+                drillable: false
+              }
+            ]
+          },
           subauthorities: {
             search_sub1_key: 'search_sub1_name',
             search_sub2_key: 'search_sub2_name',

--- a/spec/lib/authorities/linked_data/term_config_spec.rb
+++ b/spec/lib/authorities/linked_data/term_config_spec.rb
@@ -83,7 +83,7 @@ describe Qa::Authorities::LinkedData::TermConfig do
     end
   end
 
-  describe '#term_url' do
+  describe '#url_config' do
     let(:url_config) do
       {
         :@context => 'http://www.w3.org/ns/hydra/context.jsonld',
@@ -123,20 +123,10 @@ describe Qa::Authorities::LinkedData::TermConfig do
     end
 
     it 'returns nil if only search configuration is defined' do
-      expect(search_only_config.term_url).to eq nil
+      expect(search_only_config.url_config).to eq nil
     end
-    it 'returns the term url from the configuration' do
-      expect(full_config.term_url).to eq url_config
-    end
-  end
-
-  describe '#term_url' do
-    it 'returns nil if only search configuration is defined' do
-      expect(search_only_config.term_url_template).to eq nil
-    end
-    it 'returns the term url from the configuration' do
-      expected_url = 'http://localhost/test_default/term/{?subauth}/{?term_id}?param1={?param1}&param2={?param2}'
-      expect(full_config.term_url_template).to eq expected_url
+    it 'returns the url config from the configuration' do
+      expect(full_config.url_config).to be_kind_of Qa::IriTemplate::UrlConfig
     end
   end
 
@@ -255,48 +245,6 @@ describe Qa::Authorities::LinkedData::TermConfig do
     end
   end
 
-  describe '#term_replacements?' do
-    it 'returns false if only search configuration is defined' do
-      expect(search_only_config.term_replacements?).to eq false
-    end
-    it 'returns false if the configuration does NOT define replacements' do
-      expect(min_config.term_replacements?).to eq false
-    end
-    it 'returns true if the configuration defines replacements' do
-      expect(full_config.term_replacements?).to eq true
-    end
-  end
-
-  describe '#term_replacement_count' do
-    it 'returns 0 if only search configuration is defined' do
-      expect(search_only_config.term_replacement_count).to eq 0
-    end
-    it 'returns 0 if replacement_count is NOT defined' do
-      expect(min_config.term_replacement_count).to eq 0
-    end
-    it 'returns the number of replacements if defined' do
-      expect(full_config.term_replacement_count).to eq 2
-    end
-  end
-
-  describe '#term_replacements' do
-    it 'returns empty hash if only search configuration is defined' do
-      empty_hash = {}
-      expect(search_only_config.term_replacements).to eq empty_hash
-    end
-    it 'returns empty hash if no replacement patterns are defined' do
-      empty_hash = {}
-      expect(min_config.term_replacements).to eq empty_hash
-    end
-    it 'returns hash of all replacement patterns' do
-      expected_hash = {
-        param1: { :@type => 'IriTemplateMapping', variable: 'param1', property: 'hydra:freetextQuery', required: false, default: 'alpha' },
-        param2: { :@type => 'IriTemplateMapping', variable: 'param2', property: 'hydra:freetextQuery', required: false, default: 'beta' }
-      }
-      expect(full_config.term_replacements).to eq expected_hash
-    end
-  end
-
   describe '#term_subauthorities?' do
     it 'returns false if only search configuration is defined' do
       expect(search_only_config.term_subauthorities?).to eq false
@@ -352,21 +300,6 @@ describe Qa::Authorities::LinkedData::TermConfig do
         term_sub3_key: 'term_sub3_name'
       }
       expect(full_config.term_subauthorities).to eq expected_hash
-    end
-  end
-
-  describe '#term_subauthority_replacement_pattern' do
-    it 'returns empty hash if only search configuration is defined' do
-      empty_hash = {}
-      expect(search_only_config.term_subauthority_replacement_pattern).to eq empty_hash
-    end
-    it 'returns empty hash if no subauthorities are defined' do
-      empty_hash = {}
-      expect(min_config.term_subauthority_replacement_pattern).to eq empty_hash
-    end
-    it 'returns hash replacement pattern for subauthority and the default value' do
-      expected_hash = { pattern: 'subauth', default: 'term_sub2_name' }
-      expect(full_config.term_subauthority_replacement_pattern).to eq expected_hash
     end
   end
 end


### PR DESCRIPTION
Also removes obsolete methods (and related tests) that are now handled by the IriTemplate classes