### PR TITLE
extract out ldpath processing into ldpath service

### DIFF
--- a/app/services/qa/linked_data/ldpath_service.rb
+++ b/app/services/qa/linked_data/ldpath_service.rb
@@ -1,0 +1,40 @@
+# Defines the external authority predicates used to extract additional context from the graph.
+require 'ldpath'
+
+module Qa
+  module LinkedData
+    class LdpathService
+      VALUE_ON_ERROR = [].freeze
+
+      # Create the ldpath program for a given ldpath.
+      # @param ldpath [String] ldpath to follow to get a value from a graph (documation: http://marmotta.apache.org/ldpath/language.html)
+      # @param prefixes [Hash] shortcut names for URI prefixes with key = part of predicate that is the same for all terms (e.g. { "madsrdf": "http://www.loc.gov/mads/rdf/v1#" })
+      # @return [Ldpath::Program] an executable program that will extract a value from a graph
+      def self.ldpath_program(ldpath:, prefixes: {})
+        program_code = ""
+        prefixes.each { |key, url| program_code << "@prefix #{key} : <#{url}> \;\n" }
+        program_code << "property = #{ldpath} \;"
+        Ldpath::Program.parse program_code
+      rescue => e
+        Rails.logger.warn("WARNING: #{I18n.t('qa.linked_data.ldpath.parse_logger_error')}... cause: #{e.message}\n   ldpath_program=\n#{program_code}")
+        raise StandardError, I18n.t("qa.linked_data.ldpath.parse_error") + "... cause: #{e.message}"
+      end
+
+      # Evaluate an ldpath for a specific subject uri in the context of a graph and return the extracted values.
+      # @param program [Ldpath::Program] an executable program that will extract a value from a graph
+      # @param graph [RDF::Graph] the graph from which the values will be extracted
+      # @param subject_uri [RDF::URI] retrieved values will be limited to those with the subject uri
+      # @param limit_to_context [Boolean] if true, the evaluation process will not make any outside network calls.
+      #        It will limit results to those found in the context graph.
+      ## @return [Array<String>] the extracted values based on the ldpath
+      def self.ldpath_evaluate(program:, graph:, subject_uri:, limit_to_context: Qa.config.limit_ldpath_to_context?)
+        return VALUE_ON_ERROR if program.blank?
+        output = program.evaluate(subject_uri, context: graph, limit_to_context: limit_to_context)
+        output.present? ? output['property'].uniq : nil
+      rescue => e
+        Rails.logger.warn("WARNING: #{I18n.t('qa.linked_data.ldpath.evaluate_logger_error')} (cause: #{e.message}")
+        raise StandardError, I18n.t("qa.linked_data.ldpath.evaluate_error") + "... cause: #{e.message}"
+      end
+    end
+  end
+end

--- a/lib/generators/qa/install/templates/config/initializers/qa.rb
+++ b/lib/generators/qa/install/templates/config/initializers/qa.rb
@@ -14,4 +14,8 @@ Qa.config do |config|
   # For linked data access, specify default language for sorting and selection.  The default is only used if a language is not
   # specified in the authority's configuration file and not passed in as a parameter.  (e.g. :en, [:en], or [:en, :fr])
   # config.default_language = :en
+
+  # When true, prevents ldpath requests from making additional network calls.  All values will come from the context graph
+  # passed to the ldpath request.
+  # config.limit_ldpath_to_context = true
 end

--- a/lib/qa.rb
+++ b/lib/qa.rb
@@ -24,6 +24,12 @@ module Qa
     @config
   end
 
+  def self.deprecation_warning(in_msg: nil, msg:)
+    return if Rails.env == 'test'
+    in_msg = in_msg.present? ? "In #{in_msg}, " : ''
+    warn "[DEPRECATED] #{in_msg}#{msg}  It will be removed in the next major release."
+  end
+
   # Raised when the configuration directory for local authorities doesn't exist
   class ConfigDirectoryNotFound < StandardError; end
 

--- a/lib/qa/authorities/linked_data/config.rb
+++ b/lib/qa/authorities/linked_data/config.rb
@@ -79,7 +79,7 @@ module Qa::Authorities
         def convert_1_0_url_to_2_0_url(action_key)
           url_template = @authority_config.fetch(action_key, {}).fetch(:url, {}).fetch(:template, "")
           return if url_template.blank?
-          warn "[DEPRECATED] #Linked data configuration #{authority_name} has 1.0 version format which is deprecated; update to version 2.0 configuration."
+          Qa.deprecation_warning(msg: "Linked data configuration #{authority_name} has 1.0 version format which is deprecated; update to version 2.0 configuration.")
           @authority_config[action_key][:url][:template] = url_template.gsub("{?", "{")
         end
     end

--- a/lib/qa/configuration.rb
+++ b/lib/qa/configuration.rb
@@ -37,5 +37,13 @@ module Qa
     def default_language
       @default_language ||= :en
     end
+
+    # When true, prevents ldpath requests from making additional network calls.  All values will come from the context graph
+    # passed to the ldpath request.
+    attr_writer :limit_ldpath_to_context
+    def limit_ldpath_to_context?
+      return true if @limit_ldpath_to_context.nil?
+      @limit_ldpath_to_context
+    end
   end
 end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -68,4 +68,22 @@ RSpec.describe Qa::Configuration do
       end
     end
   end
+
+  describe '#limit_ldpath_to_context' do
+    context 'when NOT configured' do
+      it 'returns true' do
+        expect(subject.limit_ldpath_to_context?).to be true
+      end
+    end
+
+    context 'when configured' do
+      before do
+        subject.limit_ldpath_to_context = false
+      end
+
+      it 'returns the configured value' do
+        expect(subject.limit_ldpath_to_context?).to be false
+      end
+    end
+  end
 end

--- a/spec/models/linked_data/config/context_property_map_spec.rb
+++ b/spec/models/linked_data/config/context_property_map_spec.rb
@@ -209,34 +209,6 @@ RSpec.describe Qa::LinkedData::Config::ContextPropertyMap do
     it 'returns the values selected from the graph' do
       expect(subject.values(graph, subject_uri)).to match_array coordinates
     end
-
-    context 'when ldpath_program gets parse error' do
-      let(:ldpath) { property_map[:ldpath] }
-      let(:cause) { "undefined method `ascii_tree' for nil:NilClass" }
-      let(:warning) { I18n.t('qa.linked_data.ldpath.parse_logger_error') }
-      let(:log_message) { "WARNING: #{warning} (ldpath='#{ldpath}')\n    cause: #{cause}" }
-
-      before { allow(Ldpath::Program).to receive(:parse).with(anything).and_raise(cause) }
-
-      it 'logs error and returns PARSE ERROR as the value' do
-        expect(Rails.logger).to receive(:warn).with(log_message)
-        expect { subject.values(graph, subject_uri) }.to raise_error StandardError, I18n.t('qa.linked_data.ldpath.parse_error')
-      end
-    end
-
-    context 'when ldpath_evaluate gets parse error' do
-      let(:ldpath) { property_map[:ldpath] }
-      let(:cause) { "unknown cause" }
-      let(:warning) { I18n.t('qa.linked_data.ldpath.evaluate_logger_error') }
-      let(:log_message) { "WARNING: #{warning} (ldpath='#{ldpath}')\n    cause: #{cause}" }
-
-      before { allow(program).to receive(:evaluate).with(subject_uri, graph).and_raise(cause) }
-
-      it 'logs error and returns PARSE ERROR as the value' do
-        expect(Rails.logger).to receive(:warn).with(log_message)
-        expect { subject.values(graph, subject_uri) }.to raise_error StandardError, I18n.t('qa.linked_data.ldpath.evaluate_error')
-      end
-    end
   end
 
   describe '#expand_uri?' do
@@ -271,9 +243,9 @@ RSpec.describe Qa::LinkedData::Config::ContextPropertyMap do
       allow(Ldpath::Program).to receive(:parse).with('property = madsrdf:identifiesRWO/madsrdf:birthDate/schema:label ;').and_return(basic_program)
       allow(Ldpath::Program).to receive(:parse).with('property = skos:prefLabel ::xsd:string ;').and_return(expanded_label_program)
       allow(Ldpath::Program).to receive(:parse).with('property = loc:lccn ::xsd:string ;').and_return(expanded_id_program)
-      allow(basic_program).to receive(:evaluate).with(subject_uri, graph).and_return('property' => [expanded_uri])
-      allow(expanded_label_program).to receive(:evaluate).with(RDF::URI.new(subject_uri), graph).and_return('property' => [expanded_label])
-      allow(expanded_id_program).to receive(:evaluate).with(RDF::URI.new(subject_uri), graph).and_return('property' => [expanded_id])
+      allow(basic_program).to receive(:evaluate).with(subject_uri, context: graph, limit_to_context: true).and_return('property' => [expanded_uri])
+      allow(expanded_label_program).to receive(:evaluate).with(RDF::URI.new(subject_uri), context: graph, limit_to_context: true).and_return('property' => [expanded_label])
+      allow(expanded_id_program).to receive(:evaluate).with(RDF::URI.new(subject_uri), context: graph, limit_to_context: true).and_return('property' => [expanded_id])
     end
     it 'returns the uri, id, label for the expanded uri value' do
       expanded_values = subject.expanded_values(graph, subject_uri).first

--- a/spec/services/linked_data/ldpath_service_spec.rb
+++ b/spec/services/linked_data/ldpath_service_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+RSpec.describe Qa::LinkedData::LdpathService do
+  let(:ldpath) { 'skos:prefLabel ::xsd:string' }
+
+  describe '.ldpath_program' do
+    subject { described_class.ldpath_program(ldpath: ldpath, prefixes: prefixes) }
+
+    let(:prefixes) do
+      { skos: 'http://www.w3.org/2004/02/skos/core#' }
+    end
+
+    it 'returns instance of Ldpath::Program' do
+      expect(subject).to be_kind_of Ldpath::Program
+    end
+
+    context 'when ldpath_program gets parse error' do
+      let(:cause) { "undefined method `ascii_tree' for nil:NilClass" }
+      let(:warning) { I18n.t('qa.linked_data.ldpath.parse_logger_error') }
+      let(:program_code) { "@prefix skos : <http://www.w3.org/2004/02/skos/core#> ;\nproperty = skos:prefLabel ::xsd:string ;" }
+      let(:log_message) { "WARNING: #{warning}... cause: #{cause}\n   ldpath_program=\n#{program_code}" }
+
+      before { allow(Ldpath::Program).to receive(:parse).with(anything).and_raise(cause) }
+
+      it 'logs error and returns PARSE ERROR as the value' do
+        expect(Rails.logger).to receive(:warn).with(log_message)
+        expect { subject.values(graph, subject_uri) }.to raise_error StandardError, I18n.t('qa.linked_data.ldpath.parse_error') + "... cause: #{cause}"
+      end
+    end
+  end
+
+  describe '.ldpath_evaluate' do
+    subject { described_class.ldpath_evaluate(program: program, graph: graph, subject_uri: subject_uri) }
+
+    let(:program) { instance_double(Ldpath::Program) }
+    let(:graph) { instance_double(RDF::Graph) }
+    let(:subject_uri) { instance_double(RDF::URI) }
+    let(:values) { ['Expanded Label'] }
+
+    before do
+      allow(Ldpath::Program).to receive(:parse).with('property = skos:prefLabel ::xsd:string ;').and_return(program)
+      allow(program).to receive(:evaluate).with(subject_uri, context: graph, limit_to_context: true).and_return('property' => values)
+    end
+    it 'returns the extracted label' do
+      expect(subject).to match_array values
+    end
+
+    context 'when ldpath_evaluate gets parse error' do
+      let(:cause) { "unknown cause" }
+      let(:warning) { I18n.t('qa.linked_data.ldpath.evaluate_logger_error') }
+      let(:log_message) { "WARNING: #{warning} (cause: #{cause}" }
+
+      before { allow(program).to receive(:evaluate).with(subject_uri, context: graph, limit_to_context: true).and_raise(cause) }
+
+      it 'logs error and returns PARSE ERROR as the value' do
+        expect(Rails.logger).to receive(:warn).with(log_message)
+        expect { subject.values(graph, subject_uri) }.to raise_error StandardError, I18n.t('qa.linked_data.ldpath.evaluate_error') + "... cause: #{cause}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extract out the ldpath processing into the ldpath service.  This facilitates the next step which will be using ldpath with linked data configuration predicates specified outside the extended context section of the configuration.

This includes the ability to tell ldpath not to look outside the passed in graph.  Otherwise, ldpath may make multiple network calls per single QA request.  In many, if not most, cases, this is not performant.  By default, this is set to true which prevents ldpath from making additional network calls.