### PR TITLE
Default id to subject uri when missing

### DIFF
--- a/lib/qa/authorities/linked_data/search_query.rb
+++ b/lib/qa/authorities/linked_data/search_query.rb
@@ -68,9 +68,13 @@ module Qa::Authorities
           preds = { label: label_pred_uri }
           preds[:uri] = :subject_uri
           preds[:altlabel] = search_config.results_altlabel_predicate unless search_config.results_altlabel_predicate.nil?
-          preds[:id] = search_config.results_id_predicate unless search_config.results_id_predicate.nil?
+          preds[:id] = id_predicate.present? ? id_predicate : :subject_uri
           preds[:sort] = sort_predicate.present? ? sort_predicate : preds[:label]
           preds
+        end
+
+        def id_predicate
+          @id_predicate ||= search_config.results_id_predicate
         end
 
         def sort_predicate
@@ -86,7 +90,7 @@ module Qa::Authorities
         def convert_result_to_json(result)
           json_result = {}
           json_result[:uri] = result[:uri].first.to_s
-          json_result[:id] = result[:id].first.to_s
+          json_result[:id] = result[:id].any? ? result[:id].first.to_s : ""
           json_result[:label] = full_label(result[:label], result[:altlabel])
           json_result[:context] = result[:context] if context?
           json_result

--- a/spec/fixtures/authorities/linked_data/lod_min_config.json
+++ b/spec/fixtures/authorities/linked_data/lod_min_config.json
@@ -43,7 +43,6 @@
       "query": "query"
     },
     "results": {
-      "id_predicate":       "http://purl.org/dc/terms/identifier",
       "label_predicate":    "http://www.w3.org/2004/02/skos/core#prefLabel"
     }
   }

--- a/spec/lib/authorities/linked_data/generic_authority_spec.rb
+++ b/spec/lib/authorities/linked_data/generic_authority_spec.rb
@@ -58,6 +58,21 @@ RSpec.describe Qa::Authorities::LinkedData::GenericAuthority do
       end
     end
 
+    context 'when id predicate is not specified' do
+      let(:min_authority) { described_class.new(:LOD_MIN_CONFIG) }
+      let :results do
+        stub_request(:get, 'http://localhost/test_default/search?query=peanuts')
+          .to_return(status: 200, body: webmock_fixture('lod_oclc_personalName_query_3_results.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
+        min_authority.search('peanuts')
+      end
+      it 'uses subject uri for id' do
+        expect(results.count).to eq(3)
+        expect(results.first).to eq(uri: 'http://id.worldcat.org/fast/409667', id: 'http://id.worldcat.org/fast/409667', label: 'Cornell, Ezra, 1807-1874')
+        expect(results.second).to eq(uri: 'http://id.worldcat.org/fast/5140', id: 'http://id.worldcat.org/fast/5140', label: 'Cornell, Joseph')
+        expect(results.third).to eq(uri: 'http://id.worldcat.org/fast/72456', id: 'http://id.worldcat.org/fast/72456', label: 'Cornell, Sarah Maria, 1802-1832')
+      end
+    end
+
     # context 'in LOC authority' do
     #   ###################################
     #   ### SEARCH NOT SUPPORTED BY LOC ###


### PR DESCRIPTION
It also sets id to an empty string if a predicate is specified for the id, but no value is returned.

Fixes #218 