### PR TITLE
Replace URI.escape with ERB::Util.url_encode

### DIFF
--- a/app/models/qa/iri_template/variable_map.rb
+++ b/app/models/qa/iri_template/variable_map.rb
@@ -24,8 +24,7 @@ module Qa
         @property = Qa::LinkedData::Config::Helper.fetch(variable_map, :property, 'hydra:freetextQuery')
       end
 
-      # TODO: When implementing more complex query substitution, simple_value is used when template url specifies variable as {var_name}.
-      # Value to use in substitution, using default if one isn't passed in
+      # Value to use in substitution, using default if one isn't passed in.  Use when template url specifies variable as {var_name}.
       # @param [Object] value to use if it exists
       # @return the value to use (e.g. 'fr')
       def simple_value(sub_value = nil)
@@ -36,15 +35,14 @@ module Qa
         sub_value
       end
 
-      # TODO: When implementing more complex query substitution, parameter_value is used when template url specifies variable as {?var_name}.
-      # # Parameter and value to use in substitution, using default is one isn't passed in
-      # # @param [Object] value to use if it exists
-      # # @return the parameter and value to use (e.g. 'language=fr')
-      # def parameter_value(sub_value = nil)
-      #   simple_value = simple_value(sub_value)
-      #   return '' if simple_value.blank?
-      #   param_value = "#{variable}=#{simple_value}"
-      # end
+      # Parameter and value to use in substitution, using default is one isn't passed in. Use when template url specifies variable as {?var_name}.
+      # @param [Object] value to use if it exists
+      # @return the parameter and value to use (e.g. 'language=fr')
+      def parameter_value(sub_value = nil)
+        simple_value = simple_value(sub_value)
+        return '' if simple_value.blank?
+        "#{variable}=#{simple_value}"
+      end
 
       private
 

--- a/app/models/qa/iri_template/variable_map.rb
+++ b/app/models/qa/iri_template/variable_map.rb
@@ -1,13 +1,10 @@
 # Provide access to iri template variable map configuration.
 # See https://www.hydra-cg.com/spec/latest/core/#templated-links for information on IRI Templated Links - Variable Mapping.
 # TODO: It would be good to find a more complete resource describing templated links.
-require 'erb'
 
 module Qa
   module IriTemplate
     class VariableMap
-      include ERB::Util
-
       TYPE = "IriTemplateMapping".freeze
       attr_reader :variable
       attr_reader :default
@@ -35,7 +32,7 @@ module Qa
         raise Qa::IriTemplate::MissingParameter, "#{variable} is required, but missing" if sub_value.blank? && required?
         return default if sub_value.blank?
         sub_value = sub_value.to_s
-        sub_value = url_encode(sub_value).gsub(".", "%2E") if encode?
+        sub_value = ERB::Util.url_encode(sub_value).gsub(".", "%2E") if encode?
         sub_value
       end
 

--- a/app/services/qa/iri_template_service.rb
+++ b/app/services/qa/iri_template_service.rb
@@ -8,8 +8,6 @@ module Qa
     def self.build_url(url_config:, substitutions:)
       # TODO: This is a very simple approach using direct substitution into the template string.
       #   Better would be to...
-      #     * pattern {var_name} = simple value substitution in place of pattern produces 'value'
-      #     * pattern {?var_name} = parameter substitution in place of pattern produces 'var_name=value'
       #     * patterns without a substitution are not included in the resulting URL
       #     * appropriately adds '?' or '&'
       #     * ensure proper escaping of values (e.g. value="A simple string" which is encoded as A%20simple%20string)
@@ -24,9 +22,8 @@ module Qa
       url = url_config.template
       url_config.mapping.each do |m|
         key = m.variable
-        url = url.gsub("{?#{key}}", m.simple_value(substitutions[key])) # Incorrectly applies pattern {?var_name} to produce substitution 'value'
-        # url.gsub("{#{key}}", m.simple_value(substitutions[key]))  # TODO: pattern {var_name} should produce substitution 'value'
-        # url.gsub("{?#{key}}", m.parameter_value(substitutions[key])) # TODO: pattern {?var_name} should produce substitution 'var_name=value'
+        url = url.gsub("{#{key}}", m.simple_value(substitutions[key]))
+        url = url.gsub("{?#{key}}", m.parameter_value(substitutions[key]))
       end
       url
     end

--- a/config/authorities/linked_data/loc.json
+++ b/config/authorities/linked_data/loc.json
@@ -1,9 +1,10 @@
 {
+  "QA_CONFIG_VERSION": "2.0",
   "term": {
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type": "IriTemplate",
-      "template": "http://id.loc.gov/authorities/{?subauth}/{?term_id}",
+      "template": "http://id.loc.gov/authorities/{subauth}/{term_id}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {

--- a/config/authorities/linked_data/loc.json
+++ b/config/authorities/linked_data/loc.json
@@ -31,7 +31,9 @@
       "id_predicate": "http://id.loc.gov/vocabulary/identifiers/lccn",
       "label_predicate": "http://www.w3.org/2004/02/skos/core#prefLabel",
       "altlabel_predicate": "http://www.w3.org/2004/02/skos/core#altLabel",
-      "sameas_predicate": "http://www.w3.org/2004/02/skos/core#exactMatch"
+      "sameas_predicate": "http://www.w3.org/2004/02/skos/core#exactMatch",
+      "narrower_predicate": "http://www.loc.gov/mads/rdf/v1#hasNarrowerAuthority",
+      "broader_predicate": "http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority"
     },
     "subauthorities": {
       "subjects": "subjects",

--- a/config/authorities/linked_data/oclc_fast.json
+++ b/config/authorities/linked_data/oclc_fast.json
@@ -1,9 +1,10 @@
 {
+  "QA_CONFIG_VERSION": "2.0",
   "term": {
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type":    "IriTemplate",
-      "template": "http://id.worldcat.org/fast/{?term_id}",
+      "template": "http://id.worldcat.org/fast/{term_id}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -29,7 +30,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type": "IriTemplate",
-      "template": "http://experimental.worldcat.org/fast/search?query={?subauth}+all+%22{?query}%22&sortKeys=usage&maximumRecords={?maximumRecords}",
+      "template": "http://experimental.worldcat.org/fast/search?query={subauth}+all+%22{query}%22&sortKeys=usage&{?maximumRecords}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {

--- a/lib/qa/authorities/assign_fast/generic_authority.rb
+++ b/lib/qa/authorities/assign_fast/generic_authority.rb
@@ -53,7 +53,7 @@ module Qa::Authorities
       #   See oclc sample code at
       #   http://experimental.worldcat.org/fast/assignfast/js/assignFASTComplete.js
       def clean_query_string(q)
-        URI.escape(q.gsub(/-|\(|\)|:/, ""))
+        ERB::Util.url_encode(q.gsub(/-|\(|\)|:/, ""))
       end
 
       def parse_authority_response(raw_response)

--- a/lib/qa/authorities/crossref/generic_authority.rb
+++ b/lib/qa/authorities/crossref/generic_authority.rb
@@ -23,7 +23,7 @@ module Qa::Authorities
     end
 
     def build_query_url(q)
-      query = URI.escape(untaint(q))
+      query = ERB::Util.url_encode(untaint(q))
       "http://api.crossref.org/#{subauthority}?query=#{query}"
     end
 

--- a/lib/qa/authorities/geonames.rb
+++ b/lib/qa/authorities/geonames.rb
@@ -17,7 +17,7 @@ module Qa::Authorities
     end
 
     def build_query_url(q)
-      query = URI.escape(untaint(q))
+      query = ERB::Util.url_encode(untaint(q))
       "http://api.geonames.org/searchJSON?q=#{query}&username=#{username}&maxRows=10"
     end
 

--- a/lib/qa/authorities/getty/aat.rb
+++ b/lib/qa/authorities/getty/aat.rb
@@ -7,7 +7,7 @@ module Qa::Authorities
     end
 
     def build_query_url(q)
-      "http://vocab.getty.edu/sparql.json?query=#{URI.escape(sparql(q))}&_implicit=false&implicit=true&_equivalent=false&_form=%2Fsparql"
+      "http://vocab.getty.edu/sparql.json?query=#{ERB::Util.url_encode(sparql(q))}&_implicit=false&implicit=true&_equivalent=false&_form=%2Fsparql"
     end
 
     def sparql(q) # rubocop:disable Metrics/MethodLength

--- a/lib/qa/authorities/getty/tgn.rb
+++ b/lib/qa/authorities/getty/tgn.rb
@@ -7,7 +7,7 @@ module Qa::Authorities
     end
 
     def build_query_url(q)
-      query = URI.escape(sparql(untaint(q)))
+      query = ERB::Util.url_encode(sparql(untaint(q)))
       # Replace ampersands, otherwise the query will fail
       # Gsub hack to convert the encoded regex in the REPLACE into a form Getty understands
       "http://vocab.getty.edu/sparql.json?query=#{query.gsub('&', '%26').gsub(',[%5E,]+,[%5E,]+$', '%2C[^%2C]%2B%2C[^%2C]%2B%24')}&_implicit=false&implicit=true&_equivalent=false&_form=%2Fsparql"

--- a/lib/qa/authorities/getty/ulan.rb
+++ b/lib/qa/authorities/getty/ulan.rb
@@ -8,7 +8,7 @@ module Qa::Authorities
 
     # Replace ampersands, otherwise the query will fail
     def build_query_url(q)
-      "http://vocab.getty.edu/sparql.json?query=#{URI.escape(sparql(q)).gsub('&', '%26')}&_implicit=false&implicit=true&_equivalent=false&_form=%2Fsparql"
+      "http://vocab.getty.edu/sparql.json?query=#{ERB::Util.url_encode(sparql(q)).gsub('&', '%26')}&_implicit=false&implicit=true&_equivalent=false&_form=%2Fsparql"
     end
 
     def sparql(q) # rubocop:disable Metrics/MethodLength

--- a/lib/qa/authorities/linked_data/config.rb
+++ b/lib/qa/authorities/linked_data/config.rb
@@ -40,7 +40,7 @@ module Qa::Authorities
       end
 
       def config_version
-        @config_version ||= authority_config.fetch(:QaConfigVersion, '1.0')
+        @config_version ||= authority_config.fetch(:QA_CONFIG_VERSION, '1.0')
       end
 
       def config_version?(version)

--- a/lib/qa/authorities/linked_data/config.rb
+++ b/lib/qa/authorities/linked_data/config.rb
@@ -75,9 +75,11 @@ module Qa::Authorities
           convert_1_0_url_to_2_0_url(:term)
         end
 
+        # @deprecated Update to linked data config version 2.0 instead
         def convert_1_0_url_to_2_0_url(action_key)
           url_template = @authority_config.fetch(action_key, {}).fetch(:url, {}).fetch(:template, "")
           return if url_template.blank?
+          warn "[DEPRECATED] #Linked data configuration #{authority_name} has 1.0 version format which is deprecated; update to version 2.0 configuration."
           @authority_config[action_key][:url][:template] = url_template.gsub("{?", "{")
         end
     end

--- a/lib/qa/authorities/linked_data/config.rb
+++ b/lib/qa/authorities/linked_data/config.rb
@@ -1,7 +1,6 @@
 require 'qa/authorities/linked_data/config/term_config'.freeze
 require 'qa/authorities/linked_data/config/search_config'.freeze
 require 'json'
-require 'erb'
 
 # Provide attr_reader methods for linked data authority configurations.  Some default configurations are provided for several
 # linked data authorities and can be found at /config/authorities/linked_data.  You can add configurations for new authorities by
@@ -18,10 +17,6 @@ require 'erb'
 module Qa::Authorities
   module LinkedData
     class Config
-      class << self
-        include ERB::Util
-      end
-
       attr_reader :authority_name
 
       # Initialize to hold the configuration for the specifed authority.  Configurations are defined in config/authorities/linked_data.  See README for more information.

--- a/lib/qa/authorities/linked_data/config.rb
+++ b/lib/qa/authorities/linked_data/config.rb
@@ -39,11 +39,20 @@ module Qa::Authorities
         @prefixes ||= authority_config.fetch(:prefixes, {})
       end
 
+      def config_version
+        @config_version ||= authority_config.fetch(:QaConfigVersion, '1.0')
+      end
+
+      def config_version?(version)
+        config_version == version
+      end
+
       # Return the full configuration for an authority
       # @return [String] the authority configuration
       def authority_config
         @authority_config ||= Qa::LinkedData::AuthorityService.authority_config(@authority_name)
         raise Qa::InvalidLinkedDataAuthority, "Unable to initialize linked data authority '#{@authority_name}'" if @authority_config.nil?
+        convert_1_0_to_2_0 if @authority_config.fetch(:QA_CONFIG_VERSION, '1.0') == '1.0'
         @authority_config
       end
 
@@ -58,6 +67,19 @@ module Qa::Authorities
         pred_uri = RDF::URI(pred) unless pred.nil? || pred.length <= 0
         pred_uri
       end
+
+      private
+
+        def convert_1_0_to_2_0
+          convert_1_0_url_to_2_0_url(:search)
+          convert_1_0_url_to_2_0_url(:term)
+        end
+
+        def convert_1_0_url_to_2_0_url(action_key)
+          url_template = @authority_config.fetch(action_key, {}).fetch(:url, {}).fetch(:template, "")
+          return if url_template.blank?
+          @authority_config[action_key][:url][:template] = url_template.gsub("{?", "{")
+        end
     end
   end
 end

--- a/lib/qa/authorities/loc/generic_authority.rb
+++ b/lib/qa/authorities/loc/generic_authority.rb
@@ -24,8 +24,8 @@ module Qa::Authorities
     end
 
     def build_query_url(q)
-      escaped_query = URI.escape(q)
-      authority_fragment = Loc.get_url_for_authority(subauthority) + URI.escape(subauthority)
+      escaped_query = ERB::Util.url_encode(q)
+      authority_fragment = Loc.get_url_for_authority(subauthority) + ERB::Util.url_encode(subauthority)
       "http://id.loc.gov/search/?q=#{escaped_query}&q=#{authority_fragment}&format=json"
     end
 

--- a/lib/qa/authorities/web_service_base.rb
+++ b/lib/qa/authorities/web_service_base.rb
@@ -14,6 +14,7 @@ module Qa::Authorities
     # @param url [String]
     # @return [Hash] a parsed JSON response
     def json(url)
+      Rails.logger.info "Retrieving json for url: #{url}"
       r = response(url).body
       JSON.parse(r)
     end

--- a/spec/fixtures/authorities/linked_data/lod_encoding_config.json
+++ b/spec/fixtures/authorities/linked_data/lod_encoding_config.json
@@ -1,4 +1,5 @@
 {
+  "QA_CONFIG_VERSION": "2.0",
   "term": {
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
@@ -48,7 +49,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type":    "IriTemplate",
-      "template": "http://localhost/test_default/search?query={?query}&{?encode_true}&{?encode_false}&{?encode_not_specified}",
+      "template": "http://localhost/test_default/search?{?query}&{?encode_true}&{?encode_false}&{?encode_not_specified}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {

--- a/spec/fixtures/authorities/linked_data/lod_full_config_1_0.json
+++ b/spec/fixtures/authorities/linked_data/lod_full_config_1_0.json
@@ -1,5 +1,4 @@
 {
-  "QA_CONFIG_VERSION": "2.0",
   "prefixes": {
     "schema": "http://www.w3.org/2000/01/rdf-schema#",
     "skos": "http://www.w3.org/2004/02/skos/core#"
@@ -8,7 +7,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type":    "IriTemplate",
-      "template": "http://localhost/test_default/term/{subauth}/{term_id}?{?param1}&{?param2}",
+      "template": "http://localhost/test_default/term/{?subauth}/{?term_id}?param1={?param1}&param2={?param2}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -64,7 +63,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type": "IriTemplate",
-      "template": "http://localhost/test_default/search?{?subauth}&{?query}&{?param1}&{?param2}",
+      "template": "http://localhost/test_default/search?subauth={?subauth}&query={?query}&param1={?param1}&param2={?param2}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {

--- a/spec/fixtures/authorities/linked_data/lod_lang_defaults.json
+++ b/spec/fixtures/authorities/linked_data/lod_lang_defaults.json
@@ -1,9 +1,10 @@
 {
+  "QA_CONFIG_VERSION": "2.0",
   "term": {
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type":    "IriTemplate",
-      "template": "http://localhost/test_default/term/{?term_id}",
+      "template": "http://localhost/test_default/term/{term_id}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -29,7 +30,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type":    "IriTemplate",
-      "template": "http://localhost/test_default/search?query={?query}",
+      "template": "http://localhost/test_default/search?{?query}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {

--- a/spec/fixtures/authorities/linked_data/lod_lang_multi_defaults.json
+++ b/spec/fixtures/authorities/linked_data/lod_lang_multi_defaults.json
@@ -1,9 +1,10 @@
 {
+  "QA_CONFIG_VERSION": "2.0",
   "term": {
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type":    "IriTemplate",
-      "template": "http://localhost/test_default/term/{?term_id}",
+      "template": "http://localhost/test_default/term/{term_id}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -29,7 +30,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type":    "IriTemplate",
-      "template": "http://localhost/test_default/search?query={?query}",
+      "template": "http://localhost/test_default/search?{?query}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {

--- a/spec/fixtures/authorities/linked_data/lod_lang_no_defaults.json
+++ b/spec/fixtures/authorities/linked_data/lod_lang_no_defaults.json
@@ -1,9 +1,10 @@
 {
+  "QA_CONFIG_VERSION": "2.0",
   "term": {
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type":    "IriTemplate",
-      "template": "http://localhost/test_no_default/term/{?term_id}",
+      "template": "http://localhost/test_no_default/term/{term_id}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -28,7 +29,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type":    "IriTemplate",
-      "template": "http://localhost/test_no_default/search?query={?query}",
+      "template": "http://localhost/test_no_default/search?{?query}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {

--- a/spec/fixtures/authorities/linked_data/lod_lang_param.json
+++ b/spec/fixtures/authorities/linked_data/lod_lang_param.json
@@ -1,9 +1,10 @@
 {
+  "QA_CONFIG_VERSION": "2.0",
   "term": {
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type":    "IriTemplate",
-      "template": "http://localhost/test_replacement/term/{?term_id}?lang={?lang}",
+      "template": "http://localhost/test_replacement/term/{term_id}?{?lang}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -35,7 +36,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type":    "IriTemplate",
-      "template": "http://localhost/test_replacement/search?query={?query}&lang={?lang}",
+      "template": "http://localhost/test_replacement/search?{?query}&{?lang}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {

--- a/spec/fixtures/authorities/linked_data/lod_min_config.json
+++ b/spec/fixtures/authorities/linked_data/lod_min_config.json
@@ -1,9 +1,10 @@
 {
+  "QA_CONFIG_VERSION": "2.0",
   "term": {
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type":    "IriTemplate",
-      "template": "http://localhost/test_default/term/{?term_id}",
+      "template": "http://localhost/test_default/term/{term_id}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -27,7 +28,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type":    "IriTemplate",
-      "template": "http://localhost/test_default/search?query={?query}",
+      "template": "http://localhost/test_default/search?{?query}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {

--- a/spec/fixtures/authorities/linked_data/lod_search_only_config.json
+++ b/spec/fixtures/authorities/linked_data/lod_search_only_config.json
@@ -1,10 +1,11 @@
 {
+  "QA_CONFIG_VERSION": "2.0",
   "term": {},
   "search": {
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type": "IriTemplate",
-      "template": "http://localhost/test_default/search?subauth={?subauth}&query={?query}&param1={?param1}&param2={?param2}",
+      "template": "http://localhost/test_default/search?{?subauth}&{?query}&{?param1}&{?param2}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {

--- a/spec/fixtures/authorities/linked_data/lod_sort.json
+++ b/spec/fixtures/authorities/linked_data/lod_sort.json
@@ -1,10 +1,11 @@
 {
+  "QA_CONFIG_VERSION": "2.0",
   "term": {},
   "search": {
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type":    "IriTemplate",
-      "template": "http://localhost/test_sort/search?query={?query}",
+      "template": "http://localhost/test_sort/search?{?query}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {

--- a/spec/fixtures/authorities/linked_data/lod_term_id_param_config.json
+++ b/spec/fixtures/authorities/linked_data/lod_term_id_param_config.json
@@ -1,9 +1,10 @@
 {
+  "QA_CONFIG_VERSION": "2.0",
   "term": {
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type":    "IriTemplate",
-      "template": "http://localhost/test_default/term/{?term_id}",
+      "template": "http://localhost/test_default/term/{term_id}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {

--- a/spec/fixtures/authorities/linked_data/lod_term_only_config.json
+++ b/spec/fixtures/authorities/linked_data/lod_term_only_config.json
@@ -1,9 +1,10 @@
 {
+  "QA_CONFIG_VERSION": "2.0",
   "term": {
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type":    "IriTemplate",
-      "template": "http://localhost/test_default/term/{?subauth}/{?term_id}?param1={?param1}&param2={?param2}",
+      "template": "http://localhost/test_default/term/{subauth}/{term_id}?{?param1}&{?param2}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {

--- a/spec/fixtures/authorities/linked_data/lod_term_uri_param_config.json
+++ b/spec/fixtures/authorities/linked_data/lod_term_uri_param_config.json
@@ -1,9 +1,10 @@
 {
+  "QA_CONFIG_VERSION": "2.0",
   "term": {
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type":    "IriTemplate",
-      "template": "http://localhost/test_default/term?uri={?term_uri}",
+      "template": "http://localhost/test_default/term?uri={term_uri}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {

--- a/spec/lib/authorities/assign_fast_spec.rb
+++ b/spec/lib/authorities/assign_fast_spec.rb
@@ -48,6 +48,7 @@ describe Qa::Authorities::AssignFast do
           .to_return(status: 200, body: "", headers: {})
       end
       it "logs an info and returns an empty array" do
+        expect(Rails.logger).to receive(:info).with('Retrieving json for url: http://fast.oclc.org/searchfast/fastsuggest?&query=word%20ling&queryIndex=suggestall&queryReturn=suggestall%2Cidroot%2Cauth%2Ctype&suggest=autoSubject&rows=20')
         msg = "Could not parse response as JSON. Request url: " \
               "http://fast.oclc.org/searchfast/fastsuggest?&query=word%20ling&queryIndex=suggestall&queryReturn=suggestall%2Cidroot%2Cauth%2Ctype&suggest=autoSubject&rows=20"
         expect(Rails.logger).to receive(:info).with(msg)

--- a/spec/lib/authorities/linked_data/authority_service_spec.rb
+++ b/spec/lib/authorities/linked_data/authority_service_spec.rb
@@ -5,6 +5,7 @@ describe Qa::LinkedData::AuthorityService do
     [:LOC,
      :LOD_ENCODING_CONFIG,
      :LOD_FULL_CONFIG,
+     :LOD_FULL_CONFIG_1_0,
      :LOD_LANG_DEFAULTS,
      :LOD_LANG_MULTI_DEFAULTS,
      :LOD_LANG_NO_DEFAULTS,

--- a/spec/lib/authorities/linked_data/config_spec.rb
+++ b/spec/lib/authorities/linked_data/config_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Qa::Authorities::LinkedData::Config do
   let(:full_config) { described_class.new(:LOD_FULL_CONFIG) }
+  let(:full_config_1_0) { described_class.new(:LOD_FULL_CONFIG_1_0) }
 
   describe '#new' do
     context 'without an authority' do
@@ -24,6 +25,7 @@ describe Qa::Authorities::LinkedData::Config do
   describe '#authority_config' do
     let(:full_auth_config) do
       {
+        QA_CONFIG_VERSION: "2.0",
         prefixes: {
           schema: "http://www.w3.org/2000/01/rdf-schema#",
           skos: "http://www.w3.org/2004/02/skos/core#"
@@ -32,7 +34,7 @@ describe Qa::Authorities::LinkedData::Config do
           url: {
             :@context => 'http://www.w3.org/ns/hydra/context.jsonld',
             :@type => 'IriTemplate',
-            template: 'http://localhost/test_default/term/{?subauth}/{?term_id}?param1={?param1}&param2={?param2}',
+            template: 'http://localhost/test_default/term/{subauth}/{term_id}?{?param1}&{?param2}',
             variableRepresentation: 'BasicRepresentation',
             mapping: [
               {
@@ -88,7 +90,174 @@ describe Qa::Authorities::LinkedData::Config do
           url: {
             :@context => 'http://www.w3.org/ns/hydra/context.jsonld',
             :@type => 'IriTemplate',
-            template: 'http://localhost/test_default/search?subauth={?subauth}&query={?query}&param1={?param1}&param2={?param2}',
+            template: 'http://localhost/test_default/search?{?subauth}&{?query}&{?param1}&{?param2}',
+            variableRepresentation: 'BasicRepresentation',
+            mapping: [
+              {
+                :@type => 'IriTemplateMapping',
+                variable: 'query',
+                property: 'hydra:freetextQuery',
+                required: true
+              },
+              {
+                :@type => 'IriTemplateMapping',
+                variable: 'subauth',
+                property: 'hydra:freetextQuery',
+                required: false,
+                default: 'search_sub1_name'
+              },
+              {
+                :@type => 'IriTemplateMapping',
+                variable: 'param1',
+                property: 'hydra:freetextQuery',
+                required: false,
+                default: 'delta'
+              },
+              {
+                :@type => 'IriTemplateMapping',
+                variable: 'param2',
+                property: 'hydra:freetextQuery',
+                required: false,
+                default: 'echo'
+              }
+            ]
+          },
+          qa_replacement_patterns: {
+            query: 'query',
+            subauth: 'subauth'
+          },
+          language: ['en', 'fr', 'de'],
+          results: {
+            id_predicate: 'http://purl.org/dc/terms/identifier',
+            label_predicate: 'http://www.w3.org/2004/02/skos/core#prefLabel',
+            altlabel_predicate: 'http://www.w3.org/2004/02/skos/core#altLabel',
+            sort_predicate: 'http://www.w3.org/2004/02/skos/core#prefLabel'
+          },
+          context: {
+            groups: {
+              dates: {
+                group_label_i18n: "qa.linked_data.authority.locnames_ld4l_cache.dates",
+                group_label_default: "Dates"
+              },
+              hierarchy: {
+                group_label_i18n: "qa.linked_data.authority.locgenres_ld4l_cache.hierarchy",
+                group_label_default: "Hierarchy"
+              }
+            },
+            properties: [
+              {
+                property_label_i18n: "qa.linked_data.authority.locgenres_ld4l_cache.authoritative_label",
+                property_label_default: "Authoritative Label",
+                ldpath: "madsrdf:authoritativeLabel",
+                selectable: true,
+                drillable: false
+              },
+              {
+                group_id: "dates",
+                property_label_i18n: "qa.linked_data.authority.locnames_ld4l_cache.birth_date",
+                property_label_default: "Birth",
+                ldpath: "madsrdf:identifiesRWO/madsrdf:birthDate/schema:label",
+                selectable: false,
+                drillable: false
+              },
+              {
+                group_id: "hierarchy",
+                property_label_i18n: "qa.linked_data.authority.locgenres_ld4l_cache.narrower",
+                property_label_default: "Narrower",
+                ldpath: "skos:narrower :: xsd:string",
+                selectable: true,
+                drillable: true,
+                expansion_label_ldpath: "skos:prefLabel ::xsd:string",
+                expansion_id_ldpath: "loc:lccn ::xsd:string"
+              },
+              {
+                group_id: "hierarchy",
+                property_label_i18n: "qa.linked_data.authority.locgenres_ld4l_cache.broader",
+                property_label_default: "Broader",
+                ldpath: "skos:broader :: xsd:string",
+                selectable: true,
+                drillable: true,
+                expansion_label_ldpath: "skos:prefLabel ::xsd:string",
+                expansion_id_ldpath: "loc:lccn ::xsd:string"
+              }
+            ]
+          },
+          subauthorities: {
+            search_sub1_key: 'search_sub1_name',
+            search_sub2_key: 'search_sub2_name',
+            search_sub3_key: 'search_sub3_name'
+          }
+        }
+      }
+    end
+
+    let(:full_auth_config_1_0) do
+      {
+        prefixes: {
+          schema: "http://www.w3.org/2000/01/rdf-schema#",
+          skos: "http://www.w3.org/2004/02/skos/core#"
+        },
+        term: {
+          url: {
+            :@context => 'http://www.w3.org/ns/hydra/context.jsonld',
+            :@type => 'IriTemplate',
+            template: 'http://localhost/test_default/term/{subauth}/{term_id}?param1={param1}&param2={param2}',
+            variableRepresentation: 'BasicRepresentation',
+            mapping: [
+              {
+                :@type => 'IriTemplateMapping',
+                variable: 'term_id',
+                property: 'hydra:freetextQuery',
+                required: true
+              },
+              {
+                :@type => 'IriTemplateMapping',
+                variable: 'subauth',
+                property: 'hydra:freetextQuery',
+                required: false,
+                default: 'term_sub2_name'
+              },
+              {
+                :@type => 'IriTemplateMapping',
+                variable: 'param1',
+                property: 'hydra:freetextQuery',
+                required: false,
+                default: 'alpha'
+              },
+              {
+                :@type => 'IriTemplateMapping',
+                variable: 'param2',
+                property: 'hydra:freetextQuery',
+                required: false,
+                default: 'beta'
+              }
+            ]
+          },
+          qa_replacement_patterns: {
+            term_id: 'term_id',
+            subauth: 'subauth'
+          },
+          term_id: 'ID',
+          language: ['en'],
+          results: {
+            id_predicate: 'http://purl.org/dc/terms/identifier',
+            label_predicate: 'http://www.w3.org/2004/02/skos/core#prefLabel',
+            altlabel_predicate: 'http://www.w3.org/2004/02/skos/core#altLabel',
+            broader_predicate: 'http://www.w3.org/2004/02/skos/core#broader',
+            narrower_predicate: 'http://www.w3.org/2004/02/skos/core#narrower',
+            sameas_predicate: 'http://www.w3.org/2004/02/skos/core#exactMatch'
+          },
+          subauthorities: {
+            term_sub1_key: 'term_sub1_name',
+            term_sub2_key: 'term_sub2_name',
+            term_sub3_key: 'term_sub3_name'
+          }
+        },
+        search: {
+          url: {
+            :@context => 'http://www.w3.org/ns/hydra/context.jsonld',
+            :@type => 'IriTemplate',
+            template: 'http://localhost/test_default/search?subauth={subauth}&query={query}&param1={param1}&param2={param2}',
             variableRepresentation: 'BasicRepresentation',
             mapping: [
               {
@@ -190,9 +359,14 @@ describe Qa::Authorities::LinkedData::Config do
     end
 
     let(:authority_config) { full_config.authority_config }
+    let(:authority_config_1_0) { full_config_1_0.authority_config }
 
-    it 'returns hash of the full authority configuration' do
+    it 'returns hash of the full authority 2.0 configuration' do
       expect(authority_config).to eq full_auth_config
+    end
+
+    it 'returns hash of 1.0 configuration converting all {?var} to {var}' do
+      expect(authority_config_1_0).to eq full_auth_config_1_0
     end
   end
 

--- a/spec/lib/authorities/linked_data/config_spec.rb
+++ b/spec/lib/authorities/linked_data/config_spec.rb
@@ -395,4 +395,28 @@ describe Qa::Authorities::LinkedData::Config do
       expect(full_config.prefixes).to eq expected_results
     end
   end
+
+  describe '#config_version' do
+    context 'when version is NOT in the config file' do
+      it 'returns default as 1.0' do
+        expect(full_config_1_0.config_version).to eq '1.0'
+      end
+    end
+
+    context 'when version is specified in the config file' do
+      it 'returns the version from the config file' do
+        expect(full_config.config_version).to eq '2.0'
+      end
+    end
+  end
+
+  describe '#config_version?' do
+    it "returns true if the passed in version matches the authority's version" do
+      expect(full_config.config_version?('2.0')).to eq true
+    end
+
+    it "returns false if the passed in version does NOT match the authority's version" do
+      expect(full_config_1_0.config_version?('2.0')).to eq false
+    end
+  end
 end

--- a/spec/lib/authorities/linked_data/search_config_spec.rb
+++ b/spec/lib/authorities/linked_data/search_config_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Qa::Authorities::LinkedData::SearchConfig do
         url: {
           :@context => 'http://www.w3.org/ns/hydra/context.jsonld',
           :@type => 'IriTemplate',
-          template: 'http://localhost/test_default/search?subauth={?subauth}&query={?query}&param1={?param1}&param2={?param2}',
+          template: 'http://localhost/test_default/search?{?subauth}&{?query}&{?param1}&{?param2}',
           variableRepresentation: 'BasicRepresentation',
           mapping: [
             {

--- a/spec/lib/authorities/linked_data/term_config_spec.rb
+++ b/spec/lib/authorities/linked_data/term_config_spec.rb
@@ -12,7 +12,7 @@ describe Qa::Authorities::LinkedData::TermConfig do
         url: {
           :@context => 'http://www.w3.org/ns/hydra/context.jsonld',
           :@type => 'IriTemplate',
-          template: 'http://localhost/test_default/term/{?subauth}/{?term_id}?param1={?param1}&param2={?param2}',
+          template: 'http://localhost/test_default/term/{subauth}/{term_id}?{?param1}&{?param2}',
           variableRepresentation: 'BasicRepresentation',
           mapping: [
             {
@@ -88,7 +88,7 @@ describe Qa::Authorities::LinkedData::TermConfig do
       {
         :@context => 'http://www.w3.org/ns/hydra/context.jsonld',
         :@type => 'IriTemplate',
-        template: 'http://localhost/test_default/term/{?subauth}/{?term_id}?param1={?param1}&param2={?param2}',
+        template: 'http://localhost/test_default/term/{subauth}/{term_id}?{?param1}&{?param2}',
         variableRepresentation: 'BasicRepresentation',
         mapping: [
           {

--- a/spec/models/iri_template/url_config_spec.rb
+++ b/spec/models/iri_template/url_config_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Qa::IriTemplate::UrlConfig do
     {
       :"@context" => "http://www.w3.org/ns/hydra/context.jsonld",
       :"@type" => "IriTemplate",
-      template: "http://localhost/test_default/search?subauth={?subauth}&query={?query}&param1={?param1}&param2={?param2}",
+      template: "http://localhost/test_default/search?{?subauth}&{?query}&{?param1}&{?param2}",
       variableRepresentation: "BasicRepresentation",
       mapping: [
         {
@@ -60,7 +60,7 @@ RSpec.describe Qa::IriTemplate::UrlConfig do
 
     context 'when missing mapping' do
       before do
-        allow(url_template).to receive(:fetch).with(:template, nil).and_return("http://localhost/test_default/search?subauth={?subauth}&query={?query}&param1={?param1}&param2={?param2}")
+        allow(url_template).to receive(:fetch).with(:template, nil).and_return("http://localhost/test_default/search?{?subauth}&{?query}&{?param1}&{?param2}")
         allow(url_template).to receive(:fetch).with(:mapping, nil).and_return(nil)
       end
 
@@ -71,7 +71,7 @@ RSpec.describe Qa::IriTemplate::UrlConfig do
 
     context 'when no maps defined' do
       before do
-        allow(url_template).to receive(:fetch).with(:template, nil).and_return("http://localhost/test_default/search?subauth={?subauth}&query={?query}&param1={?param1}&param2={?param2}")
+        allow(url_template).to receive(:fetch).with(:template, nil).and_return("http://localhost/test_default/search?{?subauth}&{?query}&{?param1}&{?param2}")
         allow(url_template).to receive(:fetch).with(:mapping, nil).and_return([])
       end
 
@@ -85,7 +85,7 @@ RSpec.describe Qa::IriTemplate::UrlConfig do
     subject { described_class.new(url_template) }
 
     it 'returns the configured url template' do
-      expect(subject.template).to eq 'http://localhost/test_default/search?subauth={?subauth}&query={?query}&param1={?param1}&param2={?param2}'
+      expect(subject.template).to eq 'http://localhost/test_default/search?{?subauth}&{?query}&{?param1}&{?param2}'
     end
   end
 

--- a/spec/services/iri_template_service_spec.rb
+++ b/spec/services/iri_template_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Qa::IriTemplateService do
     {
       :'@context' => 'http://www.w3.org/ns/hydra/context.jsonld',
       :'@type' => 'IriTemplate',
-      template: 'http://localhost/test_default/search?subauth={?subauth}&query={?query}&max_records={?max_records}&language={?language}',
+      template: 'http://localhost/test_default/search?{?subauth}&{?query}&{?max_records}&{?language}',
       variableRepresentation: 'BasicRepresentation',
       mapping: [
         {


### PR DESCRIPTION
This is the closest replacement to what already exists.  There are multiple discussions on what is the correct way to do this.  We may want to revisit later.

See… https://stackoverflow.com/questions/2824126/whats-the-difference-between-uri-escape-and-cgi-escape

This addresses deprecation warnings associated with `URI.escape`