### PR TITLE
add prefixes to config and some general cleanup

### DIFF
--- a/app/models/qa/linked_data/config/context_map.rb
+++ b/app/models/qa/linked_data/config/context_map.rb
@@ -24,7 +24,7 @@ module Qa
         #       {
         #         "property_label_i18n": "qa.linked_data.authority.locgenres_ld4l_cache.authoritative_label",
         #         "property_label_default": "Authoritative Label",
-        #         "lpath": "madsrdf:authoritativeLabel",
+        #         "ldpath": "madsrdf:authoritativeLabel",
         #         "selectable": true,
         #         "drillable": false
         #       },
@@ -32,7 +32,7 @@ module Qa
         #         "group_id": "dates",
         #         "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.birth_date",
         #         "property_label_default": "Birth",
-        #         "lpath": "madsrdf:identifiesRWO/madsrdf:birthDate/schema:label",
+        #         "ldpath": "madsrdf:identifiesRWO/madsrdf:birthDate/schema:label",
         #         "selectable": false,
         #         "drillable": false
         #       }

--- a/app/models/qa/linked_data/config/context_property_map.rb
+++ b/app/models/qa/linked_data/config/context_property_map.rb
@@ -3,15 +3,17 @@ module Qa
   module LinkedData
     module Config
       class ContextPropertyMap
-        attr_reader :group_id, :label, :lpath
-        attr_reader :property_map
-        private :property_map
+        attr_reader :group_id, # id that identifies which group the property should be in
+                    :label # plain text label extracted from locales or using the default
+
+        attr_reader :property_map, :ldpath
+        private :property_map, :ldpath
 
         # @param [Hash] property_map defining information to return to provide context
         # @option property_map [String] :group_id (optional) default label to use for a property (default: no label)
         # @option property_map [String] :property_label_i18n (optional) i18n key to use to get the label for a property (default: property_label_default OR no label if neither are defined)
         # @option property_map [String] :property_label_default (optional) default label to use for a property (default: no label)
-        # @option property_map [String] :lpath (required) i18n key to use to get the label for a property
+        # @option property_map [String] :ldpath (required) identifies the values to extract from the graph (based on http://marmotta.apache.org/ldpath/language.html)
         # @option property_map [Boolean] :selectable (optional) if true, this property can selected as the value (default: false)
         # @option property_map [Boolean] :drillable (optional) if true, the label for this property can be used to execute a second query allowing navi (default: false)
         # @example property_map
@@ -19,7 +21,7 @@ module Qa
         #     "group_id": "dates",
         #     "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.birth_date",
         #     "property_label_default": "Birth",
-        #     "lpath": "madsrdf:identifiesRWO/madsrdf:birthDate/schema:label",
+        #     "ldpath": "madsrdf:identifiesRWO/madsrdf:birthDate/schema:label",
         #     "selectable": false,
         #     "drillable": false
         #   }
@@ -27,7 +29,7 @@ module Qa
           @property_map = property_map
           @group_id = Qa::LinkedData::Config::Helper.fetch_symbol(property_map, :group_id, nil)
           @label = extract_label
-          @lpath = Qa::LinkedData::Config::Helper.fetch_required(property_map, :lpath, false)
+          @ldpath = Qa::LinkedData::Config::Helper.fetch_required(property_map, :ldpath, false)
           @selectable = Qa::LinkedData::Config::Helper.fetch_boolean(property_map, :selectable, false)
           @drillable = Qa::LinkedData::Config::Helper.fetch_boolean(property_map, :drillable, false)
         end
@@ -44,12 +46,16 @@ module Qa
           @drillable
         end
 
+        def group?
+          group_id.present?
+        end
+
         private
 
           def extract_label
             i18n_key = Qa::LinkedData::Config::Helper.fetch(property_map, :property_label_i18n, nil)
             default = Qa::LinkedData::Config::Helper.fetch(property_map, :property_label_default, nil)
-            return I18n.t(i18n_key, default) if i18n_key.present?
+            return I18n.t(i18n_key, default: default) if i18n_key.present?
             default
           end
       end

--- a/app/services/qa/linked_data/graph_service.rb
+++ b/app/services/qa/linked_data/graph_service.rb
@@ -46,6 +46,7 @@ module Qa
           graph.statements.each do |st|
             new_graph.insert(st.dup)
           end
+          new_graph
         end
 
         private

--- a/app/services/qa/linked_data/mapper/search_results_mapper_service.rb
+++ b/app/services/qa/linked_data/mapper/search_results_mapper_service.rb
@@ -8,9 +8,6 @@ module Qa
         self.deep_sort_service = Qa::LinkedData::DeepSortService
 
         class << self
-          # class_attribute :graph_mapper_service
-          # graph_mapper_service = QA::LinkedData::Mapper::GraphMapperService
-
           # Extract predicates specified in the predicate_map from the graph and return as an array of value maps for each search result subject URI.
           # If a sort key is present, a subject will only be included in the results if it has a statement with the sort predicate.
           # @param graph [RDF::Graph] the graph from which to extract result values

--- a/lib/qa/authorities/linked_data/config.rb
+++ b/lib/qa/authorities/linked_data/config.rb
@@ -23,27 +23,30 @@ module Qa::Authorities
       end
 
       attr_reader :authority_name
-      attr_reader :authority_config
 
       # Initialize to hold the configuration for the specifed authority.  Configurations are defined in config/authorities/linked_data.  See README for more information.
       # @param [String] the name of the configuration file for the authority
       # @return [Qa::Authorities::LinkedData::Config] instance of this class
       def initialize(auth_name)
         @authority_name = auth_name
-        auth_config
+        authority_config
       end
 
       def search
-        @search ||= Qa::Authorities::LinkedData::SearchConfig.new(auth_config.fetch(:search))
+        @search ||= Qa::Authorities::LinkedData::SearchConfig.new(authority_config.fetch(:search), prefixes)
       end
 
       def term
-        @term ||= Qa::Authorities::LinkedData::TermConfig.new(auth_config.fetch(:term))
+        @term ||= Qa::Authorities::LinkedData::TermConfig.new(authority_config.fetch(:term), prefixes)
+      end
+
+      def prefixes
+        @prefixes ||= authority_config.fetch(:prefixes, {})
       end
 
       # Return the full configuration for an authority
       # @return [String] the authority configuration
-      def auth_config
+      def authority_config
         @authority_config ||= Qa::LinkedData::AuthorityService.authority_config(@authority_name)
         raise Qa::InvalidLinkedDataAuthority, "Unable to initialize linked data authority '#{@authority_name}'" if @authority_config.nil?
         @authority_config

--- a/lib/qa/authorities/linked_data/config/search_config.rb
+++ b/lib/qa/authorities/linked_data/config/search_config.rb
@@ -6,8 +6,9 @@ module Qa::Authorities
   module LinkedData
     class SearchConfig
       # @param [Hash] config the search portion of the config
-      def initialize(config)
+      def initialize(config, prefixes = {})
         @search_config = config
+        @prefixes = prefixes
       end
 
       attr_reader :search_config
@@ -83,10 +84,8 @@ module Qa::Authorities
       # Return the context map if it is defined
       # @return [Qa::LinkedData::Config::ContextMap] the context map
       def context_map
-        return @context_map if @context_map.present?
-        context_config = search_config.fetch(:context, {})
-        return nil if context_config.blank?
-        @context_map = Qa::LinkedData::Config::ContextMap.new(context_config)
+        return nil unless search_config.key?(:context)
+        @context_map ||= Qa::LinkedData::Config::ContextMap.new(search_config.fetch(:context))
       end
 
       # Return parameters that are required for QA api

--- a/lib/qa/authorities/linked_data/config/term_config.rb
+++ b/lib/qa/authorities/linked_data/config/term_config.rb
@@ -6,8 +6,9 @@ module Qa::Authorities
   module LinkedData
     class TermConfig
       # @param [Hash] config the term portion of the config
-      def initialize(config)
+      def initialize(config, prefixes = {})
         @term_config = config
+        @prefixes = prefixes
       end
 
       attr_reader :term_config

--- a/lib/qa/authorities/linked_data/generic_authority.rb
+++ b/lib/qa/authorities/linked_data/generic_authority.rb
@@ -10,7 +10,8 @@ module Qa::Authorities
     # @see Qa::LinkedDataTermsController#show
     # @see Qa::Authorities::LinkedData::Config
     class GenericAuthority < Base
-      attr_reader :auth_config
+      attr_reader :authority_config
+      private :authority_config
 
       delegate :supports_term?, :term_subauthorities?, :term_subauthority?,
                :term_id_expects_uri?, :term_id_expects_id?, to: :term_config
@@ -19,7 +20,7 @@ module Qa::Authorities
       delegate :subauthority?, :subauthorities?, to: :search_config, prefix: 'search'
 
       def initialize(auth_name)
-        @auth_config = Qa::Authorities::LinkedData::Config.new(auth_name)
+        @authority_config = Qa::Authorities::LinkedData::Config.new(auth_name)
       end
 
       def reload_authorities
@@ -45,11 +46,11 @@ module Qa::Authorities
       private
 
         def search_config
-          auth_config.search
+          authority_config.search
         end
 
         def term_config
-          auth_config.term
+          authority_config.term
         end
     end
   end

--- a/lib/qa/authorities/linked_data/search_query.rb
+++ b/lib/qa/authorities/linked_data/search_query.rb
@@ -22,9 +22,9 @@ module Qa::Authorities
 
       # Search a linked data authority
       # @praram [String] the query
-      # @param [Symbol] (optional) language: language used to select literals when multi-language is supported (e.g. :en, :fr, etc.)
-      # @param [Hash] (optional) replacements: replacement values with { pattern_name (defined in YAML config) => value }
-      # @param [String] subauth: the subauthority to query
+      # @param language [Symbol] (optional) language used to select literals when multi-language is supported (e.g. :en, :fr, etc.)
+      # @param replacements [Hash] (optional) replacement values with { pattern_name (defined in YAML config) => value }
+      # @param subauth [String] (optional) the subauthority to query
       # @return [String] json results
       # @example Json Results for Linked Data Search
       #   [ {"uri":"http://id.worldcat.org/fast/5140","id":"5140","label":"Cornell, Joseph"},
@@ -47,9 +47,9 @@ module Qa::Authorities
         end
 
         def parse_search_authority_response
-          results = results_mapper_service.map_values(graph: @graph, predicate_map: preds_for_search,
-                                                      sort_key: :sort, preferred_language: @language)
-          convert_search_to_json(results)
+          results = results_mapper_service.map_values(graph: @graph, predicate_map: preds_for_search, sort_key: :sort,
+                                                      preferred_language: @language)
+          convert_results_to_json(results)
         end
 
         def preds_for_search
@@ -67,21 +67,25 @@ module Qa::Authorities
           @sort_predicate ||= search_config.results_sort_predicate
         end
 
-        def convert_search_to_json(results)
+        def convert_results_to_json(results)
           json_results = []
-          results.each do |result|
-            uri = result[:uri].first.to_s
-            id = result[:id].first.to_s
-            label = language_sort_service.new(result[:label], language).sort
-            altlabel = language_sort_service.new(result[:altlabel], language).sort
-            json_results << { uri: uri, id: id, label: full_label(label, altlabel) }
-          end
+          results.each { |result| json_results << convert_result_to_json(result) }
           json_results
         end
 
+        def convert_result_to_json(result)
+          json_result = {}
+          json_result[:uri] = result[:uri].first.to_s
+          json_result[:id] = result[:id].first.to_s
+          json_result[:label] = full_label(result[:label], result[:altlabel])
+          json_result
+        end
+
         def full_label(label = [], altlabel = [])
+          label = language_sort_service.new(label, language).sort
+          altlabel = language_sort_service.new(altlabel, language).sort
           lbl = wrap_labels(label)
-          lbl += " (#{altlabel.join(', ')})" unless altlabel.nil? || altlabel.length <= 0
+          lbl += " (#{altlabel.join(', ')})" if altlabel.present?
           lbl = lbl.slice(0..95) + '...' if lbl.length > 98
           lbl.strip
         end

--- a/spec/fixtures/authorities/linked_data/lod_full_config.json
+++ b/spec/fixtures/authorities/linked_data/lod_full_config.json
@@ -1,4 +1,8 @@
 {
+  "prefixes": {
+    "schema": "http://www.w3.org/2000/01/rdf-schema#",
+    "skos": "http://www.w3.org/2004/02/skos/core#"
+  },
   "term": {
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
@@ -113,7 +117,7 @@
         {
           "property_label_i18n": "qa.linked_data.authority.locgenres_ld4l_cache.authoritative_label",
           "property_label_default": "Authoritative Label",
-          "lpath": "madsrdf:authoritativeLabel",
+          "ldpath": "madsrdf:authoritativeLabel",
           "selectable": true,
           "drillable": false
         },
@@ -121,7 +125,7 @@
           "group_id": "dates",
           "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.birth_date",
           "property_label_default": "Birth",
-          "lpath": "madsrdf:identifiesRWO/madsrdf:birthDate/schema:label",
+          "ldpath": "madsrdf:identifiesRWO/madsrdf:birthDate/schema:label",
           "selectable": false,
           "drillable": false
         }

--- a/spec/lib/authorities/linked_data/config_spec.rb
+++ b/spec/lib/authorities/linked_data/config_spec.rb
@@ -21,9 +21,13 @@ describe Qa::Authorities::LinkedData::Config do
     end
   end
 
-  describe '#auth_config' do
+  describe '#authority_config' do
     let(:full_auth_config) do
       {
+        prefixes: {
+          schema: "http://www.w3.org/2000/01/rdf-schema#",
+          skos: "http://www.w3.org/2004/02/skos/core#"
+        },
         term: {
           url: {
             :@context => 'http://www.w3.org/ns/hydra/context.jsonld',
@@ -138,7 +142,7 @@ describe Qa::Authorities::LinkedData::Config do
               {
                 property_label_i18n: "qa.linked_data.authority.locgenres_ld4l_cache.authoritative_label",
                 property_label_default: "Authoritative Label",
-                lpath: "madsrdf:authoritativeLabel",
+                ldpath: "madsrdf:authoritativeLabel",
                 selectable: true,
                 drillable: false
               },
@@ -146,7 +150,7 @@ describe Qa::Authorities::LinkedData::Config do
                 group_id: "dates",
                 property_label_i18n: "qa.linked_data.authority.locnames_ld4l_cache.birth_date",
                 property_label_default: "Birth",
-                lpath: "madsrdf:identifiesRWO/madsrdf:birthDate/schema:label",
+                ldpath: "madsrdf:identifiesRWO/madsrdf:birthDate/schema:label",
                 selectable: false,
                 drillable: false
               }
@@ -161,8 +165,36 @@ describe Qa::Authorities::LinkedData::Config do
       }
     end
 
+    let(:authority_config) { full_config.authority_config }
+
     it 'returns hash of the full authority configuration' do
-      expect(full_config.auth_config).to eq full_auth_config
+      expect(authority_config).to eq full_auth_config
+    end
+  end
+
+  describe '#search' do
+    it 'returns instance of search config class' do
+      expect(full_config.search).to be_kind_of Qa::Authorities::LinkedData::SearchConfig
+    end
+  end
+
+  describe '#term' do
+    it 'returns instance of term config class' do
+      expect(full_config.term).to be_kind_of Qa::Authorities::LinkedData::TermConfig
+    end
+  end
+
+  describe '#prefixes' do
+    let(:expected_results) do
+      {
+        schema: "http://www.w3.org/2000/01/rdf-schema#",
+        skos: "http://www.w3.org/2004/02/skos/core#"
+      }
+    end
+
+    it 'returns hash of prefix definitions' do
+      expect(full_config.prefixes).to be_kind_of Hash
+      expect(full_config.prefixes).to eq expected_results
     end
   end
 end

--- a/spec/lib/authorities/linked_data/search_config_spec.rb
+++ b/spec/lib/authorities/linked_data/search_config_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Qa::Authorities::LinkedData::SearchConfig do
             {
               property_label_i18n: "qa.linked_data.authority.locgenres_ld4l_cache.authoritative_label",
               property_label_default: "Authoritative Label",
-              lpath: "madsrdf:authoritativeLabel",
+              ldpath: "madsrdf:authoritativeLabel",
               selectable: true,
               drillable: false
             },
@@ -74,7 +74,7 @@ RSpec.describe Qa::Authorities::LinkedData::SearchConfig do
               group_id: "dates",
               property_label_i18n: "qa.linked_data.authority.locnames_ld4l_cache.birth_date",
               property_label_default: "Birth",
-              lpath: "madsrdf:identifiesRWO/madsrdf:birthDate/schema:label",
+              ldpath: "madsrdf:identifiesRWO/madsrdf:birthDate/schema:label",
               selectable: false,
               drillable: false
             }

--- a/spec/models/iri_template/url_config_spec.rb
+++ b/spec/models/iri_template/url_config_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Qa::IriTemplate::UrlConfig do
     it { is_expected.to respond_to :mapping }
   end
 
-  describe '#initialize' do
+  describe '#new' do
     context 'when missing template' do
       before do
         allow(url_template).to receive(:fetch).with(:template, nil).and_return(nil)

--- a/spec/models/iri_template/variable_map_spec.rb
+++ b/spec/models/iri_template/variable_map_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Qa::IriTemplate::VariableMap do
     # it { is_expected.to respond_to :parameter_value }
   end
 
-  describe '#initialize' do
+  describe '#new' do
     context 'when variable is missing' do
       before do
         map.delete(:variable)

--- a/spec/models/linked_data/config/context_map_spec.rb
+++ b/spec/models/linked_data/config/context_map_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Qa::LinkedData::Config::ContextMap do
         {
           property_label_i18n: 'qa.linked_data.authority.locgenres_ld4l_cache.authoritative_label',
           property_label_default: 'default_Authoritative Label',
-          lpath: 'madsrdf:authoritativeLabel',
+          ldpath: 'madsrdf:authoritativeLabel',
           selectable: true,
           drillable: false
         },
@@ -32,7 +32,7 @@ RSpec.describe Qa::LinkedData::Config::ContextMap do
           group_id: 'dates',
           property_label_i18n: 'qa.linked_data.authority.locnames_ld4l_cache.birth_date',
           property_label_default: 'default_Birth',
-          lpath: 'madsrdf:identifiesRWO/madsrdf:birthDate/schema:label',
+          ldpath: 'madsrdf:identifiesRWO/madsrdf:birthDate/schema:label',
           selectable: false,
           drillable: false
         },
@@ -40,7 +40,7 @@ RSpec.describe Qa::LinkedData::Config::ContextMap do
           group_id: 'dates',
           property_label_i18n: 'qa.linked_data.authority.locnames_ld4l_cache.death_date',
           property_label_default: 'default_Death',
-          lpath: 'madsrdf:identifiesRWO/madsrdf:deathDate/schema:label',
+          ldpath: 'madsrdf:identifiesRWO/madsrdf:deathDate/schema:label',
           selectable: false,
           drillable: false
         }

--- a/spec/models/linked_data/config/context_property_map_spec.rb
+++ b/spec/models/linked_data/config/context_property_map_spec.rb
@@ -8,22 +8,18 @@ RSpec.describe Qa::LinkedData::Config::ContextPropertyMap do
       group_id: 'dates',
       property_label_i18n: 'qa.linked_data.authority.locnames_ld4l_cache.birth_date',
       property_label_default: 'default_Birth',
-      lpath: 'madsrdf:identifiesRWO/madsrdf:birthDate/schema:label',
+      ldpath: 'madsrdf:identifiesRWO/madsrdf:birthDate/schema:label',
       selectable: false,
       drillable: false
     }
   end
 
-  describe 'model attributes' do
-    it { is_expected.to respond_to :lpath }
-  end
-
-  describe '#initialize' do
-    context 'when lpath is missing' do
-      before { property_map.delete(:lpath) }
+  describe '#new' do
+    context 'when ldpath is missing' do
+      before { property_map.delete(:ldpath) }
 
       it 'raises an error' do
-        expect { subject }.to raise_error(Qa::InvalidConfiguration, 'lpath is required')
+        expect { subject }.to raise_error(Qa::InvalidConfiguration, 'ldpath is required')
       end
     end
 
@@ -100,7 +96,7 @@ RSpec.describe Qa::LinkedData::Config::ContextPropertyMap do
     context 'when map defines property_label_i18n key' do
       context 'and i18n translation is defined in locales' do
         before do
-          allow(I18n).to receive(:t).with('qa.linked_data.authority.locnames_ld4l_cache.birth_date', 'default_Birth').and_return('Birth')
+          allow(I18n).to receive(:t).with('qa.linked_data.authority.locnames_ld4l_cache.birth_date', default: 'default_Birth').and_return('Birth')
         end
 
         it 'returns the translated text' do
@@ -111,7 +107,7 @@ RSpec.describe Qa::LinkedData::Config::ContextPropertyMap do
       context 'and i18n translation is NOT defined in locales' do
         context 'and default is defined in the map' do
           before do
-            allow(I18n).to receive(:t).with('qa.linked_data.authority.locnames_ld4l_cache.birth_date', 'default_Birth').and_return('default_Birth')
+            allow(I18n).to receive(:t).with('qa.linked_data.authority.locnames_ld4l_cache.birth_date', default: 'default_Birth').and_return('default_Birth')
           end
 
           it 'returns the default value' do
@@ -122,7 +118,7 @@ RSpec.describe Qa::LinkedData::Config::ContextPropertyMap do
         context 'and default is NOT defined in the map' do
           before do
             property_map.delete(:property_label_default)
-            allow(I18n).to receive(:t).with('qa.linked_data.authority.locnames_ld4l_cache.birth_date', nil).and_return(nil)
+            allow(I18n).to receive(:t).with('qa.linked_data.authority.locnames_ld4l_cache.birth_date', default: nil).and_return(nil)
           end
 
           it 'returns nil' do
@@ -163,6 +159,22 @@ RSpec.describe Qa::LinkedData::Config::ContextPropertyMap do
 
       it 'returns nil' do
         expect(subject.group_id).to eq nil
+      end
+    end
+  end
+
+  describe '#group?' do
+    context 'when map defines group_id' do
+      it 'returns true' do
+        expect(subject.group?).to be true
+      end
+    end
+
+    context 'when map does NOT define group_id' do
+      before { property_map.delete(:group_id) }
+
+      it 'returns false' do
+        expect(subject.group?).to be false
       end
     end
   end

--- a/spec/services/linked_data/graph_service_spec.rb
+++ b/spec/services/linked_data/graph_service_spec.rb
@@ -211,4 +211,22 @@ RSpec.describe Qa::LinkedData::GraphService do
       expect(subject.map(&:to_s)).to match_array ['http://id.loc.gov/authorities/names/n79021621', 'https://viaf.org/viaf/126293486']
     end
   end
+
+  describe '.deep_copy' do
+    subject { described_class.object_values(graph: graph, subject: subject_uri, predicate: predicate_uri) }
+
+    let(:url) { 'http://experimental.worldcat.org/fast/search?maximumRecords=3&query=cql.any%20all%20%22cornell%22&sortKeys=usage' }
+    let(:graph) { described_class.load_graph(url: url) }
+    let(:copied_graph) { described_class.deep_copy(graph: graph) }
+
+    before do
+      stub_request(:get, 'http://experimental.worldcat.org/fast/search?maximumRecords=3&query=cql.any%20all%20%22cornell%22&sortKeys=usage')
+        .to_return(status: 200, body: webmock_fixture('lod_oclc_all_query_3_results.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
+    end
+
+    it 'returns a copy of the graph' do
+      expect(copied_graph).to be_kind_of RDF::Graph
+      expect(copied_graph.statements.count).to eq graph.statements.count
+    end
+  end
 end


### PR DESCRIPTION
Adds:
* prefix to configs

Fixes bugs:
* fix I18n fetch with default (it was incorrect)
* fix GraphService.deep_copy which returned an array of statements instead of the graph; now returns graph as expected

Includes a bunch of cleanup in prep of next PR:
* rename lpath to ldpath (actual name of the query language)
* rename method auth_config to authority_config (more consistent)
* clean up conversion to json in search config to make it easier to extend with context
* add some tests for methods that weren’t tested
* use `describe ‘#new’ do` in tests instead of `#initialize` (more consistent)
