### PR TITLE
Update search/term configs to be able to read in results config specified as ldpath

### DIFF
--- a/app/services/qa/linked_data/ldpath_service.rb
+++ b/app/services/qa/linked_data/ldpath_service.rb
@@ -1,0 +1,38 @@
+# Defines the external authority predicates used to extract additional context from the graph.
+require 'ldpath'
+
+module Qa
+  module LinkedData
+    class LdpathService
+      VALUE_ON_ERROR = [].freeze
+
+      # Create the ldpath program for a given ldpath.
+      # @param [String] ldpath to follow to get a value from a graph (documation: http://marmotta.apache.org/ldpath/language.html)
+      # @param [Hash] shortcut names for URI prefixes with key = part of predicate that is the same for all terms (e.g. { "madsrdf": "http://www.loc.gov/mads/rdf/v1#" })
+      # @return [Ldpath::Program] an executable program that will extract a value from a graph
+      def self.ldpath_program(ldpath:, prefixes: {})
+        program_code = ""
+        prefixes.each { |key, url| program_code << "@prefix #{key} : <#{url}> \;\n" }
+        program_code << "property = #{ldpath} \;"
+        Ldpath::Program.parse program_code
+      rescue => e
+        Rails.logger.warn("WARNING: #{I18n.t('qa.linked_data.ldpath.parse_logger_error')}... cause: #{e.message}\n   ldpath_program=\n#{program_code}")
+        raise StandardError, I18n.t("qa.linked_data.ldpath.parse_error") + "... cause: #{e.message}"
+      end
+
+      # Evaluate an ldpath for a specific subject uri in the context of a graph and return the extracted values.
+      # @param [Ldpath::Program] an executable program that will extract a value from a graph
+      # @param [RDF::Graph] the graph
+      # @param [RDF::URI] the subject uri
+      ## @return [Array<String>] the extracted values based on the ldpath
+      def self.ldpath_evaluate(program:, graph:, subject_uri:)
+        return VALUE_ON_ERROR if program.blank?
+        output = program.evaluate(subject_uri, context: graph, limit_to_context: Qa.config.limit_ldpath_to_context?)
+        output.present? ? output['property'].uniq : nil
+      rescue => e
+        Rails.logger.warn("WARNING: #{I18n.t('qa.linked_data.ldpath.evaluate_logger_error')} (cause: #{e.message}")
+        raise StandardError, I18n.t("qa.linked_data.ldpath.evaluate_error") + "... cause: #{e.message}"
+      end
+    end
+  end
+end

--- a/lib/generators/qa/install/templates/config/initializers/qa.rb
+++ b/lib/generators/qa/install/templates/config/initializers/qa.rb
@@ -14,4 +14,8 @@ Qa.config do |config|
   # For linked data access, specify default language for sorting and selection.  The default is only used if a language is not
   # specified in the authority's configuration file and not passed in as a parameter.  (e.g. :en, [:en], or [:en, :fr])
   # config.default_language = :en
+
+  # When true, prevents ldpath requests from making additional network calls.  All values will come from the context graph
+  # passed to the ldpath request.
+  # config.limit_ldpath_to_context = true
 end

--- a/lib/qa.rb
+++ b/lib/qa.rb
@@ -24,6 +24,12 @@ module Qa
     @config
   end
 
+  def self.deprecation_warning(in_msg: nil, msg:)
+    return if Rails.env == 'test'
+    in_msg = in_msg.present? ? "In #{in_msg}, " : ''
+    warn "[DEPRECATED] #{in_msg}#{msg}  It will be removed in the next major release."
+  end
+
   # Raised when the configuration directory for local authorities doesn't exist
   class ConfigDirectoryNotFound < StandardError; end
 

--- a/lib/qa/authorities/linked_data/config.rb
+++ b/lib/qa/authorities/linked_data/config.rb
@@ -79,7 +79,7 @@ module Qa::Authorities
         def convert_1_0_url_to_2_0_url(action_key)
           url_template = @authority_config.fetch(action_key, {}).fetch(:url, {}).fetch(:template, "")
           return if url_template.blank?
-          warn "[DEPRECATED] #Linked data configuration #{authority_name} has 1.0 version format which is deprecated; update to version 2.0 configuration."
+          Qa.deprecation_warning(msg: "Linked data configuration #{authority_name} has 1.0 version format which is deprecated; update to version 2.0 configuration.")
           @authority_config[action_key][:url][:template] = url_template.gsub("{?", "{")
         end
     end

--- a/lib/qa/authorities/linked_data/config/search_config.rb
+++ b/lib/qa/authorities/linked_data/config/search_config.rb
@@ -46,16 +46,34 @@ module Qa::Authorities
         search_config[:results]
       end
 
+      # Return results id_ldpath
+      # @return [String] the configured predicate to use to extract the id from the results
+      def results_id_ldpath
+        Config.config_value(results, :id_ldpath)
+      end
+
       # Return results id_predicate
       # @return [String] the configured predicate to use to extract the id from the results
       def results_id_predicate
         Config.predicate_uri(results, :id_predicate)
       end
 
+      # Return results label_ldpath
+      # @return [String] the configured predicate to use to extract label values from the results
+      def results_label_ldpath
+        Config.config_value(results, :label_ldpath)
+      end
+
       # Return results label_predicate
       # @return [String] the configured predicate to use to extract label values from the results
       def results_label_predicate
         Config.predicate_uri(results, :label_predicate)
+      end
+
+      # Return results altlabel_ldpath
+      # @return [String] the configured predicate to use to extract altlabel values from the results
+      def results_altlabel_ldpath
+        Config.config_value(results, :altlabel_ldpath)
       end
 
       # Return results altlabel_predicate
@@ -69,6 +87,12 @@ module Qa::Authorities
       def supports_sort?
         return true unless results_sort_predicate.nil? || !results_sort_predicate.size.positive?
         false
+      end
+
+      # Return results sort_predicate
+      # @return [String] the configured predicate to use for sorting results from the query search
+      def results_sort_ldpath
+        Config.config_value(results, :sort_ldpath)
       end
 
       # Return results sort_predicate

--- a/lib/qa/authorities/linked_data/config/term_config.rb
+++ b/lib/qa/authorities/linked_data/config/term_config.rb
@@ -5,6 +5,8 @@
 module Qa::Authorities
   module LinkedData
     class TermConfig
+      attr_reader :prefixes
+
       # @param [Hash] config the term portion of the config
       def initialize(config, prefixes = {})
         @term_config = config
@@ -58,10 +60,22 @@ module Qa::Authorities
         Config.config_value(term_config, :results)
       end
 
+      # Return results id_ldpath
+      # @return [String] the configured predicate to use to extract the id from the results
+      def term_results_id_ldpath
+        Config.config_value(term_results, :id_ldpath)
+      end
+
       # Return results id_predicate
       # @return [String] the configured predicate to use to extract the id from the results
       def term_results_id_predicate
         Config.predicate_uri(term_results, :id_predicate)
+      end
+
+      # Return results label_ldpath
+      # @return [String] the configured predicate to use to extract label values from the results
+      def term_results_label_ldpath
+        Config.config_value(term_results, :label_ldpath)
       end
 
       # Return results label_predicate
@@ -70,10 +84,22 @@ module Qa::Authorities
         Config.predicate_uri(term_results, :label_predicate)
       end
 
+      # Return results altlabel_ldpath
+      # @return [String] the configured predicate to use to extract altlabel values from the results
+      def term_results_altlabel_ldpath
+        Config.config_value(term_results, :altlabel_ldpath)
+      end
+
       # Return results altlabel_predicate
       # @return [String] the configured predicate to use to extract altlabel values from the results
       def term_results_altlabel_predicate
         Config.predicate_uri(term_results, :altlabel_predicate)
+      end
+
+      # Return results broader_ldpath
+      # @return [String] the configured predicate to use to extract URIs for broader terms from the results
+      def term_results_broader_ldpath
+        Config.config_value(term_results, :broader_ldpath)
       end
 
       # Return results broader_predicate
@@ -82,10 +108,22 @@ module Qa::Authorities
         Config.predicate_uri(term_results, :broader_predicate)
       end
 
+      # Return results narrower_ldpath
+      # @return [String] the configured predicate to use to extract URIs for narrower terms from the results
+      def term_results_narrower_ldpath
+        Config.config_value(term_results, :narrower_ldpath)
+      end
+
       # Return results narrower_predicate
       # @return [String] the configured predicate to use to extract URIs for narrower terms from the results
       def term_results_narrower_predicate
         Config.predicate_uri(term_results, :narrower_predicate)
+      end
+
+      # Return results sameas_ldpath
+      # @return [String] the configured predicate to use to extract URIs for sameas terms from the results
+      def term_results_sameas_ldpath
+        Config.config_value(term_results, :sameas_ldpath)
       end
 
       # Return results sameas_predicate

--- a/lib/qa/configuration.rb
+++ b/lib/qa/configuration.rb
@@ -37,5 +37,13 @@ module Qa
     def default_language
       @default_language ||= :en
     end
+
+    # When true, prevents ldpath requests from making additional network calls.  All values will come from the context graph
+    # passed to the ldpath request.
+    attr_writer :limit_ldpath_to_context
+    def limit_ldpath_to_context?
+      return true if @limit_ldpath_to_context.nil?
+      @limit_ldpath_to_context
+    end
   end
 end

--- a/spec/lib/authorities/linked_data/search_config_spec.rb
+++ b/spec/lib/authorities/linked_data/search_config_spec.rb
@@ -2,10 +2,23 @@ require 'spec_helper'
 require 'qa/authorities/linked_data/config/search_config'
 
 RSpec.describe Qa::Authorities::LinkedData::SearchConfig do
+  before do
+    Qa::LinkedData::AuthorityService.load_authorities
+  end
+
   let(:full_config) { Qa::Authorities::LinkedData::Config.new(:LOD_FULL_CONFIG).search }
   let(:min_config) { Qa::Authorities::LinkedData::Config.new(:LOD_MIN_CONFIG).search }
   let(:term_only_config) { Qa::Authorities::LinkedData::Config.new(:LOD_TERM_ONLY_CONFIG).search }
   let(:encoding_config) { Qa::Authorities::LinkedData::Config.new(:LOD_ENCODING_CONFIG).search }
+
+  let(:ldpath_results_config) do
+    {
+      id_ldpath: 'schema:identifier ::xsd:string',
+      label_ldpath: 'skos:prefLabel ::xsd:string',
+      altlabel_ldpath: 'skos:altLabel ::xsd:string',
+      sort_ldpath: 'skos:prefLabel ::xsd:string'
+    }
+  end
 
   describe '#search_config' do
     let(:full_search_config) do
@@ -186,6 +199,19 @@ RSpec.describe Qa::Authorities::LinkedData::SearchConfig do
     end
   end
 
+  describe '#results_id_ldpath' do
+    it 'returns nil if only term configuration is defined' do
+      expect(term_only_config.results_id_ldpath).to eq nil
+    end
+
+    context 'when id specified as ldpath' do
+      before { allow(full_config).to receive(:results).and_return(ldpath_results_config) }
+      it 'returns the ldpath' do
+        expect(full_config.results_id_ldpath).to eq 'schema:identifier ::xsd:string'
+      end
+    end
+  end
+
   describe '#results_label_predicate' do
     it 'returns nil if only term configuration is defined' do
       expect(term_only_config.results_label_predicate).to eq nil
@@ -195,15 +221,44 @@ RSpec.describe Qa::Authorities::LinkedData::SearchConfig do
     end
   end
 
+  describe '#results_label_ldpath' do
+    it 'returns nil if only term configuration is defined' do
+      expect(term_only_config.results_label_ldpath).to eq nil
+    end
+
+    context 'when label specified as ldpath' do
+      before { allow(full_config).to receive(:results).and_return(ldpath_results_config) }
+      it 'returns the ldpath' do
+        expect(full_config.results_label_ldpath).to eq 'skos:prefLabel ::xsd:string'
+      end
+    end
+  end
+
   describe '#results_altlabel_predicate' do
     it 'returns nil if only term configuration is defined' do
       expect(term_only_config.results_altlabel_predicate).to eq nil
     end
-    it 'return nil if altlabel predicate is not defined' do
+    it 'returns nil if altlabel predicate is not defined' do
       expect(min_config.results_altlabel_predicate).to eq nil
     end
     it 'returns the predicate that holds the altlabel in search results' do
       expect(full_config.results_altlabel_predicate).to eq RDF::URI('http://www.w3.org/2004/02/skos/core#altLabel')
+    end
+  end
+
+  describe '#results_altlabel_ldpath' do
+    it 'returns nil if only term configuration is defined' do
+      expect(term_only_config.results_altlabel_ldpath).to eq nil
+    end
+    it 'returns nil if altlabel ldpath is not defined' do
+      expect(min_config.results_altlabel_ldpath).to eq nil
+    end
+
+    context 'when altlabel specified as ldpath' do
+      before { allow(full_config).to receive(:results).and_return(ldpath_results_config) }
+      it 'returns the ldpath' do
+        expect(full_config.results_altlabel_ldpath).to eq 'skos:altLabel ::xsd:string'
+      end
     end
   end
 
@@ -228,6 +283,22 @@ RSpec.describe Qa::Authorities::LinkedData::SearchConfig do
     end
     it 'returns the predicate on which results should be sorted' do
       expect(full_config.results_sort_predicate).to eq RDF::URI('http://www.w3.org/2004/02/skos/core#prefLabel')
+    end
+  end
+
+  describe '#results_sort_ldpath' do
+    it 'returns nil if only term configuration is defined' do
+      expect(term_only_config.results_sort_ldpath).to eq nil
+    end
+    it 'returns nil if sort ldpath is not defined' do
+      expect(min_config.results_sort_ldpath).to eq nil
+    end
+
+    context 'when sort specified as ldpath' do
+      before { allow(full_config).to receive(:results).and_return(ldpath_results_config) }
+      it 'returns the ldpath' do
+        expect(full_config.results_sort_ldpath).to eq 'skos:prefLabel ::xsd:string'
+      end
     end
   end
 

--- a/spec/lib/authorities/linked_data/term_config_spec.rb
+++ b/spec/lib/authorities/linked_data/term_config_spec.rb
@@ -7,6 +7,17 @@ describe Qa::Authorities::LinkedData::TermConfig do
   let(:search_only_config) { Qa::Authorities::LinkedData::Config.new(:LOD_SEARCH_ONLY_CONFIG).term }
   let(:encoding_config) { Qa::Authorities::LinkedData::Config.new(:LOD_ENCODING_CONFIG).term }
 
+  let(:ldpath_results_config) do
+    {
+      id_ldpath:       'schema:identifier ::xsd:string',
+      label_ldpath:    'skos:prefLabel ::xsd:string',
+      altlabel_ldpath: 'skos:altLabel ::xsd:string',
+      broader_ldpath:  'skos:broader ::xsd:string',
+      narrower_ldpath: 'skos:narrower ::xsd:string',
+      sameas_ldpath:   'skos:exactMatch ::xsd:string'
+    }
+  end
+
   describe '#term_config' do
     let(:full_term_config) do
       {
@@ -204,12 +215,38 @@ describe Qa::Authorities::LinkedData::TermConfig do
     end
   end
 
+  describe '#term_results_id_ldpath' do
+    it 'returns nil if only search configuration is defined' do
+      expect(search_only_config.term_results_id_ldpath).to eq nil
+    end
+
+    context 'when id specified as ldpath' do
+      before { allow(full_config).to receive(:term_results).and_return(ldpath_results_config) }
+      it 'returns the ldpath' do
+        expect(full_config.term_results_id_ldpath).to eq 'schema:identifier ::xsd:string'
+      end
+    end
+  end
+
   describe '#term_results_label_predicate' do
     it 'returns nil if only search configuration is defined' do
       expect(search_only_config.term_results_label_predicate).to eq nil
     end
     it 'returns the predicate that holds the label in term results' do
       expect(full_config.term_results_label_predicate).to eq RDF::URI('http://www.w3.org/2004/02/skos/core#prefLabel')
+    end
+  end
+
+  describe '#term_results_label_ldpath' do
+    it 'returns nil if only search configuration is defined' do
+      expect(search_only_config.term_results_label_ldpath).to eq nil
+    end
+
+    context 'when label specified as ldpath' do
+      before { allow(full_config).to receive(:term_results).and_return(ldpath_results_config) }
+      it 'returns the ldpath' do
+        expect(full_config.term_results_label_ldpath).to eq 'skos:prefLabel ::xsd:string'
+      end
     end
   end
 
@@ -225,6 +262,22 @@ describe Qa::Authorities::LinkedData::TermConfig do
     end
   end
 
+  describe '#term_results_altlabel_ldpath' do
+    it 'returns nil if only search configuration is defined' do
+      expect(search_only_config.term_results_altlabel_ldpath).to eq nil
+    end
+    it 'return nil if altlabel predicate is not defined' do
+      expect(min_config.term_results_altlabel_ldpath).to eq nil
+    end
+
+    context 'when altlabel specified as ldpath' do
+      before { allow(full_config).to receive(:term_results).and_return(ldpath_results_config) }
+      it 'returns the ldpath' do
+        expect(full_config.term_results_altlabel_ldpath).to eq 'skos:altLabel ::xsd:string'
+      end
+    end
+  end
+
   describe '#term_results_broader_predicate' do
     it 'returns nil if only search configuration is defined' do
       expect(search_only_config.term_results_broader_predicate).to eq nil
@@ -234,6 +287,22 @@ describe Qa::Authorities::LinkedData::TermConfig do
     end
     it 'returns the predicate that holds any broader terms in term results' do
       expect(full_config.term_results_broader_predicate).to eq RDF::URI('http://www.w3.org/2004/02/skos/core#broader')
+    end
+  end
+
+  describe '#term_results_broader_ldpath' do
+    it 'returns nil if only search configuration is defined' do
+      expect(search_only_config.term_results_broader_ldpath).to eq nil
+    end
+    it 'return nil if broader predicate is not defined' do
+      expect(min_config.term_results_broader_ldpath).to eq nil
+    end
+
+    context 'when broader specified as ldpath' do
+      before { allow(full_config).to receive(:term_results).and_return(ldpath_results_config) }
+      it 'returns the ldpath' do
+        expect(full_config.term_results_broader_ldpath).to eq 'skos:broader ::xsd:string'
+      end
     end
   end
 
@@ -249,6 +318,22 @@ describe Qa::Authorities::LinkedData::TermConfig do
     end
   end
 
+  describe '#term_results_narrower_ldpath' do
+    it 'returns nil if only search configuration is defined' do
+      expect(search_only_config.term_results_narrower_ldpath).to eq nil
+    end
+    it 'return nil if narrower predicate is not defined' do
+      expect(min_config.term_results_narrower_ldpath).to eq nil
+    end
+
+    context 'when narrower specified as ldpath' do
+      before { allow(full_config).to receive(:term_results).and_return(ldpath_results_config) }
+      it 'returns the ldpath' do
+        expect(full_config.term_results_narrower_ldpath).to eq 'skos:narrower ::xsd:string'
+      end
+    end
+  end
+
   describe '#term_results_sameas_predicate' do
     it 'returns nil if only search configuration is defined' do
       expect(search_only_config.term_results_sameas_predicate).to eq nil
@@ -258,6 +343,22 @@ describe Qa::Authorities::LinkedData::TermConfig do
     end
     it 'returns the predicate that holds any sameas terms in term results' do
       expect(full_config.term_results_sameas_predicate).to eq RDF::URI('http://www.w3.org/2004/02/skos/core#exactMatch')
+    end
+  end
+
+  describe '#term_results_sameas_ldpath' do
+    it 'returns nil if only search configuration is defined' do
+      expect(search_only_config.term_results_sameas_ldpath).to eq nil
+    end
+    it 'return nil if sameas predicate is not defined' do
+      expect(min_config.term_results_sameas_ldpath).to eq nil
+    end
+
+    context 'when sameas specified as ldpath' do
+      before { allow(full_config).to receive(:term_results).and_return(ldpath_results_config) }
+      it 'returns the ldpath' do
+        expect(full_config.term_results_sameas_ldpath).to eq 'skos:exactMatch ::xsd:string'
+      end
     end
   end
 

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -68,4 +68,22 @@ RSpec.describe Qa::Configuration do
       end
     end
   end
+
+  describe '#limit_ldpath_to_context' do
+    context 'when NOT configured' do
+      it 'returns true' do
+        expect(subject.limit_ldpath_to_context?).to be true
+      end
+    end
+
+    context 'when configured' do
+      before do
+        subject.limit_ldpath_to_context = false
+      end
+
+      it 'returns the configured value' do
+        expect(subject.limit_ldpath_to_context?).to be false
+      end
+    end
+  end
 end

--- a/spec/models/linked_data/config/context_property_map_spec.rb
+++ b/spec/models/linked_data/config/context_property_map_spec.rb
@@ -209,34 +209,6 @@ RSpec.describe Qa::LinkedData::Config::ContextPropertyMap do
     it 'returns the values selected from the graph' do
       expect(subject.values(graph, subject_uri)).to match_array coordinates
     end
-
-    context 'when ldpath_program gets parse error' do
-      let(:ldpath) { property_map[:ldpath] }
-      let(:cause) { "undefined method `ascii_tree' for nil:NilClass" }
-      let(:warning) { I18n.t('qa.linked_data.ldpath.parse_logger_error') }
-      let(:log_message) { "WARNING: #{warning} (ldpath='#{ldpath}')\n    cause: #{cause}" }
-
-      before { allow(Ldpath::Program).to receive(:parse).with(anything).and_raise(cause) }
-
-      it 'logs error and returns PARSE ERROR as the value' do
-        expect(Rails.logger).to receive(:warn).with(log_message)
-        expect { subject.values(graph, subject_uri) }.to raise_error StandardError, I18n.t('qa.linked_data.ldpath.parse_error')
-      end
-    end
-
-    context 'when ldpath_evaluate gets parse error' do
-      let(:ldpath) { property_map[:ldpath] }
-      let(:cause) { "unknown cause" }
-      let(:warning) { I18n.t('qa.linked_data.ldpath.evaluate_logger_error') }
-      let(:log_message) { "WARNING: #{warning} (ldpath='#{ldpath}')\n    cause: #{cause}" }
-
-      before { allow(program).to receive(:evaluate).with(subject_uri, graph).and_raise(cause) }
-
-      it 'logs error and returns PARSE ERROR as the value' do
-        expect(Rails.logger).to receive(:warn).with(log_message)
-        expect { subject.values(graph, subject_uri) }.to raise_error StandardError, I18n.t('qa.linked_data.ldpath.evaluate_error')
-      end
-    end
   end
 
   describe '#expand_uri?' do
@@ -271,9 +243,9 @@ RSpec.describe Qa::LinkedData::Config::ContextPropertyMap do
       allow(Ldpath::Program).to receive(:parse).with('property = madsrdf:identifiesRWO/madsrdf:birthDate/schema:label ;').and_return(basic_program)
       allow(Ldpath::Program).to receive(:parse).with('property = skos:prefLabel ::xsd:string ;').and_return(expanded_label_program)
       allow(Ldpath::Program).to receive(:parse).with('property = loc:lccn ::xsd:string ;').and_return(expanded_id_program)
-      allow(basic_program).to receive(:evaluate).with(subject_uri, graph).and_return('property' => [expanded_uri])
-      allow(expanded_label_program).to receive(:evaluate).with(RDF::URI.new(subject_uri), graph).and_return('property' => [expanded_label])
-      allow(expanded_id_program).to receive(:evaluate).with(RDF::URI.new(subject_uri), graph).and_return('property' => [expanded_id])
+      allow(basic_program).to receive(:evaluate).with(subject_uri, context: graph, limit_to_context: true).and_return('property' => [expanded_uri])
+      allow(expanded_label_program).to receive(:evaluate).with(RDF::URI.new(subject_uri), context: graph, limit_to_context: true).and_return('property' => [expanded_label])
+      allow(expanded_id_program).to receive(:evaluate).with(RDF::URI.new(subject_uri), context: graph, limit_to_context: true).and_return('property' => [expanded_id])
     end
     it 'returns the uri, id, label for the expanded uri value' do
       expanded_values = subject.expanded_values(graph, subject_uri).first

--- a/spec/services/linked_data/ldpath_service_spec.rb
+++ b/spec/services/linked_data/ldpath_service_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+RSpec.describe Qa::LinkedData::LdpathService do
+  let(:ldpath) { 'skos:prefLabel ::xsd:string' }
+
+  describe '.ldpath_program' do
+    subject { described_class.ldpath_program(ldpath: ldpath, prefixes: prefixes) }
+
+    let(:prefixes) do
+      { skos: 'http://www.w3.org/2004/02/skos/core#' }
+    end
+
+    it 'returns instance of Ldpath::Program' do
+      expect(subject).to be_kind_of Ldpath::Program
+    end
+
+    context 'when ldpath_program gets parse error' do
+      let(:cause) { "undefined method `ascii_tree' for nil:NilClass" }
+      let(:warning) { I18n.t('qa.linked_data.ldpath.parse_logger_error') }
+      let(:program_code) { "@prefix skos : <http://www.w3.org/2004/02/skos/core#> ;\nproperty = skos:prefLabel ::xsd:string ;" }
+      let(:log_message) { "WARNING: #{warning}... cause: #{cause}\n   ldpath_program=\n#{program_code}" }
+
+      before { allow(Ldpath::Program).to receive(:parse).with(anything).and_raise(cause) }
+
+      it 'logs error and returns PARSE ERROR as the value' do
+        expect(Rails.logger).to receive(:warn).with(log_message)
+        expect { subject.values(graph, subject_uri) }.to raise_error StandardError, I18n.t('qa.linked_data.ldpath.parse_error') + "... cause: #{cause}"
+      end
+    end
+  end
+
+  describe '.ldpath_evaluate' do
+    subject { described_class.ldpath_evaluate(program: program, graph: graph, subject_uri: subject_uri) }
+
+    let(:program) { instance_double(Ldpath::Program) }
+    let(:graph) { instance_double(RDF::Graph) }
+    let(:subject_uri) { instance_double(RDF::URI) }
+    let(:values) { ['Expanded Label'] }
+
+    before do
+      allow(Ldpath::Program).to receive(:parse).with('property = skos:prefLabel ::xsd:string ;').and_return(program)
+      allow(program).to receive(:evaluate).with(subject_uri, context: graph, limit_to_context: true).and_return('property' => values)
+    end
+    it 'returns the extracted label' do
+      expect(subject).to match_array values
+    end
+
+    context 'when ldpath_evaluate gets parse error' do
+      let(:cause) { "unknown cause" }
+      let(:warning) { I18n.t('qa.linked_data.ldpath.evaluate_logger_error') }
+      let(:log_message) { "WARNING: #{warning} (cause: #{cause}" }
+
+      before { allow(program).to receive(:evaluate).with(subject_uri, context: graph, limit_to_context: true).and_raise(cause) }
+
+      it 'logs error and returns PARSE ERROR as the value' do
+        expect(Rails.logger).to receive(:warn).with(log_message)
+        expect { subject.values(graph, subject_uri) }.to raise_error StandardError, I18n.t('qa.linked_data.ldpath.evaluate_error') + "... cause: #{cause}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is also a precursor to extend configurations as ldpath beyond extended context section of the config.