### PR TITLE
Provide better error messages

### DIFF
--- a/app/controllers/qa/linked_data_terms_controller.rb
+++ b/app/controllers/qa/linked_data_terms_controller.rb
@@ -34,20 +34,23 @@ class Qa::LinkedDataTermsController < ::ApplicationController
   # Return a list of terms based on a query
   # get "/search/linked_data/:vocab(/:subauthority)"
   # @see Qa::Authorities::LinkedData::SearchQuery#search
-  def search
+  def search # rubocop:disable Metrics/MethodLength
     terms = @authority.search(query, subauth: subauthority, language: language, replacements: replacement_params, context: context?)
     cors_allow_origin_header(response)
     render json: terms
   rescue Qa::ServiceUnavailable
-    logger.warn "Service Unavailable - Search query #{query} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
-    head :service_unavailable
+    msg = "Service Unavailable - Search query #{query} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
+    logger.warn msg
+    render json: { errors: msg }, status: :service_unavailable
   rescue Qa::ServiceError
-    logger.warn "Internal Server Error - Search query #{query} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
-    head :internal_server_error
+    msg = "Internal Server Error - Search query #{query} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
+    logger.warn msg
+    render json: { errors: msg }, status: :internal_server_error
   rescue RDF::FormatError
-    logger.warn "RDF Format Error - Results from search query #{query} for#{subauth_warn_msg} authority #{vocab_param} " \
+    msg = "RDF Format Error - Results from search query #{query} for#{subauth_warn_msg} authority #{vocab_param} " \
                 "was not identified as a valid RDF format.  You may need to include the linkeddata gem."
-    head :internal_server_error
+    logger.warn msg
+    render json: { errors: msg }, status: :internal_server_error
   end
 
   # Return all the information for a given term given an id or URI
@@ -60,18 +63,22 @@ class Qa::LinkedDataTermsController < ::ApplicationController
     content_type = jsonld? ? 'application/ld+json' : 'application/json'
     render json: term, content_type: content_type
   rescue Qa::TermNotFound
-    logger.warn "Term Not Found - Fetch term #{id} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
-    head :not_found
+    msg = "Term Not Found - Fetch term #{id} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
+    logger.warn msg
+    render json: { errors: msg }, status: :not_found
   rescue Qa::ServiceUnavailable
-    logger.warn "Service Unavailable - Fetch term #{id} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
-    head :service_unavailable
+    msg = "Service Unavailable - Fetch term #{id} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
+    logger.warn msg
+    render json: { errors: msg }, status: :service_unavailable
   rescue Qa::ServiceError
-    logger.warn "Internal Server Error - Fetch term #{id} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
-    head :internal_server_error
+    msg = "Internal Server Error - Fetch term #{id} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
+    logger.warn msg
+    render json: { errors: msg }, status: :internal_server_error
   rescue RDF::FormatError
-    logger.warn "RDF Format Error - Results from fetch term #{id} for#{subauth_warn_msg} authority #{vocab_param} " \
+    msg = "RDF Format Error - Results from fetch term #{id} for#{subauth_warn_msg} authority #{vocab_param} " \
                 "was not identified as a valid RDF format.  You may need to include the linkeddata gem."
-    head :internal_server_error
+    logger.warn msg
+    render json: { errors: msg }, status: :internal_server_error
   end
 
   # Return all the information for a given term given a URI
@@ -83,50 +90,58 @@ class Qa::LinkedDataTermsController < ::ApplicationController
     content_type = jsonld? ? 'application/ld+json' : 'application/json'
     render json: term, content_type: content_type
   rescue Qa::TermNotFound
-    logger.warn "Term Not Found - Fetch term #{uri} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
-    head :not_found
+    msg = "Term Not Found - Fetch term #{uri} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
+    logger.warn msg
+    render json: { errors: msg }, status: :not_found
   rescue Qa::ServiceUnavailable
-    logger.warn "Service Unavailable - Fetch term #{uri} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
-    head :service_unavailable
+    msg = "Service Unavailable - Fetch term #{uri} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
+    logger.warn msg
+    render json: { errors: msg }, status: :service_unavailable
   rescue Qa::ServiceError
-    logger.warn "Internal Server Error - Fetch term #{uri} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
-    head :internal_server_error
+    msg = "Internal Server Error - Fetch term #{uri} unsuccessful for#{subauth_warn_msg} authority #{vocab_param}"
+    logger.warn msg
+    render json: { errors: msg }, status: :internal_server_error
   rescue RDF::FormatError
-    logger.warn "RDF Format Error - Results from fetch term #{uri} for#{subauth_warn_msg} authority #{vocab_param} " \
+    msg = "RDF Format Error - Results from fetch term #{uri} for#{subauth_warn_msg} authority #{vocab_param} " \
                 "was not identified as a valid RDF format.  You may need to include the linkeddata gem."
-    head :internal_server_error
+    logger.warn msg
+    render json: { errors: msg }, status: :internal_server_error
   end
 
   private
 
     def check_authority
       if params[:vocab].nil? || !params[:vocab].size.positive? # rubocop:disable Style/GuardClause
-        logger.warn "Required param 'vocab' is missing or empty"
-        head :bad_request
+        msg = "Required param 'vocab' is missing or empty"
+        logger.warn msg
+        render json: { errors: msg }, status: :bad_request
       end
     end
 
     def check_search_subauthority
       return if subauthority.nil?
       unless @authority.search_subauthority?(subauthority) # rubocop:disable Style/GuardClause
-        logger.warn "Unable to initialize linked data search sub-authority '#{subauthority}' for authority '#{vocab_param}'"
-        head :bad_request
+        msg = "Unable to initialize linked data search sub-authority '#{subauthority}' for authority '#{vocab_param}'"
+        logger.warn msg
+        render json: { errors: msg }, status: :bad_request
       end
     end
 
     def check_show_subauthority
       return if subauthority.nil?
       unless @authority.term_subauthority?(subauthority) # rubocop:disable Style/GuardClause
-        logger.warn "Unable to initialize linked data term sub-authority '#{subauthority}' for authority '#{vocab_param}'"
-        head :bad_request
+        msg = "Unable to initialize linked data term sub-authority '#{subauthority}' for authority '#{vocab_param}'"
+        logger.warn msg
+        render json: { errors: msg }, status: :bad_request
       end
     end
 
     def init_authority
       @authority = Qa::Authorities::LinkedData::GenericAuthority.new(vocab_param)
     rescue Qa::InvalidLinkedDataAuthority => e
-      logger.warn e.message
-      head :bad_request
+      msg = e.message
+      logger.warn msg
+      render json: { errors: msg }, status: :bad_request
     end
 
     def vocab_param
@@ -146,8 +161,9 @@ class Qa::LinkedDataTermsController < ::ApplicationController
     end
 
     def missing_required_param(action_name, param_name)
-      logger.warn "Required #{action_name} param '#{param_name}' is missing or empty"
-      head :bad_request
+      msg = "Required #{action_name} param '#{param_name}' is missing or empty"
+      logger.warn msg
+      render json: { errors: msg }, status: :bad_request
     end
 
     # converts wildcards into URL-encoded characters
@@ -198,8 +214,9 @@ class Qa::LinkedDataTermsController < ::ApplicationController
       token = params.key?(:auth_token) ? params[:auth_token] : nil
       valid = Qa.config.valid_authority_reload_token?(token)
       return true if valid
-      logger.warn "FAIL: unable to reload authorities; error_msg: Invalid token (#{token}) does not match expected token."
-      head :unauthorized
+      msg = "FAIL: unable to reload authorities; error_msg: Invalid token (#{token}) does not match expected token."
+      logger.warn msg
+      render json: { errors: msg }, status: :unauthorized
       false
     end
 end

--- a/app/controllers/qa/terms_controller.rb
+++ b/app/controllers/qa/terms_controller.rb
@@ -34,15 +34,19 @@ class Qa::TermsController < ::ApplicationController
   end
 
   def check_vocab_param
-    head :not_found unless params[:vocab].present?
+    return if params[:vocab].present?
+    msg = "Required param 'vocab' is missing or empty"
+    logger.warn msg
+    render json: { errors: msg }, status: :bad_request
   end
 
   def init_authority # rubocop:disable Metrics/MethodLength
     begin
       mod = authority_class.camelize.constantize
     rescue NameError
-      logger.warn "Unable to initialize authority #{authority_class}"
-      head :not_found
+      msg = "Unable to initialize authority #{authority_class}"
+      logger.warn msg
+      render json: { errors: msg }, status: :bad_request
       return
     end
     begin
@@ -53,13 +57,17 @@ class Qa::TermsController < ::ApplicationController
                      mod.subauthority_for(params[:subauthority])
                    end
     rescue Qa::InvalidSubAuthority, Qa::MissingSubAuthority => e
-      logger.warn e.message
-      head :not_found
+      msg = e.message
+      logger.warn msg
+      render json: { errors: msg }, status: :bad_request
     end
   end
 
   def check_query_param
-    head :not_found unless params[:q].present?
+    return if params[:q].present?
+    msg = "Required param 'q' is missing or empty"
+    logger.warn msg
+    render json: { errors: msg }, status: :bad_request
   end
 
   private

--- a/spec/controllers/terms_controller_spec.rb
+++ b/spec/controllers/terms_controller_spec.rb
@@ -6,29 +6,29 @@ describe Qa::TermsController, type: :controller do
   end
 
   describe "#check_vocab_param" do
-    it "returns 404 if the vocabulary is missing" do
+    it "returns 400 if the vocabulary is missing" do
       get :search, params: { q: "a query", vocab: "" }
-      expect(response.code).to eq("404")
+      expect(response.code).to eq("400")
     end
   end
 
   describe "#check_query_param" do
-    it "returns 404 if the query is missing" do
+    it "returns 400 if the query is missing" do
       get :search, params: { q: "", vocab: "tgnlang" }
-      expect(response.code).to eq("404")
+      expect(response.code).to eq("400")
     end
   end
 
   describe "#init_authority" do
     context "when the authority does not exist" do
-      it "returns 404" do
+      it "returns 400" do
         expect(Rails.logger).to receive(:warn).with("Unable to initialize authority Qa::Authorities::Non-existent-authority")
         get :search, params: { q: "a query", vocab: "non-existent-authority" }
-        expect(response.code).to eq("404")
+        expect(response.code).to eq("400")
       end
     end
     context "when a sub-authority does not exist" do
-      it "returns 404 if a sub-authority does not exist" do
+      it "returns 400 if a sub-authority does not exist" do
         msg = "Unable to initialize sub-authority non-existent-subauthority for Qa::Authorities::Loc. Valid sub-authorities are " \
               "[\"subjects\", \"names\", \"classification\", \"childrensSubjects\", \"genreForms\", \"performanceMediums\", " \
               "\"graphicMaterials\", \"organizations\", \"relators\", \"countries\", \"ethnographicTerms\", \"geographicAreas\", " \
@@ -40,17 +40,17 @@ describe Qa::TermsController, type: :controller do
               "\"signatureEncoding\", \"signatureMethod\", \"softwareType\", \"storageMedium\"]"
         expect(Rails.logger).to receive(:warn).with(msg)
         get :search, params: { q: "a query", vocab: "loc", subauthority: "non-existent-subauthority" }
-        expect(response.code).to eq("404")
+        expect(response.code).to eq("400")
       end
     end
     context "when a sub-authority is absent" do
-      it "returns 404 for LOC" do
+      it "returns 400 for LOC" do
         get :search, params: { q: "a query", vocab: "loc" }
-        expect(response.code).to eq("404")
+        expect(response.code).to eq("400")
       end
-      it "returns 404 for oclcts" do
+      it "returns 400 for oclcts" do
         get :search, params: { q: "a query", vocab: "oclcts" }
-        expect(response.code).to eq("404")
+        expect(response.code).to eq("400")
       end
     end
   end
@@ -88,7 +88,7 @@ describe Qa::TermsController, type: :controller do
         expect(response).to be_successful
       end
 
-      it "does not return 404 if subauthority is valid" do
+      it "does not return 400 if subauthority is valid" do
         get :search, params: { q: "Berry", vocab: "loc", subauthority: "names" }
         expect(response).to be_successful
       end


### PR DESCRIPTION
* For malformed requests (e.g. missing required parameter, non-supported auths/subauths), terms_controller currently returns 404, not_found.  This was changed to use 400, bad_request, which is what linked_data_terms_controller already uses for these types of errors. (Fixes issue #162)

* For both controllers, error messages now return error json when errors occur.  (Fixes Issue #58)

```
{"errors":"Required search param 'q' is missing or empty"}
```