### PR TITLE
Catch and log error when response from Getty contains an error

### DIFF
--- a/lib/qa/authorities/getty/aat.rb
+++ b/lib/qa/authorities/getty/aat.rb
@@ -52,6 +52,11 @@ module Qa::Authorities
         response['results']['bindings'].map do |result|
           { 'id' => result['s']['value'], 'label' => result['name']['value'] }
         end
+      rescue StandardError => e
+        cause = response.fetch('error', {}).fetch('cause', 'UNKNOWN')
+        cause = cause.present? ? cause : 'UNKNOWN'
+        Rails.logger.warn "  ERROR fetching Getty response: #{e.message}; cause: #{cause}"
+        {}
       end
   end
 end

--- a/lib/qa/authorities/getty/tgn.rb
+++ b/lib/qa/authorities/getty/tgn.rb
@@ -59,6 +59,11 @@ module Qa::Authorities
         response['results']['bindings'].map do |result|
           { 'id' => result['s']['value'], 'label' => result['name']['value'] + ' (' + result['par']['value'].gsub(/\,[^\,]+\,[^\,]+$/, '') + ')' }
         end
+      rescue StandardError => e
+        cause = response.fetch('error', {}).fetch('cause', 'UNKNOWN')
+        cause = cause.present? ? cause : 'UNKNOWN'
+        Rails.logger.warn "  ERROR fetching Getty response: #{e.message}; cause: #{cause}"
+        {}
       end
   end
 end

--- a/lib/qa/authorities/getty/ulan.rb
+++ b/lib/qa/authorities/getty/ulan.rb
@@ -57,6 +57,11 @@ module Qa::Authorities
         response['results']['bindings'].map do |result|
           { 'id' => result['s']['value'], 'label' => result['name']['value'] + ' (' + result['bio']['value'] + ')' }
         end
+      rescue StandardError => e
+        cause = response.fetch('error', {}).fetch('cause', 'UNKNOWN')
+        cause = cause.present? ? cause : 'UNKNOWN'
+        Rails.logger.warn "  ERROR fetching Getty response: #{e.message}; cause: #{cause}"
+        {}
       end
   end
 end

--- a/spec/fixtures/getty-error-response.txt
+++ b/spec/fixtures/getty-error-response.txt
@@ -1,0 +1,10 @@
+{
+  "error" : {
+    "cause" : null,
+    "stackTrace" : [],
+    "message" : "/sparql.json?+%28regex%28%3Fname%2C+%22amphorae%22%2C+%22i%22%29%29%29+.+%7D+ORDER+BY+%3Fname&_equivalent=false&_form=%2Fsparql&_implicit=false&implicit=true&query=SELECT+%3Fs+%3Fname+%7B+%3Fs+a+skos%3AConcept%3B+luc%3Aterm+%22Panathenaic+amphorae%22%3B+skos%3AinScheme+%3Chttp%3A%2F%2Fvocab.getty.edu%2Faat%2F%3E+%3B+gvp%3AprefLabelGVP+%5Bskosxl%3AliteralForm+%3Fname%5D.+FILTER+%28%28regex%28%3Fname%2C+%22Panathenaic%22%2C+%22i%22%29%29+",
+    "localizedMessage" : "/sparql.json?+%28regex%28%3Fname%2C+%22amphorae%22%2C+%22i%22%29%29%29+.+%7D+ORDER+BY+%3Fname&_equivalent=false&_form=%2Fsparql&_implicit=false&implicit=true&query=SELECT+%3Fs+%3Fname+%7B+%3Fs+a+skos%3AConcept%3B+luc%3Aterm+%22Panathenaic+amphorae%22%3B+skos%3AinScheme+%3Chttp%3A%2F%2Fvocab.getty.edu%2Faat%2F%3E+%3B+gvp%3AprefLabelGVP+%5Bskosxl%3AliteralForm+%3Fname%5D.+FILTER+%28%28regex%28%3Fname%2C+%22Panathenaic%22%2C+%22i%22%29%29+",
+    "suppressed" : []
+  },
+  "stackTrace" : ""
+}

--- a/spec/lib/authorities/getty/aat_spec.rb
+++ b/spec/lib/authorities/getty/aat_spec.rb
@@ -27,6 +27,18 @@ describe Qa::Authorities::Getty::AAT do
         expect(subject.last).to eq("id" => 'http://vocab.getty.edu/aat/300265560', "label" => "photoscreenprints")
         expect(subject.size).to eq(10)
       end
+
+      context 'when Getty returns an error,' do
+        before do
+          stub_request(:get, /vocab\.getty\.edu.*/)
+            .to_return(body: webmock_fixture("getty-error-response.txt"), status: 500)
+        end
+
+        it 'logs error and returns empty results' do
+          expect(Rails.logger).to receive(:warn).with("  ERROR fetching Getty response: undefined method `[]' for nil:NilClass; cause: UNKNOWN")
+          expect(subject).to be {}
+        end
+      end
     end
   end
 

--- a/spec/lib/authorities/getty/tgn_spec.rb
+++ b/spec/lib/authorities/getty/tgn_spec.rb
@@ -27,6 +27,18 @@ describe Qa::Authorities::Getty::TGN do
         expect(subject.last).to eq("id" => 'http://vocab.getty.edu/tgn/7022503', "label" => "Cawood Branch (Kentucky, United States)")
         expect(subject.size).to eq(6)
       end
+
+      context 'when Getty returns an error,' do
+        before do
+          stub_request(:get, /vocab\.getty\.edu.*/)
+            .to_return(body: webmock_fixture("getty-error-response.txt"), status: 500)
+        end
+
+        it 'logs error and returns empty results' do
+          expect(Rails.logger).to receive(:warn).with("  ERROR fetching Getty response: undefined method `[]' for nil:NilClass; cause: UNKNOWN")
+          expect(subject).to be {}
+        end
+      end
     end
   end
 

--- a/spec/lib/authorities/getty/ulan_spec.rb
+++ b/spec/lib/authorities/getty/ulan_spec.rb
@@ -27,6 +27,18 @@ describe Qa::Authorities::Getty::Ulan do
         expect(subject.last).to eq("id" => 'http://vocab.getty.edu/ulan/500023812', "label" => "Warren, Charles Turner (English engraver, 1762-1823)")
         expect(subject.size).to eq(142)
       end
+
+      context 'when Getty returns an error,' do
+        before do
+          stub_request(:get, /vocab\.getty\.edu.*/)
+            .to_return(body: webmock_fixture("getty-error-response.txt"), status: 500)
+        end
+
+        it 'logs error and returns empty results' do
+          expect(Rails.logger).to receive(:warn).with("  ERROR fetching Getty response: undefined method `[]' for nil:NilClass; cause: UNKNOWN")
+          expect(subject).to be {}
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Failing URL:  http://localhost:3000/qa/search/getty/aat?q=Panathenaic%20amphorae

Logs: ` ERROR fetching Getty response: undefined method `[]' for nil:NilClass; cause: UNKNOWN`
Returns: `{}`