### PR TITLE
Create ldpath program for context property map

### DIFF
--- a/app/services/qa/linked_data/mapper/graph_mapper_service.rb
+++ b/app/services/qa/linked_data/mapper/graph_mapper_service.rb
@@ -29,9 +29,9 @@ module Qa
           value_map = {}
           predicate_map.each do |key, predicate|
             values = predicate == :subject_uri ? [subject_uri] : graph_service.object_values(graph: graph, subject: subject_uri, predicate: predicate)
-            values = yield values if block_given?
             value_map[key] = values
           end
+          value_map = yield value_map if block_given?
           value_map
         end
       end

--- a/qa.gemspec
+++ b/qa.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activerecord-import'
   s.add_dependency 'deprecation'
   s.add_dependency 'faraday'
+  s.add_dependency 'ldpath'
   s.add_dependency 'nokogiri', '~> 1.6'
   s.add_dependency 'rails', '~> 5.0'
   s.add_dependency 'rdf'

--- a/spec/models/linked_data/config/context_property_map_spec.rb
+++ b/spec/models/linked_data/config/context_property_map_spec.rb
@@ -193,4 +193,19 @@ RSpec.describe Qa::LinkedData::Config::ContextPropertyMap do
       end
     end
   end
+
+  describe '#values' do
+    let(:program) { instance_double(Ldpath::Program) }
+    let(:coordinates) { '42.4488° N, 76.4763° W' }
+    let(:subject_uri) { instance_double(RDF::URI) }
+    let(:graph) { instance_double(RDF::Graph) }
+
+    before do
+      allow(Ldpath::Program).to receive(:parse).with(anything).and_return(program)
+      allow(program).to receive(:evaluate).with(anything, anything).and_return('property' => [coordinates, coordinates, coordinates]) # check that uniq is applied
+    end
+    it 'returns the ldpath program for this property map' do
+      expect(subject.values(graph, subject_uri)).to match_array coordinates
+    end
+  end
 end

--- a/spec/services/linked_data/mapper/graph_mapper_service_spec.rb
+++ b/spec/services/linked_data/mapper/graph_mapper_service_spec.rb
@@ -71,6 +71,35 @@ RSpec.describe Qa::LinkedData::Mapper::GraphMapperService do
         validate_entry(subject, :sort, ['3'], RDF::Literal)
       end
     end
+
+    context 'when block is passed in' do
+      let(:subject_uri) { RDF::URI.new('http://id.worldcat.org/fast/5140') }
+      let(:context) do
+        { location: '42.4488° N, 76.4763° W' }
+      end
+      let(:subject) do
+        described_class.map_values(graph: graph, predicate_map: predicate_map, subject_uri: subject_uri) do |value_map|
+          value_map[:context] = context
+          value_map
+        end
+      end
+
+      it 'yields to passed in block' do
+        expect(subject.count).to eq 7
+        expect(subject).to be_kind_of Hash
+        expect(subject.keys).to match_array [:uri, :id, :label, :altlabel, :sameas, :sort, :context]
+
+        validate_entry(subject, :uri, [subject_uri.to_s], RDF::URI)
+        validate_entry(subject, :id, ['5140'], RDF::Literal)
+        validate_entry(subject, :label, ['Cornell, Joseph'], RDF::Literal)
+        validate_entry(subject, :altlabel, [], NilClass)
+        validate_entry(subject, :sameas, [], NilClass)
+        validate_entry(subject, :sort, ['3'], RDF::Literal)
+
+        expect(subject[:context]).to be_kind_of Hash
+        expect(subject[:context]).to include(context)
+      end
+    end
   end
 
   def validate_entry(results, key, values, entry_kind)


### PR DESCRIPTION
Also moves block processing for graph_mapper_service outside of the individual property to the set of properties.  This allows for adding context to the set of properties returned.

Example:
```
{ 
  id: 1, 
  label: 'The title', 
  context:
  {
    location: '42.4488° N, 76.4763° W'
  }
}
``` 
