### PR TITLE
Expand context when the value is an URI and expasion was requested in the config

### DIFF
--- a/app/models/qa/linked_data/config/context_map.rb
+++ b/app/models/qa/linked_data/config/context_map.rb
@@ -68,7 +68,7 @@ module Qa
             return if groups.key? group_id
             i18n_key = Qa::LinkedData::Config::Helper.fetch(group_map, :group_label_i18n, nil)
             default = Qa::LinkedData::Config::Helper.fetch(group_map, :group_label_default, nil)
-            return groups[group_id] = I18n.t(i18n_key, default) if i18n_key.present?
+            return groups[group_id] = I18n.t(i18n_key, default: default) if i18n_key.present?
             groups[group_id] = default
           end
       end

--- a/app/services/qa/linked_data/mapper/context_mapper_service.rb
+++ b/app/services/qa/linked_data/mapper/context_mapper_service.rb
@@ -21,23 +21,28 @@ module Qa
           def map_context(graph:, context_map:, subject_uri:)
             context = []
             context_map.properties.each do |property_map|
-              values = property_map.values(graph, subject_uri)
+              values = property_values(property_map, graph, subject_uri)
               next if values.blank?
-              context << construct_context(context_map, property_map, values)
+              context << populate_property_map(context_map, property_map, values)
             end
             context
           end
 
           private
 
-            def construct_context(context_map, property_map, values)
+            def populate_property_map(context_map, property_map, values)
               property_info = {}
-              property_info["group"] = context_map.group_label(property_map.group_id) if property_map.group? # TODO: should be group label
+              property_info["group"] = context_map.group_label(property_map.group_id) if property_map.group?
               property_info["property"] = property_map.label
               property_info["values"] = values
               property_info["selectable"] = property_map.selectable?
               property_info["drillable"] = property_map.drillable?
               property_info
+            end
+
+            def property_values(property_map, graph, subject_uri)
+              return property_map.expanded_values(graph, subject_uri) if property_map.expand_uri?
+              property_map.values(graph, subject_uri)
             end
         end
       end

--- a/app/services/qa/linked_data/mapper/context_mapper_service.rb
+++ b/app/services/qa/linked_data/mapper/context_mapper_service.rb
@@ -21,22 +21,30 @@ module Qa
           def map_context(graph:, context_map:, subject_uri:)
             context = []
             context_map.properties.each do |property_map|
-              values = property_values(property_map, graph, subject_uri)
-              next if values.blank?
-              context << populate_property_map(context_map, property_map, values)
+              populated_property_map = populate_property_map(context_map, property_map, graph, subject_uri)
+              next if populated_property_map.blank?
+              context << populated_property_map
             end
             context
           end
 
           private
 
-            def populate_property_map(context_map, property_map, values)
+            def populate_property_map(context_map, property_map, graph, subject_uri)
+              begin
+                values = property_values(property_map, graph, subject_uri)
+              rescue => e
+                values = Qa::LinkedData::Config::ContextPropertyMap::VALUE_ON_ERROR
+                error = e.message
+              end
+
               property_info = {}
               property_info["group"] = context_map.group_label(property_map.group_id) if property_map.group?
               property_info["property"] = property_map.label
               property_info["values"] = values
               property_info["selectable"] = property_map.selectable?
               property_info["drillable"] = property_map.drillable?
+              property_info["error"] = error if error.present?
               property_info
             end
 

--- a/config/locales/qa.en.yml
+++ b/config/locales/qa.en.yml
@@ -1,0 +1,9 @@
+---
+en:
+  qa:
+    linked_data:
+      ldpath:
+        evaluate_error: LDPATH EVALUATION ERROR (See log for more information)
+        evaluate_logger_error: LDPath failed to evaluate the graph with the provided ldpath.
+        parse_error: LDPATH PARSE ERROR (See log for more information)
+        parse_logger_error: LDPath failed to parse during ldpath program creation.

--- a/spec/fixtures/authorities/linked_data/lod_full_config.json
+++ b/spec/fixtures/authorities/linked_data/lod_full_config.json
@@ -111,6 +111,10 @@
         "dates": {
           "group_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.dates",
           "group_label_default": "Dates"
+        },
+        "hierarchy": {
+          "group_label_i18n": "qa.linked_data.authority.locgenres_ld4l_cache.hierarchy",
+          "group_label_default": "Hierarchy"
         }
       },
       "properties": [
@@ -128,6 +132,26 @@
           "ldpath": "madsrdf:identifiesRWO/madsrdf:birthDate/schema:label",
           "selectable": false,
           "drillable": false
+        },
+        {
+          "group_id": "hierarchy",
+          "property_label_i18n": "qa.linked_data.authority.locgenres_ld4l_cache.narrower",
+          "property_label_default": "Narrower",
+          "ldpath": "skos:narrower :: xsd:string",
+          "selectable": true,
+          "drillable": true,
+          "expansion_label_ldpath": "skos:prefLabel ::xsd:string",
+          "expansion_id_ldpath": "loc:lccn ::xsd:string"
+        },
+        {
+          "group_id": "hierarchy",
+          "property_label_i18n": "qa.linked_data.authority.locgenres_ld4l_cache.broader",
+          "property_label_default": "Broader",
+          "ldpath": "skos:broader :: xsd:string",
+          "selectable": true,
+          "drillable": true,
+          "expansion_label_ldpath": "skos:prefLabel ::xsd:string",
+          "expansion_id_ldpath": "loc:lccn ::xsd:string"
         }
       ]
     },

--- a/spec/lib/authorities/linked_data/config_spec.rb
+++ b/spec/lib/authorities/linked_data/config_spec.rb
@@ -136,6 +136,10 @@ describe Qa::Authorities::LinkedData::Config do
               dates: {
                 group_label_i18n: "qa.linked_data.authority.locnames_ld4l_cache.dates",
                 group_label_default: "Dates"
+              },
+              hierarchy: {
+                group_label_i18n: "qa.linked_data.authority.locgenres_ld4l_cache.hierarchy",
+                group_label_default: "Hierarchy"
               }
             },
             properties: [
@@ -153,6 +157,26 @@ describe Qa::Authorities::LinkedData::Config do
                 ldpath: "madsrdf:identifiesRWO/madsrdf:birthDate/schema:label",
                 selectable: false,
                 drillable: false
+              },
+              {
+                group_id: "hierarchy",
+                property_label_i18n: "qa.linked_data.authority.locgenres_ld4l_cache.narrower",
+                property_label_default: "Narrower",
+                ldpath: "skos:narrower :: xsd:string",
+                selectable: true,
+                drillable: true,
+                expansion_label_ldpath: "skos:prefLabel ::xsd:string",
+                expansion_id_ldpath: "loc:lccn ::xsd:string"
+              },
+              {
+                group_id: "hierarchy",
+                property_label_i18n: "qa.linked_data.authority.locgenres_ld4l_cache.broader",
+                property_label_default: "Broader",
+                ldpath: "skos:broader :: xsd:string",
+                selectable: true,
+                drillable: true,
+                expansion_label_ldpath: "skos:prefLabel ::xsd:string",
+                expansion_id_ldpath: "loc:lccn ::xsd:string"
               }
             ]
           },

--- a/spec/lib/authorities/linked_data/search_config_spec.rb
+++ b/spec/lib/authorities/linked_data/search_config_spec.rb
@@ -60,6 +60,10 @@ RSpec.describe Qa::Authorities::LinkedData::SearchConfig do
             dates: {
               group_label_i18n: "qa.linked_data.authority.locnames_ld4l_cache.dates",
               group_label_default: "Dates"
+            },
+            hierarchy: {
+              group_label_i18n: "qa.linked_data.authority.locgenres_ld4l_cache.hierarchy",
+              group_label_default: "Hierarchy"
             }
           },
           properties: [
@@ -77,6 +81,26 @@ RSpec.describe Qa::Authorities::LinkedData::SearchConfig do
               ldpath: "madsrdf:identifiesRWO/madsrdf:birthDate/schema:label",
               selectable: false,
               drillable: false
+            },
+            {
+              group_id: "hierarchy",
+              property_label_i18n: "qa.linked_data.authority.locgenres_ld4l_cache.narrower",
+              property_label_default: "Narrower",
+              ldpath: "skos:narrower :: xsd:string",
+              selectable: true,
+              drillable: true,
+              expansion_label_ldpath: "skos:prefLabel ::xsd:string",
+              expansion_id_ldpath: "loc:lccn ::xsd:string"
+            },
+            {
+              group_id: "hierarchy",
+              property_label_i18n: "qa.linked_data.authority.locgenres_ld4l_cache.broader",
+              property_label_default: "Broader",
+              ldpath: "skos:broader :: xsd:string",
+              selectable: true,
+              drillable: true,
+              expansion_label_ldpath: "skos:prefLabel ::xsd:string",
+              expansion_id_ldpath: "loc:lccn ::xsd:string"
             }
           ]
         },

--- a/spec/models/linked_data/config/context_map_spec.rb
+++ b/spec/models/linked_data/config/context_map_spec.rb
@@ -6,10 +6,6 @@ RSpec.describe Qa::LinkedData::Config::ContextMap do
   before do
     # simulate the existence of the i18n entries
     allow(I18n).to receive(:t).and_call_original
-    allow(I18n).to receive(:t).with('qa.linked_data.authority.locnames_ld4l_cache.dates', 'default_Dates').and_return('Dates')
-    allow(I18n).to receive(:t).with('qa.linked_data.authority.locnames_ld4l_cache.authoritative_label', 'default_Authoritative Label').and_return('Authoritative Label')
-    allow(I18n).to receive(:t).with('qa.linked_data.authority.locnames_ld4l_cache.birth_date', 'default_Birth').and_return('Birth')
-    allow(I18n).to receive(:t).with('qa.linked_data.authority.locnames_ld4l_cache.death_date', 'default_Death').and_return('Death')
   end
 
   let(:context_map) do
@@ -75,6 +71,10 @@ RSpec.describe Qa::LinkedData::Config::ContextMap do
   describe '#group_label' do
     context 'when map defines group_label_i18n key' do
       context 'and i18n translation is defined in locales' do
+        before do
+          allow(I18n).to receive(:t).with('qa.linked_data.authority.locnames_ld4l_cache.dates', default: 'default_Dates').and_return('Dates')
+        end
+
         it 'returns the translated text' do
           expect(subject.group_label(:dates)).to eq 'Dates'
         end
@@ -83,7 +83,7 @@ RSpec.describe Qa::LinkedData::Config::ContextMap do
       context 'and i18n translation is NOT defined in locales' do
         context 'and default is defined in the map' do
           before do
-            allow(I18n).to receive(:t).with('qa.linked_data.authority.locnames_ld4l_cache.dates', 'default_Dates').and_return('default_Dates')
+            allow(I18n).to receive(:t).with('qa.linked_data.authority.locnames_ld4l_cache.dates', default: 'default_Dates').and_return('default_Dates')
           end
 
           it 'returns the default value' do

--- a/spec/services/linked_data/mapper/context_mapper_service_spec.rb
+++ b/spec/services/linked_data/mapper/context_mapper_service_spec.rb
@@ -28,18 +28,21 @@ RSpec.describe Qa::LinkedData::Mapper::ContextMapperService do
     allow(birth_date_property_map).to receive(:group?).and_return(false)
     allow(birth_date_property_map).to receive(:selectable?).and_return(false)
     allow(birth_date_property_map).to receive(:drillable?).and_return(false)
+    allow(birth_date_property_map).to receive(:expand_uri?).and_return(false)
 
     allow(death_date_property_map).to receive(:label).and_return('Death')
     allow(death_date_property_map).to receive(:values).with(graph, subject_uri).and_return(death_date_values)
     allow(death_date_property_map).to receive(:group?).and_return(false)
     allow(death_date_property_map).to receive(:selectable?).and_return(false)
     allow(death_date_property_map).to receive(:drillable?).and_return(false)
+    allow(death_date_property_map).to receive(:expand_uri?).and_return(false)
 
     allow(occupation_property_map).to receive(:label).and_return('Occupation')
     allow(occupation_property_map).to receive(:values).with(graph, subject_uri).and_return(occupation_values)
     allow(occupation_property_map).to receive(:group?).and_return(false)
     allow(occupation_property_map).to receive(:selectable?).and_return(false)
     allow(occupation_property_map).to receive(:drillable?).and_return(false)
+    allow(occupation_property_map).to receive(:expand_uri?).and_return(false)
   end
 
   describe '.map_context' do

--- a/spec/services/linked_data/mapper/context_mapper_service_spec.rb
+++ b/spec/services/linked_data/mapper/context_mapper_service_spec.rb
@@ -114,6 +114,17 @@ RSpec.describe Qa::LinkedData::Mapper::ContextMapperService do
         expect(result['selectable']).to be true
       end
     end
+
+    context 'when error occurs' do
+      let(:cause) { I18n.t('qa.linked_data.ldpath.parse_error') }
+      before { allow(occupation_property_map).to receive(:values).with(graph, subject_uri).and_raise(cause) }
+      it 'includes error message and empty value array' do
+        result = find_property_to_test(subject, 'Occupation')
+        expect(result.key?('error')).to be true
+        expect(result['error']).to eq cause
+        expect(result['values']).to match_array([])
+      end
+    end
   end
 
   def find_property_to_test(results, label)


### PR DESCRIPTION
**Adds:**

* expands context for URIs to optionally include label and id

**Fixes:**

* group label improperly passed default to I18n
* clean up some comments
* extracts parts of longer methods into private methods to avoid rubocop complaints and/or to keep DRY

**Examples:**

Regular context (from previous PR)
```
{
    property: "Authoritative Label",
    values: [
        "Science films"
    ],
    selectable: true,
    drillable: false
},
```

Expanding URI values in context (with this PR)
```
{
    group: "Hierarchy",
    property: "Narrower",
    values: [
        {
            uri: "http://id.loc.gov/authorities/genreForms/gf2011026416",
            id: "gf2011026416",
            label: "Nature films"
        }
    ],
    selectable: true,
    drillable: true
},
```