### PR TITLE
allow language to be specified in the http accept_language header

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           project: qa
 
       - samvera/engine_cart_generate:
-          cache_key: v1-internal-test-app-{{ checksum "qa.gemspec" }}-{{ checksum "spec/test_app_templates/lib/generators/test_app_generator.rb" }}-{{ checksum "lib/generators/qa/install/install_generator.rb" }}-<< parameters.rails_version >>-<< parameters.ruby_version >>
+          cache_key: v2-internal-test-app-{{ checksum "qa.gemspec" }}-{{ checksum "spec/test_app_templates/lib/generators/test_app_generator.rb" }}-{{ checksum "lib/generators/qa/install/install_generator.rb" }}-<< parameters.rails_version >>-<< parameters.ruby_version >>
 
       - samvera/bundle_for_gem:
           ruby_version: << parameters.ruby_version >>

--- a/app/controllers/qa/linked_data_terms_controller.rb
+++ b/app/controllers/qa/linked_data_terms_controller.rb
@@ -180,7 +180,9 @@ class Qa::LinkedDataTermsController < ::ApplicationController
     end
 
     def language
-      params[:lang]
+      request_language = request.env['HTTP_ACCEPT_LANGUAGE']
+      request_language = request_language.scan(/^[a-z]{2}/).first if request_language.present?
+      params[:lang] || request_language
     end
 
     def subauthority
@@ -188,7 +190,7 @@ class Qa::LinkedDataTermsController < ::ApplicationController
     end
 
     def replacement_params
-      params.reject { |k, _v| ['q', 'vocab', 'controller', 'action', 'subauthority', 'language', 'id'].include?(k) }
+      params.reject { |k, _v| ['q', 'vocab', 'controller', 'action', 'subauthority', 'lang', 'id'].include?(k) }
     end
 
     def subauth_warn_msg

--- a/app/services/qa/iri_template_service.rb
+++ b/app/services/qa/iri_template_service.rb
@@ -1,31 +1,39 @@
 # Provide service for building a URL based on an IRI Templated Link and its variable mappings based on provided substitutions.
 module Qa
   class IriTemplateService
-    # Construct an url from an IriTemplate making identified substitutions
-    # @param url_config [Qa::IriTemplate::UrlConfig] configuration (json) holding the template and variable mappings
-    # @param substitutions [HashWithIndifferentAccess] name-value pairs to substitute into the url template
-    # @return [String] url with substitutions
-    def self.build_url(url_config:, substitutions:)
-      # TODO: This is a very simple approach using direct substitution into the template string.
-      #   Better would be to...
-      #     * patterns without a substitution are not included in the resulting URL
-      #     * appropriately adds '?' or '&'
-      #     * ensure proper escaping of values (e.g. value="A simple string" which is encoded as A%20simple%20string)
-      #   Even more advanced would be to...
-      #     * support BasicRepresentation (which is what it does now)
-      #     * support ExplicitRepresentation
-      #        * literal encoding for values (e.g. value="A simple string" becomes %22A%20simple%20string%22)
-      #        * language encoding for values (e.g. value="A simple string" becomes value="A simple string"@en which is encoded as %22A%20simple%20string%22%40en)
-      #        * type encoding for values (e.g. value=5.5 becomes value="5.5"^^http://www.w3.org/2001/XMLSchema#decimal which is encoded
-      #                                         as %225.5%22%5E%5Ehttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23decimal)
-      # Fuller implementations parse the template into component parts and then build the URL by adding parts in as applicable.
-      url = url_config.template
-      url_config.mapping.each do |m|
-        key = m.variable
-        url = url.gsub("{#{key}}", m.simple_value(substitutions[key]))
-        url = url.gsub("{?#{key}}", m.parameter_value(substitutions[key]))
+    class << self
+      # Construct an url from an IriTemplate making identified substitutions
+      # @param url_config [Qa::IriTemplate::UrlConfig] configuration (json) holding the template and variable mappings
+      # @param substitutions [HashWithIndifferentAccess] name-value pairs to substitute into the url template
+      # @return [String] url with substitutions
+      def build_url(url_config:, substitutions:)
+        # TODO: This is a very simple approach using direct substitution into the template string.
+        #   Better would be to...
+        #     * appropriately adds '?' or '&'
+        #     * ensure proper escaping of values (e.g. value="A simple string" which is encoded as A%20simple%20string)
+        #   Even more advanced would be to...
+        #     * support BasicRepresentation (which is what it does now)
+        #     * support ExplicitRepresentation
+        #        * literal encoding for values (e.g. value="A simple string" becomes %22A%20simple%20string%22)
+        #        * language encoding for values (e.g. value="A simple string" becomes value="A simple string"@en which is encoded as %22A%20simple%20string%22%40en)
+        #        * type encoding for values (e.g. value=5.5 becomes value="5.5"^^http://www.w3.org/2001/XMLSchema#decimal which is encoded
+        #                                         as %225.5%22%5E%5Ehttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23decimal)
+        # Fuller implementations parse the template into component parts and then build the URL by adding parts in as applicable.
+        url = url_config.template
+        url_config.mapping.each do |m|
+          key = m.variable
+          url = url.gsub("{#{key}}", m.simple_value(substitutions[key]))
+          url = url.gsub("{?#{key}}", m.parameter_value(substitutions[key]))
+        end
+        clean(url)
       end
-      url
+
+      private
+
+        # In the process of substitution, if a value is missing, you can end up with '?&', '&&', or ending with '&'.  These are all removed this method.
+        def clean(url)
+          url.gsub(/&&*/, '&').chomp('&').gsub('?&', '?')
+        end
     end
   end
 end

--- a/app/services/qa/linked_data/authority_url_service.rb
+++ b/app/services/qa/linked_data/authority_url_service.rb
@@ -58,7 +58,7 @@ module Qa
           end
 
           def language_value(language)
-            return nil if language.blank? || !language.is_a?(Array)
+            return nil if language.blank?
             language.first
           end
       end

--- a/app/services/qa/linked_data/authority_url_service.rb
+++ b/app/services/qa/linked_data/authority_url_service.rb
@@ -4,16 +4,17 @@ module Qa
     class AuthorityUrlService
       class << self
         # Build a url for an authority/subauthority for the specified action.
-        # @param authority [Symbol] name of a registered authority
-        # @param subauthority [String] name of a subauthority
+        # @param action_config [Qa::Authorities::LinkedData::SearchConfig | Qa::Authorities::LinkedData::TermConfig] action configuration for the authority
         # @param action [Symbol] action with valid values :search or :term
         # @param action_request [String] the request the user is making of the authority (e.g. query text or term id/uri)
-        # @param substitutions [Hash] variable-value pairs to substitute into the URL template
-        # @return a valid URL the submits the action request to the external authority
-        def build_url(action_config:, action:, action_request:, substitutions: {}, subauthority: nil)
+        # @param substitutions [Hash] variable-value pairs to substitute into the URL template (optional)
+        # @param subauthority [String] name of a subauthority (optional)
+        # @param language [Array<Symbol>] languages for filtering returned literals (optional)
+        # @return a valid URL that submits the action request to the external authority
+        def build_url(action_config:, action:, action_request:, substitutions: {}, subauthority: nil, language: nil) # rubocop:disable Metrics/ParameterLists
           action_validation(action)
           url_config = action_config.url_config
-          selected_substitutions = url_config.extract_substitutions(combined_substitutions(action_config, action, action_request, substitutions, subauthority))
+          selected_substitutions = url_config.extract_substitutions(combined_substitutions(action_config, action, action_request, substitutions, subauthority, language))
           Qa::IriTemplateService.build_url(url_config: url_config, substitutions: selected_substitutions)
         end
 
@@ -24,9 +25,10 @@ module Qa
             raise Qa::UnsupportedAction, "#{action} Not Supported - Action must be one of the supported actions (e.g. :term, :search)"
           end
 
-          def combined_substitutions(action_config, action, action_request, substitutions, subauthority)
+          def combined_substitutions(action_config, action, action_request, substitutions, subauthority, language) # rubocop:disable Metrics/ParameterLists
             substitutions[action_request_variable(action_config, action)] = action_request
-            substitutions[action_subauth_variable(action_config)] = action_subauth_variable_value(action_config, subauthority) if subauthority.present?
+            substitutions[action_subauth_variable(action_config)] = action_subauth_variable_value(action_config, subauthority) if supports_subauthorities?(action_config) && subauthority.present?
+            substitutions[action_language_variable(action_config)] = language_value(language) if supports_language_parameter?(action_config) && language.present?
             substitutions
           end
 
@@ -35,12 +37,29 @@ module Qa
             action_config.qa_replacement_patterns[key]
           end
 
+          def supports_subauthorities?(action_config)
+            action_config.supports_subauthorities?
+          end
+
           def action_subauth_variable(action_config)
             action_config.qa_replacement_patterns[:subauth]
           end
 
           def action_subauth_variable_value(action_config, subauthority)
             action_config.subauthorities[subauthority.to_sym]
+          end
+
+          def supports_language_parameter?(action_config)
+            action_config.supports_language_parameter?
+          end
+
+          def action_language_variable(action_config)
+            action_config.qa_replacement_patterns[:lang]
+          end
+
+          def language_value(language)
+            return nil if language.blank? || !language.is_a?(Array)
+            language.first
           end
       end
     end

--- a/app/services/qa/linked_data/language_service.rb
+++ b/app/services/qa/linked_data/language_service.rb
@@ -2,6 +2,8 @@
 module Qa
   module LinkedData
     class LanguageService
+      WILDCARD = '*'.freeze
+
       class << self
         def preferred_language(user_language: nil, authority_language: nil)
           return normalize_language(user_language) if user_language.present?
@@ -22,6 +24,7 @@ module Qa
           def normalize_language(language)
             return language if language.blank?
             language = [language] unless language.is_a? Array
+            return nil if language.include?(WILDCARD)
             language.map(&:to_sym)
           end
       end

--- a/lib/qa/authorities/linked_data/config/search_config.rb
+++ b/lib/qa/authorities/linked_data/config/search_config.rb
@@ -29,6 +29,7 @@ module Qa::Authorities
       end
 
       # Return the preferred language for literal value selection for search query.
+      # This is the default used for this authority if the user does not pass in a language.
       # Only applies if the authority provides language encoded literals.
       # @return [String] the configured language for search query
       def language
@@ -90,10 +91,20 @@ module Qa::Authorities
         @context_map ||= Qa::LinkedData::Config::ContextMap.new(search_config.fetch(:context), prefixes)
       end
 
-      # Return parameters that are required for QA api
+      # Return parameters that are supported directly by QA api (e.g. q, subauth, lang)
       # @return [Hash] the configured search url parameter mappings
       def qa_replacement_patterns
-        search_config.fetch(:qa_replacement_patterns)
+        search_config.fetch(:qa_replacement_patterns, {})
+      end
+
+      # @return [Boolean] true if supports language parameter; otherwise, false
+      def supports_subauthorities?
+        qa_replacement_patterns.key?(:subauth) && subauthorities?
+      end
+
+      # @return [Boolean] true if supports language parameter; otherwise, false
+      def supports_language_parameter?
+        qa_replacement_patterns.key? :lang
       end
 
       # Are there subauthorities configured for search query?

--- a/lib/qa/authorities/linked_data/config/term_config.rb
+++ b/lib/qa/authorities/linked_data/config/term_config.rb
@@ -41,6 +41,8 @@ module Qa::Authorities
       end
 
       # Return the preferred language for literal value selection for term fetch.  Only applies if the authority provides language encoded literals.
+      # This is the default used for this authority if the user does not pass in a language.
+      # Only applies if the authority provides language encoded literals.
       # @return [Symbol] the configured language for term fetch (default - :en)
       def term_language
         return @term_language unless @term_language.nil?
@@ -95,15 +97,26 @@ module Qa::Authorities
       # Return parameters that are required for QA api
       # @return [Hash] the configured term url parameter mappings
       def term_qa_replacement_patterns
-        Config.config_value(term_config, :qa_replacement_patterns)
+        term_config.fetch(:qa_replacement_patterns, {})
       end
       alias qa_replacement_patterns term_qa_replacement_patterns
+
+      # @return [Boolean] true if supports language parameter; otherwise, false
+      def supports_subauthorities?
+        qa_replacement_patterns.key?(:subauth) && subauthorities?
+      end
+
+      # @return [Boolean] true if supports language parameter; otherwise, false
+      def supports_language_parameter?
+        qa_replacement_patterns.key? :lang
+      end
 
       # Are there subauthorities configured for term fetch?
       # @return [True|False] true if there are subauthorities configured term fetch; otherwise, false
       def term_subauthorities?
         term_subauthority_count.positive?
       end
+      alias subauthorities? term_subauthorities?
 
       # Is a specific subauthority configured for term fetch?
       # @return [True|False] true if the specified subauthority is configured for term fetch; otherwise, false

--- a/lib/qa/authorities/linked_data/find_term.rb
+++ b/lib/qa/authorities/linked_data/find_term.rb
@@ -37,7 +37,7 @@ module Qa::Authorities
       def find(id, language: nil, replacements: {}, subauth: nil, jsonld: false)
         raise Qa::InvalidLinkedDataAuthority, "Unable to initialize linked data term sub-authority #{subauth}" unless subauth.nil? || term_subauthority?(subauth)
         @language = Qa::LinkedData::LanguageService.preferred_language(user_language: language, authority_language: term_config.term_language)
-        url = Qa::LinkedData::AuthorityUrlService.build_url(action_config: term_config, action: :term, action_request: id, substitutions: replacements, subauthority: subauth)
+        url = Qa::LinkedData::AuthorityUrlService.build_url(action_config: term_config, action: :term, action_request: id, substitutions: replacements, subauthority: subauth, language: @language)
         Rails.logger.info "QA Linked Data term url: #{url}"
         load_graph(url: url)
         return "{}" unless full_graph.size.positive?

--- a/lib/qa/authorities/linked_data/search_query.rb
+++ b/lib/qa/authorities/linked_data/search_query.rb
@@ -35,7 +35,7 @@ module Qa::Authorities
         raise Qa::InvalidLinkedDataAuthority, "Unable to initialize linked data search sub-authority #{subauth}" unless subauth.nil? || subauthority?(subauth)
         @context = context
         @language = language_service.preferred_language(user_language: language, authority_language: search_config.language)
-        url = authority_service.build_url(action_config: search_config, action: :search, action_request: query, substitutions: replacements, subauthority: subauth)
+        url = authority_service.build_url(action_config: search_config, action: :search, action_request: query, substitutions: replacements, subauthority: subauth, language: @language)
         Rails.logger.info "QA Linked Data search url: #{url}"
         load_graph(url: url)
         parse_search_authority_response

--- a/spec/features/linked_data/language_spec.rb
+++ b/spec/features/linked_data/language_spec.rb
@@ -1,0 +1,298 @@
+require 'spec_helper'
+require 'qa/authorities/linked_data/config/search_config'
+require 'json'
+
+RSpec.describe 'language processing', type: :controller do # rubocop:disable RSpec/DescribeClass
+  before do
+    @controller = Qa::LinkedDataTermsController.new
+    @routes = Qa::Engine.routes
+    stub_request(:get, "http://localhost/test_default/search?query=my_query")
+      .to_return(status: 200, body: webmock_fixture("lod_lang_search_enesfrde.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
+  end
+
+  let(:de_expected_results) do
+    [
+      { "uri" => "http://id.worldcat.org/fast/530369", "id" => "http://id.worldcat.org/fast/530369", "label" => "Buttermilch" }, # de only b/c all tagged
+      { "uri" => "http://id.worldcat.org/fast/557490", "id" => "http://id.worldcat.org/fast/557490", "label" => "[Kondensmilch, lakto densigita]" }, # de + untagged
+      { "uri" => "http://id.worldcat.org/fast/5140", "id" => "http://id.worldcat.org/fast/5140", "label" => "getrocknete Milch" } # de only b/c all tagged
+    ]
+  end
+  let(:en_expected_results) do
+    [
+      { "uri" => "http://id.worldcat.org/fast/530369", "id" => "http://id.worldcat.org/fast/530369", "label" => "buttermilk" }, # en only b/c all tagged
+      { "uri" => "http://id.worldcat.org/fast/557490", "id" => "http://id.worldcat.org/fast/557490", "label" => "[condensed milk, lakto densigita]" }, # en + untagged
+      { "uri" => "http://id.worldcat.org/fast/5140", "id" => "http://id.worldcat.org/fast/5140", "label" => "dried milk" } # en only b/c all tagged
+    ]
+  end
+  let(:es_expected_results) do
+    [
+      { "uri" => "http://id.worldcat.org/fast/530369", "id" => "http://id.worldcat.org/fast/530369", "label" => "[Buttermilch, buttermilk, Babeurre]" }, # all matches b/c no matching tag
+      { "uri" => "http://id.worldcat.org/fast/557490", "id" => "http://id.worldcat.org/fast/557490", "label" => "[leche condensada, lakto densigita]" }, # es + untagged
+      { "uri" => "http://id.worldcat.org/fast/5140", "id" => "http://id.worldcat.org/fast/5140", "label" => "leche en polvo" } # es only b/c all tagged
+    ]
+  end
+  let(:fr_expected_results) do
+    [
+      { "uri" => "http://id.worldcat.org/fast/530369", "id" => "http://id.worldcat.org/fast/530369", "label" => "Babeurre" }, # fr only b/c all tagged
+      { "uri" => "http://id.worldcat.org/fast/557490", "id" => "http://id.worldcat.org/fast/557490", "label" => "[lait condensé, lakto densigita]" }, # fr + untagged
+      { "uri" => "http://id.worldcat.org/fast/5140", "id" => "http://id.worldcat.org/fast/5140", "label" => "lait en poudre" } # fr only b/c all tagged
+    ]
+  end
+  let(:fr_alt_expected_results) do
+    [
+      { "uri" => "http://id.worldcat.org/fast/530369", "id" => "530369", "label" => "Babeurre (délicieux)" }, # fr only in results + (alt label)
+      { "uri" => "http://id.worldcat.org/fast/557490", "id" => "557490", "label" => "lait condensé (crémeux)" }, # fr only in results + (alt label)
+      { "uri" => "http://id.worldcat.org/fast/5140", "id" => "5140", "label" => "lait en poudre (poudreux)" } # fr only in results + (alt label)
+    ]
+  end
+  let(:sv_alt_expected_results) do
+    [
+      { "uri" => "http://id.worldcat.org/fast/530369", "id" => "530369", "label" => "kärnmjölk (smaskigt)" }, # sv only in results + (alt label)
+      { "uri" => "http://id.worldcat.org/fast/557490", "id" => "557490", "label" => "kondenserad mjölk (krämig)" }, # sv only in results + (alt label)
+      { "uri" => "http://id.worldcat.org/fast/5140", "id" => "5140", "label" => "mjölkpulver (pulver-)" } # sv only in results + (alt label)
+    ]
+  end
+  let(:nil_expected_results) do
+    # returns values for all language when requested lang is nil
+    [
+      { "uri" => "http://id.worldcat.org/fast/530369", "id" => "http://id.worldcat.org/fast/530369", "label" => "[Buttermilch, buttermilk, Babeurre]" },
+      { "uri" => "http://id.worldcat.org/fast/557490", "id" => "http://id.worldcat.org/fast/557490", "label" => "[Kondensmilch, condensed milk, leche condensada, lait condensé, lakto densigita]" },
+      { "uri" => "http://id.worldcat.org/fast/5140", "id" => "http://id.worldcat.org/fast/5140", "label" => "[getrocknete Milch, dried milk, leche en polvo, lait en poudre]" }
+    ]
+  end
+
+  context 'when configured authority URL includes a language parameter' do
+    before do
+      stub_request(:get, "http://localhost/test_default/search?lang=sv&param1=delta&param2=echo&query=my_query&subauth=search_sub1_name")
+        .to_return(status: 200, body: webmock_fixture("lod_lang_search_sv.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
+    end
+
+    it 'passes language to authority for filtering based on user specified language' do
+      get :search, params: { q: 'my_query', vocab: 'LOD_FULL_CONFIG', maximumRecords: '3', lang: 'sv' }
+      expect(response).to be_successful
+      results = JSON.parse(response.body)
+      expect(results).to match_array sv_alt_expected_results
+    end
+  end
+
+  context 'when language includes a WILDCARD (i.e. *)' do
+    before do
+      stub_request(:get, "http://localhost/test_default/search?subauth=search_sub1_name&query=my_query&param1=delta&param2=echo&lang=fr")
+        .to_return(status: 200, body: webmock_fixture("lod_lang_search_fr.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
+    end
+
+    it 'does not filter languages through graph service' do
+      get :search, params: { q: 'my_query', vocab: 'LOD_MIN_CONFIG', maximumRecords: '3', lang: '*' }
+      expect(response).to be_successful
+      results = JSON.parse(response.body)
+      expect(results).to match_array nil_expected_results
+    end
+
+    it 'reverts to parameter default when passing to the authority' do
+      get :search, params: { q: 'my_query', vocab: 'LOD_FULL_CONFIG', maximumRecords: '3', lang: '*' }
+      expect(response).to be_successful
+      results = JSON.parse(response.body)
+      expect(results).to match_array fr_alt_expected_results
+    end
+  end
+
+  context 'when site defined default language' do
+    before do
+      allow(Qa.config).to receive(:default_language).and_return('en')
+    end
+
+    context 'and authority defined default language' do
+      before do
+        allow_any_instance_of(Qa::Authorities::LinkedData::SearchConfig).to receive(:language).and_return('de') # rubocop:disable RSpec/AnyInstance
+      end
+
+      context 'and language is passed via access_language in the http request header' do
+        context 'and user passes language as parameter' do
+          it 'filters results to the user passed in language (e.g. es + untagged)' do
+            get :search, params: { q: 'my_query', vocab: 'LOD_MIN_CONFIG', maximumRecords: '3', lang: 'es' }
+            expect(response).to be_successful
+            results = JSON.parse(response.body)
+            expect(results).to match_array es_expected_results
+          end
+        end
+
+        context 'and user does NOT pass in language as a parameter' do
+          it 'filters results to the http request access_language (e.g. fr + untagged)' do
+            request.env['HTTP_ACCEPT_LANGUAGE'] = 'fr'
+            get :search, params: { q: 'my_query', vocab: 'LOD_MIN_CONFIG', maximumRecords: '3' }
+            expect(response).to be_successful
+            results = JSON.parse(response.body)
+            expect(results).to match_array fr_expected_results
+          end
+        end
+      end
+
+      context 'and language is NOT passed via access_language in the http request header' do
+        context 'and user passes language as parameter' do
+          it 'filters results to the user passed in language (e.g. es + untagged)' do
+            get :search, params: { q: 'my_query', vocab: 'LOD_MIN_CONFIG', maximumRecords: '3', lang: 'es' }
+            expect(response).to be_successful
+            results = JSON.parse(response.body)
+            expect(results).to match_array es_expected_results
+          end
+        end
+
+        context 'and user does NOT pass in language as a parameter' do
+          it 'filters results to the authority defined language (e.g. de + untagged)' do
+            get :search, params: { q: 'my_query', vocab: 'LOD_MIN_CONFIG', maximumRecords: '3' }
+            expect(response).to be_successful
+            results = JSON.parse(response.body)
+            expect(results).to match_array de_expected_results
+          end
+        end
+      end
+    end
+
+    context 'and authority does NOT define default language' do
+      before do
+        allow_any_instance_of(Qa::Authorities::LinkedData::SearchConfig).to receive(:language).and_return(nil) # rubocop:disable RSpec/AnyInstance
+      end
+
+      context 'and language is passed via access_language in the http request header' do
+        context 'and user passes language as parameter' do
+          it 'filters results to the user passed in language (e.g. es + untagged)' do
+            get :search, params: { q: 'my_query', vocab: 'LOD_MIN_CONFIG', maximumRecords: '3', lang: 'es' }
+            expect(response).to be_successful
+            results = JSON.parse(response.body)
+            expect(results).to match_array es_expected_results
+          end
+        end
+
+        context 'and user does NOT pass in language as a parameter' do
+          it 'filters results to the http request access_language (e.g. fr + untagged)' do
+            request.env['HTTP_ACCEPT_LANGUAGE'] = 'fr'
+            get :search, params: { q: 'my_query', vocab: 'LOD_MIN_CONFIG', maximumRecords: '3' }
+            expect(response).to be_successful
+            results = JSON.parse(response.body)
+            expect(results).to match_array fr_expected_results
+          end
+        end
+      end
+
+      context 'and language is NOT passed via access_language in the http request header' do
+        context 'and user passes language as parameter' do
+          it 'filters results to the user passed in language (e.g. es + untagged)' do
+            get :search, params: { q: 'my_query', vocab: 'LOD_MIN_CONFIG', maximumRecords: '3', lang: 'es' }
+            expect(response).to be_successful
+            results = JSON.parse(response.body)
+            expect(results).to match_array es_expected_results
+          end
+        end
+
+        context 'and user does NOT pass in language as a parameter' do
+          it 'filters results to the site defined language (e.g. en + untagged)' do
+            get :search, params: { q: 'my_query', vocab: 'LOD_MIN_CONFIG', maximumRecords: '3' }
+            expect(response).to be_successful
+            results = JSON.parse(response.body)
+            expect(results).to match_array en_expected_results
+          end
+        end
+      end
+    end
+  end
+
+  context 'when site does NOT define default language' do
+    before do
+      allow(Qa.config).to receive(:default_language).and_return(nil)
+    end
+
+    context 'and authority defined default language' do
+      before do
+        allow_any_instance_of(Qa::Authorities::LinkedData::SearchConfig).to receive(:language).and_return('de') # rubocop:disable RSpec/AnyInstance
+      end
+
+      context 'and language is passed via access_language in the http request header' do
+        context 'and user passes language as parameter' do
+          it 'filters results to the user passed in language (e.g. es + untagged)' do
+            get :search, params: { q: 'my_query', vocab: 'LOD_MIN_CONFIG', maximumRecords: '3', lang: 'es' }
+            expect(response).to be_successful
+            results = JSON.parse(response.body)
+            expect(results).to match_array es_expected_results
+          end
+        end
+
+        context 'and user does NOT pass in language as a parameter' do
+          it 'filters results to the http request access_language (e.g. fr + untagged)' do
+            request.env['HTTP_ACCEPT_LANGUAGE'] = 'fr'
+            get :search, params: { q: 'my_query', vocab: 'LOD_MIN_CONFIG', maximumRecords: '3' }
+            expect(response).to be_successful
+            results = JSON.parse(response.body)
+            expect(results).to match_array fr_expected_results
+          end
+        end
+      end
+
+      context 'and language is NOT passed via access_language in the http request header' do
+        context 'and user passes language as parameter' do
+          it 'filters results to the user passed in language (e.g. es + untagged)' do
+            get :search, params: { q: 'my_query', vocab: 'LOD_MIN_CONFIG', maximumRecords: '3', lang: 'es' }
+            expect(response).to be_successful
+            results = JSON.parse(response.body)
+            expect(results).to match_array es_expected_results
+          end
+        end
+
+        context 'and user does NOT pass in language as a parameter' do
+          it 'filters results to the authority defined language (e.g. de + untagged)' do
+            get :search, params: { q: 'my_query', vocab: 'LOD_MIN_CONFIG', maximumRecords: '3' }
+            expect(response).to be_successful
+            results = JSON.parse(response.body)
+            expect(results).to match_array de_expected_results
+          end
+        end
+      end
+    end
+
+    context 'and authority does NOT define default language' do
+      before do
+        allow_any_instance_of(Qa::Authorities::LinkedData::SearchConfig).to receive(:language).and_return(nil) # rubocop:disable RSpec/AnyInstance
+      end
+
+      context 'and language is passed via access_language in the http request header' do
+        context 'and user passes language as parameter' do
+          it 'filters results to the user passed in language (e.g. es + untagged)' do
+            get :search, params: { q: 'my_query', vocab: 'LOD_MIN_CONFIG', maximumRecords: '3', lang: 'es' }
+            expect(response).to be_successful
+            results = JSON.parse(response.body)
+            expect(results).to match_array es_expected_results
+          end
+        end
+
+        context 'and user does NOT pass in language as a parameter' do
+          it 'filters results to the http request access_language (e.g. fr + untagged)' do
+            request.env['HTTP_ACCEPT_LANGUAGE'] = 'fr'
+            get :search, params: { q: 'my_query', vocab: 'LOD_MIN_CONFIG', maximumRecords: '3' }
+            expect(response).to be_successful
+            results = JSON.parse(response.body)
+            expect(results).to match_array fr_expected_results
+          end
+        end
+      end
+
+      context 'and language is NOT passed via access_language in the http request header' do
+        context 'and user passes language as parameter' do
+          it 'filters results to the user passed in language (e.g. es + untagged)' do
+            get :search, params: { q: 'my_query', vocab: 'LOD_MIN_CONFIG', maximumRecords: '3', lang: 'es' }
+            expect(response).to be_successful
+            results = JSON.parse(response.body)
+            expect(results).to match_array es_expected_results
+          end
+        end
+
+        context 'and user does NOT pass in language as a parameter' do
+          it 'does not filter results' do
+            get :search, params: { q: 'my_query', vocab: 'LOD_MIN_CONFIG', maximumRecords: '3' }
+            expect(response).to be_successful
+            results = JSON.parse(response.body)
+            expect(results).to match_array nil_expected_results
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/authorities/linked_data/lod_full_config.json
+++ b/spec/fixtures/authorities/linked_data/lod_full_config.json
@@ -8,7 +8,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type":    "IriTemplate",
-      "template": "http://localhost/test_default/term/{subauth}/{term_id}?{?param1}&{?param2}",
+      "template": "http://localhost/test_default/term/{subauth}/{term_id}?{?param1}&{?param2}&{?lang}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -37,15 +37,23 @@
           "property": "hydra:freetextQuery",
           "required": false,
           "default": "beta"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "lang",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "de"
         }
       ]
     },
     "qa_replacement_patterns": {
       "term_id": "term_id",
-      "subauth": "subauth"
+      "subauth": "subauth",
+      "lang": "lang"
     },
     "term_id": "ID",
-    "language": [ "en" ],
+    "language": [ "es" ],
     "results": {
       "id_predicate":       "http://purl.org/dc/terms/identifier",
       "label_predicate":    "http://www.w3.org/2004/02/skos/core#prefLabel",
@@ -64,7 +72,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type": "IriTemplate",
-      "template": "http://localhost/test_default/search?{?subauth}&{?query}&{?param1}&{?param2}",
+      "template": "http://localhost/test_default/search?{?subauth}&{?query}&{?param1}&{?param2}&{?lang}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -93,12 +101,20 @@
           "property": "hydra:freetextQuery",
           "required": false,
           "default": "echo"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "lang",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "fr"
         }
       ]
     },
     "qa_replacement_patterns": {
       "query": "query",
-      "subauth": "subauth"
+      "subauth": "subauth",
+      "lang": "lang"
     },
     "language": [ "en", "fr", "de" ],
     "results": {

--- a/spec/fixtures/lod_lang_search_enesfrde.rdf.xml
+++ b/spec/fixtures/lod_lang_search_enesfrde.rdf.xml
@@ -1,0 +1,60 @@
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:coord="http://whatever/java/ORG.oclc.util.CoordToDecimal" xmlns:naco="http://whatever/java/ORG.oclc.util.NacoNormalize" xmlns:norm="http://whatever/java/ORG.oclc.util.NormalFormC" xmlns:schema="http://schema.org/" xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#" xmlns:skosxl="http://www.w3.org/2008/05/skos-xl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:void="http://rdfs.org/ns/void#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:mx="http://www.loc.gov/MARC21/slim" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xml:base="http://id.worldcat.org/fast/">
+  <rdf:Description rdf:about="530369">
+    <dct:identifier>530369</dct:identifier>
+    <skos:prefLabel xml:lang="en">buttermilk</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Babeurre</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Buttermilch</skos:prefLabel>
+    <skos:altLabel xml:lang="en">yummy</skos:altLabel>
+    <skos:altLabel xml:lang="fr">délicieux</skos:altLabel>
+    <skos:altLabel xml:lang="de">lecker</skos:altLabel>
+  </rdf:Description>
+  <rdf:Description rdf:about="fst00530369">
+    <rdfs:comment>This identifier is deprecated. See the rdfs:seeAlso link for the new identifier.</rdfs:comment>
+    <rdfs:seeAlso rdf:resource="530369"/>
+  </rdf:Description>
+  <foaf:Document rdf:about="530369/rdf.xml">
+    <foaf:primaryTopic rdf:resource="530369"/>
+    <dc:format>application/rdf+xml</dc:format>
+    <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2005-05-13T00:00:00.0</dct:created>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2012-07-06T14:07:21.0</dct:modified>
+    <dct:language rdf:resource="http://lexvo.org/id/iso639-3/eng"/>
+  </foaf:Document>
+  <rdf:Description rdf:about="5140">
+    <dct:identifier>5140</dct:identifier>
+    <skos:prefLabel xml:lang="en">dried milk</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">lait en poudre</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">getrocknete Milch</skos:prefLabel>
+    <skos:prefLabel xml:lang="es">leche en polvo</skos:prefLabel>
+    <skos:altLabel xml:lang="en">powdery</skos:altLabel>
+    <skos:altLabel xml:lang="fr">poudreux</skos:altLabel>
+    <skos:altLabel xml:lang="de">Pulverförmig</skos:altLabel>
+    <skos:altLabel xml:lang="es">en polvo</skos:altLabel>
+    <skos:altLabel>pulvora</skos:altLabel>
+  </rdf:Description>
+  <rdf:Description rdf:about="fst00005140">
+    <rdfs:comment>This identifier is deprecated. See the rdfs:seeAlso link for the new identifier.</rdfs:comment>
+    <rdfs:seeAlso rdf:resource="5140"/>
+  </rdf:Description>
+  <foaf:Document rdf:about="5140/rdf.xml">
+    <foaf:primaryTopic rdf:resource="5140"/>
+    <dc:format>application/rdf+xml</dc:format>
+    <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2004-09-24T00:00:00.0</dct:created>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2012-07-06T14:07:21.0</dct:modified>
+  </foaf:Document>
+  <rdf:Description rdf:about="557490">
+    <dct:identifier>557490</dct:identifier>
+    <skos:prefLabel xml:lang="en">condensed milk</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">lait condensé</skos:prefLabel>
+    <skos:prefLabel xml:lang="de">Kondensmilch</skos:prefLabel>
+    <skos:prefLabel xml:lang="es">leche condensada</skos:prefLabel>
+    <skos:prefLabel>lakto densigita</skos:prefLabel>
+    <skos:altLabel xml:lang="en">creamy</skos:altLabel>
+    <skos:altLabel xml:lang="fr">crémeux</skos:altLabel>
+    <skos:altLabel xml:lang="de">cremig</skos:altLabel>
+    <skos:altLabel xml:lang="es">cremoso</skos:altLabel>
+  </rdf:Description>
+  <rdf:Description rdf:about="fst00557490">
+    <rdfs:comment>This identifier is deprecated. See the rdfs:seeAlso link for the new identifier.</rdfs:comment>
+    <rdfs:seeAlso rdf:resource="557490"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/spec/fixtures/lod_lang_search_sv.rdf.xml
+++ b/spec/fixtures/lod_lang_search_sv.rdf.xml
@@ -1,0 +1,42 @@
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:coord="http://whatever/java/ORG.oclc.util.CoordToDecimal" xmlns:naco="http://whatever/java/ORG.oclc.util.NacoNormalize" xmlns:norm="http://whatever/java/ORG.oclc.util.NormalFormC" xmlns:schema="http://schema.org/" xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#" xmlns:skosxl="http://www.w3.org/2008/05/skos-xl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:void="http://rdfs.org/ns/void#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:mx="http://www.loc.gov/MARC21/slim" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xml:base="http://id.worldcat.org/fast/">
+  <rdf:Description rdf:about="530369">
+    <dct:identifier>530369</dct:identifier>
+    <skos:prefLabel xml:lang="en">kärnmjölk</skos:prefLabel>
+    <skos:altLabel xml:lang="en">smaskigt</skos:altLabel>
+  </rdf:Description>
+  <rdf:Description rdf:about="fst00530369">
+    <rdfs:comment>This identifier is deprecated. See the rdfs:seeAlso link for the new identifier.</rdfs:comment>
+    <rdfs:seeAlso rdf:resource="530369"/>
+  </rdf:Description>
+  <foaf:Document rdf:about="530369/rdf.xml">
+    <foaf:primaryTopic rdf:resource="530369"/>
+    <dc:format>application/rdf+xml</dc:format>
+    <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2005-05-13T00:00:00.0</dct:created>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2012-07-06T14:07:21.0</dct:modified>
+    <dct:language rdf:resource="http://lexvo.org/id/iso639-3/eng"/>
+  </foaf:Document>
+  <rdf:Description rdf:about="5140">
+    <dct:identifier>5140</dct:identifier>
+    <skos:prefLabel xml:lang="en">mjölkpulver</skos:prefLabel>
+    <skos:altLabel xml:lang="en">pulver-</skos:altLabel>
+  </rdf:Description>
+  <rdf:Description rdf:about="fst00005140">
+    <rdfs:comment>This identifier is deprecated. See the rdfs:seeAlso link for the new identifier.</rdfs:comment>
+    <rdfs:seeAlso rdf:resource="5140"/>
+  </rdf:Description>
+  <foaf:Document rdf:about="5140/rdf.xml">
+    <foaf:primaryTopic rdf:resource="5140"/>
+    <dc:format>application/rdf+xml</dc:format>
+    <dct:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2004-09-24T00:00:00.0</dct:created>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2012-07-06T14:07:21.0</dct:modified>
+  </foaf:Document>
+  <rdf:Description rdf:about="557490">
+    <dct:identifier>557490</dct:identifier>
+    <skos:prefLabel xml:lang="en">kondenserad mjölk</skos:prefLabel>
+    <skos:altLabel xml:lang="en">krämig</skos:altLabel>
+  </rdf:Description>
+  <rdf:Description rdf:about="fst00557490">
+    <rdfs:comment>This identifier is deprecated. See the rdfs:seeAlso link for the new identifier.</rdfs:comment>
+    <rdfs:seeAlso rdf:resource="557490"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/spec/lib/authorities/linked_data/config_spec.rb
+++ b/spec/lib/authorities/linked_data/config_spec.rb
@@ -34,7 +34,7 @@ describe Qa::Authorities::LinkedData::Config do
           url: {
             :@context => 'http://www.w3.org/ns/hydra/context.jsonld',
             :@type => 'IriTemplate',
-            template: 'http://localhost/test_default/term/{subauth}/{term_id}?{?param1}&{?param2}',
+            template: 'http://localhost/test_default/term/{subauth}/{term_id}?{?param1}&{?param2}&{?lang}',
             variableRepresentation: 'BasicRepresentation',
             mapping: [
               {
@@ -63,15 +63,23 @@ describe Qa::Authorities::LinkedData::Config do
                 property: 'hydra:freetextQuery',
                 required: false,
                 default: 'beta'
+              },
+              {
+                :@type => 'IriTemplateMapping',
+                variable: 'lang',
+                property: 'hydra:freetextQuery',
+                required: false,
+                default: 'de'
               }
             ]
           },
           qa_replacement_patterns: {
             term_id: 'term_id',
-            subauth: 'subauth'
+            subauth: 'subauth',
+            lang: 'lang'
           },
           term_id: 'ID',
-          language: ['en'],
+          language: ['es'],
           results: {
             id_predicate: 'http://purl.org/dc/terms/identifier',
             label_predicate: 'http://www.w3.org/2004/02/skos/core#prefLabel',
@@ -90,7 +98,7 @@ describe Qa::Authorities::LinkedData::Config do
           url: {
             :@context => 'http://www.w3.org/ns/hydra/context.jsonld',
             :@type => 'IriTemplate',
-            template: 'http://localhost/test_default/search?{?subauth}&{?query}&{?param1}&{?param2}',
+            template: 'http://localhost/test_default/search?{?subauth}&{?query}&{?param1}&{?param2}&{?lang}',
             variableRepresentation: 'BasicRepresentation',
             mapping: [
               {
@@ -119,12 +127,20 @@ describe Qa::Authorities::LinkedData::Config do
                 property: 'hydra:freetextQuery',
                 required: false,
                 default: 'echo'
+              },
+              {
+                :@type => 'IriTemplateMapping',
+                variable: 'lang',
+                property: 'hydra:freetextQuery',
+                required: false,
+                default: 'fr'
               }
             ]
           },
           qa_replacement_patterns: {
             query: 'query',
-            subauth: 'subauth'
+            subauth: 'subauth',
+            lang: 'lang'
           },
           language: ['en', 'fr', 'de'],
           results: {

--- a/spec/lib/authorities/linked_data/search_config_spec.rb
+++ b/spec/lib/authorities/linked_data/search_config_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'qa/authorities/linked_data/config/search_config'
 
 RSpec.describe Qa::Authorities::LinkedData::SearchConfig do
   let(:full_config) { Qa::Authorities::LinkedData::Config.new(:LOD_FULL_CONFIG).search }
@@ -12,7 +13,7 @@ RSpec.describe Qa::Authorities::LinkedData::SearchConfig do
         url: {
           :@context => 'http://www.w3.org/ns/hydra/context.jsonld',
           :@type => 'IriTemplate',
-          template: 'http://localhost/test_default/search?{?subauth}&{?query}&{?param1}&{?param2}',
+          template: 'http://localhost/test_default/search?{?subauth}&{?query}&{?param1}&{?param2}&{?lang}',
           variableRepresentation: 'BasicRepresentation',
           mapping: [
             {
@@ -41,12 +42,20 @@ RSpec.describe Qa::Authorities::LinkedData::SearchConfig do
               property: 'hydra:freetextQuery',
               required: false,
               default: 'echo'
+            },
+            {
+              :@type => 'IriTemplateMapping',
+              variable: 'lang',
+              property: 'hydra:freetextQuery',
+              required: false,
+              default: 'fr'
             }
           ]
         },
         qa_replacement_patterns: {
           query: 'query',
-          subauth: 'subauth'
+          subauth: 'subauth',
+          lang: 'lang'
         },
         language: ['en', 'fr', 'de'],
         results: {
@@ -243,6 +252,30 @@ RSpec.describe Qa::Authorities::LinkedData::SearchConfig do
     end
     it 'returns the context map if defined in the configuration' do
       expect(full_config.context_map).to be_kind_of Qa::LinkedData::Config::ContextMap
+    end
+  end
+
+  describe '#supports_language_parameter?' do
+    it 'returns false if only term configuration is defined' do
+      expect(term_only_config.supports_language_parameter?).to eq false
+    end
+    it 'returns false if the configuration does NOT define the lang replacement' do
+      expect(min_config.supports_language_parameter?).to eq false
+    end
+    it 'returns true if the configuration defines the lang replacement' do
+      expect(full_config.supports_language_parameter?).to eq true
+    end
+  end
+
+  describe '#supports_subauthorities?' do
+    it 'returns false if only term configuration is defined' do
+      expect(term_only_config.supports_subauthorities?).to eq false
+    end
+    it 'returns false if the configuration does NOT define the subauth replacement' do
+      expect(min_config.supports_subauthorities?).to eq false
+    end
+    it 'returns true if the configuration defines the subauth replacement' do
+      expect(full_config.supports_subauthorities?).to eq true
     end
   end
 

--- a/spec/lib/authorities/linked_data/term_config_spec.rb
+++ b/spec/lib/authorities/linked_data/term_config_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'qa/authorities/linked_data/config/term_config'
 
 describe Qa::Authorities::LinkedData::TermConfig do
   let(:full_config) { Qa::Authorities::LinkedData::Config.new(:LOD_FULL_CONFIG).term }
@@ -12,7 +13,7 @@ describe Qa::Authorities::LinkedData::TermConfig do
         url: {
           :@context => 'http://www.w3.org/ns/hydra/context.jsonld',
           :@type => 'IriTemplate',
-          template: 'http://localhost/test_default/term/{subauth}/{term_id}?{?param1}&{?param2}',
+          template: 'http://localhost/test_default/term/{subauth}/{term_id}?{?param1}&{?param2}&{?lang}',
           variableRepresentation: 'BasicRepresentation',
           mapping: [
             {
@@ -41,15 +42,23 @@ describe Qa::Authorities::LinkedData::TermConfig do
               property: 'hydra:freetextQuery',
               required: false,
               default: 'beta'
+            },
+            {
+              :@type => 'IriTemplateMapping',
+              variable: 'lang',
+              property: 'hydra:freetextQuery',
+              required: false,
+              default: 'de'
             }
           ]
         },
         qa_replacement_patterns: {
           term_id: 'term_id',
-          subauth: 'subauth'
+          subauth: 'subauth',
+          lang: 'lang'
         },
         term_id: 'ID',
-        language: ['en'],
+        language: ['es'],
         results: {
           id_predicate: 'http://purl.org/dc/terms/identifier',
           label_predicate: 'http://www.w3.org/2004/02/skos/core#prefLabel',
@@ -88,7 +97,7 @@ describe Qa::Authorities::LinkedData::TermConfig do
       {
         :@context => 'http://www.w3.org/ns/hydra/context.jsonld',
         :@type => 'IriTemplate',
-        template: 'http://localhost/test_default/term/{subauth}/{term_id}?{?param1}&{?param2}',
+        template: 'http://localhost/test_default/term/{subauth}/{term_id}?{?param1}&{?param2}&{?lang}',
         variableRepresentation: 'BasicRepresentation',
         mapping: [
           {
@@ -117,6 +126,13 @@ describe Qa::Authorities::LinkedData::TermConfig do
             property: 'hydra:freetextQuery',
             required: false,
             default: 'beta'
+          },
+          {
+            :@type => 'IriTemplateMapping',
+            variable: 'lang',
+            property: 'hydra:freetextQuery',
+            required: false,
+            default: 'de'
           }
         ]
       }
@@ -156,7 +172,7 @@ describe Qa::Authorities::LinkedData::TermConfig do
       expect(min_config.term_language).to eq nil
     end
     it 'returns the preferred language for selecting literal values if configured for term' do
-      expect(full_config.term_language).to eq [:en]
+      expect(full_config.term_language).to eq [:es]
     end
   end
 
@@ -242,6 +258,30 @@ describe Qa::Authorities::LinkedData::TermConfig do
     end
     it 'returns the predicate that holds any sameas terms in term results' do
       expect(full_config.term_results_sameas_predicate).to eq RDF::URI('http://www.w3.org/2004/02/skos/core#exactMatch')
+    end
+  end
+
+  describe '#supports_language_parameter?' do
+    it 'returns false if only search configuration is defined' do
+      expect(search_only_config.supports_language_parameter?).to eq false
+    end
+    it 'returns false if the configuration does NOT define the lang replacement' do
+      expect(min_config.supports_language_parameter?).to eq false
+    end
+    it 'returns true if the configuration defines the lang replacement' do
+      expect(full_config.supports_language_parameter?).to eq true
+    end
+  end
+
+  describe '#supports_subauthorities?' do
+    it 'returns false if only search configuration is defined' do
+      expect(search_only_config.supports_subauthorities?).to eq false
+    end
+    it 'returns false if the configuration does NOT define the subauth replacement' do
+      expect(min_config.supports_subauthorities?).to eq false
+    end
+    it 'returns true if the configuration defines the subauth replacement' do
+      expect(full_config.supports_subauthorities?).to eq true
     end
   end
 

--- a/spec/services/linked_data/language_service_spec.rb
+++ b/spec/services/linked_data/language_service_spec.rb
@@ -8,33 +8,74 @@ RSpec.describe Qa::LinkedData::LanguageService do
     let(:authority_language) { nil }
 
     context 'when neither user nor authority language are passed in' do
-      it 'returns default language from Qa configuration' do
-        expect(subject).to match_array [:en]
+      context 'and site wide default language is set' do
+        before do
+          allow(Qa.config).to receive(:default_language).and_return(:en)
+        end
+        it 'returns default language from Qa configuration' do
+          expect(subject).to match_array [:en]
+        end
+      end
+
+      context 'and site wide default language is WILDCARD' do
+        before do
+          allow(Qa.config).to receive(:default_language).and_return(Qa::LinkedData::LanguageService::WILDCARD)
+        end
+        it 'returns default language from Qa configuration' do
+          expect(subject).to eq nil
+        end
+      end
+
+      context 'and site wide default language is not specified' do
+        before do
+          allow(Qa.config).to receive(:default_language).and_return(nil)
+        end
+        it 'returns default language from Qa configuration' do
+          expect(subject).to eq nil
+        end
       end
     end
 
     context 'when authority language is passed in and user language is NOT passed in' do
-      let(:authority_language) { :fr }
+      context 'and site wide default language is set' do
+        let(:authority_language) { :fr }
 
-      it 'returns authority language' do
-        expect(subject).to match_array [:fr]
+        it 'returns authority language' do
+          expect(subject).to match_array [:fr]
+        end
+      end
+
+      context 'and authority default language is WILDCARD' do
+        let(:authority_language) { '*' }
+
+        it 'returns default language from Qa configuration' do
+          expect(subject).to eq nil
+        end
       end
     end
 
     context 'when user and authority language are passed in' do
-      let(:user_language) { :de }
       let(:authority_language) { :fr }
+      let(:user_language) { :de }
 
       it 'returns user language' do
         expect(subject).to match_array [:de]
       end
-    end
 
-    context 'when multiple languages' do
-      let(:user_language) { [:de, :fr] }
+      context 'and there are multiple user languages' do
+        let(:user_language) { [:de, :fr] }
 
-      it 'returns multiple languages' do
-        expect(subject).to match_array [:de, :fr]
+        it 'returns multiple languages' do
+          expect(subject).to match_array [:de, :fr]
+        end
+      end
+
+      context 'and user language is wildcard' do
+        let(:user_language) { '*' }
+
+        it 'returns user language' do
+          expect(subject).to eq nil
+        end
       end
     end
   end


### PR DESCRIPTION
Adds a few other improvements…
* allow * as a wildcard for language processing which will prevent filtering of literals by language
* do not include parameters that do not have a value when building URLs
* clean template built URL to remove any occurances of ?&, &&, or ending with &
