### PR TITLE
switch search configs to use ldpath instead of predicates for specifying results

### DIFF
--- a/app/services/qa/linked_data/mapper/graph_ldpath_mapper_service.rb
+++ b/app/services/qa/linked_data/mapper/graph_ldpath_mapper_service.rb
@@ -1,0 +1,49 @@
+# Provide service for mapping predicates to object values.
+module Qa
+  module LinkedData
+    module Mapper
+      class GraphLdpathMapperService
+        class_attribute :ldpath_service
+        self.ldpath_service = Qa::LinkedData::LdpathService
+
+        # Extract values for ldpath specified in the ldpath_map from the graph and return as a value map for a single subject URI.
+        # @param graph [RDF::Graph] the graph from which to extract result values
+        # @param prefixes [Hash<Symbol><String>] URL map of prefixes to use with ldpaths
+        # @example prefixes
+        #   {
+        #     locid: 'http://id.loc.gov/vocabulary/identifiers/',
+        #     skos: 'http://www.w3.org/2004/02/skos/core#',
+        #     vivo: 'http://vivoweb.org/ontology/core#'
+        #   }
+        # @param ldpath [Hash<Symbol><String||Symbol>] value either maps to a ldpath in the graph or is :subject_uri indicating to use the subject uri as the value
+        # @example ldpath map
+        #   {
+        #     uri: :subject_uri,
+        #     id: 'locid:lccn :: xsd::string',
+        #     label: 'skos:prefLabel :: xsd::string',
+        #     altlabel: 'skos:altLabel :: xsd::string',
+        #     sort: 'vivo:rank :: xsd::integer'
+        #   }
+        # @param subject_uri [RDF::URI] the subject within the graph for which the values are being extracted
+        # @return [<Hash<Symbol><Array<Object>>] mapped result values with hash of map key = array of object values identified by the ldpath map.
+        # @example value map for a single result
+        #   {:uri=>[#<RDF::URI:0x3fcff54a829c URI:http://id.loc.gov/authorities/names/n2010043281>],
+        #    :id=>[#<RDF::Literal:0x3fcff4a367b4("n2010043281")>],
+        #    :label=>[#<RDF::Literal:0x3fcff54a9a98("Valli, Sabrina"@en)>],
+        #    :altlabel=>[],
+        #    :sort=>[#<RDF::Literal:0x3fcff54b4c18("2")>]}
+        def self.map_values(graph:, ldpath_map:, subject_uri:, prefixes: {})
+          value_map = {}
+          ldpath_map.each do |key, ldpath|
+            next value_map[key] = [subject_uri] if ldpath == :subject_uri
+            ldpath_program = ldpath_service.ldpath_program(ldpath: ldpath, prefixes: prefixes)
+            values = ldpath_service.ldpath_evaluate(program: ldpath_program, graph: graph, subject_uri: subject_uri)
+            value_map[key] = values
+          end
+          value_map = yield value_map if block_given?
+          value_map
+        end
+      end
+    end
+  end
+end

--- a/app/services/qa/linked_data/mapper/graph_predicate_mapper_service.rb
+++ b/app/services/qa/linked_data/mapper/graph_predicate_mapper_service.rb
@@ -2,7 +2,10 @@
 module Qa
   module LinkedData
     module Mapper
-      class GraphMapperService
+      class GraphPredicateMapperService
+        class_attribute :graph_service
+        self.graph_service = Qa::LinkedData::GraphService
+
         # Extract predicates specified in the predicate_map from the graph and return as a value map for a single subject URI.
         # @param graph [RDF::Graph] the graph from which to extract result values
         # @param predicate_map [Hash<Symbol><String||Symbol>] value either maps to a predicate in the graph or is :subject_uri indicating to use the subject uri as the value
@@ -22,9 +25,14 @@ module Qa
         #    :label=>[#<RDF::Literal:0x3fcff54a9a98("Valli, Sabrina"@en)>],
         #    :altlabel=>[],
         #    :sort=>[#<RDF::Literal:0x3fcff54b4c18("2")>]}
-        def self.map_values(graph:, predicate_map:, subject_uri:, &block)
-          Qa.deprecation_warning(msg: "`Qa::LinkedData::Mapper::GraphMapperService` is deprecated; update to `Qa::LinkedData::Mapper::GraphPredicateMapperService`.")
-          Qa::LinkedData::Mapper::GraphPredicateMapperService.map_values(graph: graph, predicate_map: predicate_map, subject_uri: subject_uri, &block)
+        def self.map_values(graph:, predicate_map:, subject_uri:)
+          value_map = {}
+          predicate_map.each do |key, predicate|
+            values = predicate == :subject_uri ? [subject_uri] : graph_service.object_values(graph: graph, subject: subject_uri, predicate: predicate)
+            value_map[key] = values
+          end
+          value_map = yield value_map if block_given?
+          value_map
         end
       end
     end

--- a/config/authorities/linked_data/oclc_fast.json
+++ b/config/authorities/linked_data/oclc_fast.json
@@ -1,5 +1,10 @@
 {
-  "QA_CONFIG_VERSION": "2.0",
+  "QA_CONFIG_VERSION": "2.1",
+  "prefixes": {
+    "dcterms": "http://purl.org/dc/terms/",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "schema": "http://schema.org/"
+  },
   "term": {
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
@@ -60,9 +65,9 @@
       "subauth": "subauth"
     },
     "results": {
-      "id_predicate":       "http://purl.org/dc/terms/identifier",
-      "label_predicate":    "http://www.w3.org/2004/02/skos/core#prefLabel",
-      "sort_predicate":     "http://www.w3.org/2004/02/skos/core#prefLabel"
+      "id_ldpath":       "dcterms:identifier",
+      "label_ldpath":    "skos:prefLabel",
+      "sort_ldpath":     "skos:prefLabel"
     },
     "subauthorities": {
       "topic":          "oclc.topic",

--- a/lib/qa/authorities/linked_data/config.rb
+++ b/lib/qa/authorities/linked_data/config.rb
@@ -28,7 +28,7 @@ module Qa::Authorities
       end
 
       def search
-        @search ||= Qa::Authorities::LinkedData::SearchConfig.new(authority_config.fetch(:search), prefixes)
+        @search ||= Qa::Authorities::LinkedData::SearchConfig.new(authority_config.fetch(:search), prefixes, self)
       end
 
       def term

--- a/lib/qa/authorities/linked_data/config/search_config.rb
+++ b/lib/qa/authorities/linked_data/config/search_config.rb
@@ -5,16 +5,19 @@
 module Qa::Authorities
   module LinkedData
     class SearchConfig
-      attr_reader :prefixes
+      attr_reader :prefixes, :full_config, :search_config
+      private :full_config, :search_config
+
+      delegate :authority_name, to: :full_config
 
       # @param [Hash] config the search portion of the config
-      def initialize(config, prefixes = {})
+      # @param [Hash<Symbol><String>] prefixes URL map of prefixes to use with ldpaths
+      # @param [Qa::Authorities::LinkedData::Config] full_config the full linked data configuration that the passed in search config is part of
+      def initialize(config, prefixes = {}, full_config = nil)
         @search_config = config
         @prefixes = prefixes
+        @full_config = full_config
       end
-
-      attr_reader :search_config
-      private :search_config
 
       # Does this authority configuration have search defined?
       # @return [Boolean] true if search is configured; otherwise, false
@@ -40,14 +43,14 @@ module Qa::Authorities
         @language = lang.collect(&:to_sym)
       end
 
-      # Return results predicates if specified
-      # @return [Hash,NilClass] all the configured predicates to pull out of the results
+      # Return results ldpaths or predicates if specified
+      # @return [Hash,NilClass] all the configured ldpaths or predicates to pull out of the results
       def results
         search_config[:results]
       end
 
       # Return results id_ldpath
-      # @return [String] the configured predicate to use to extract the id from the results
+      # @return [String] the configured ldpath to use to extract the id from the results
       def results_id_ldpath
         Config.config_value(results, :id_ldpath)
       end
@@ -55,11 +58,15 @@ module Qa::Authorities
       # Return results id_predicate
       # @return [String] the configured predicate to use to extract the id from the results
       def results_id_predicate
+        Qa.deprecation_warning(
+          in_msg: 'Qa::Authorities::LinkedData::SearchConfig',
+          msg: "`results_id_predicate` is deprecated; use `results_id_ldpath` by updating linked data search config results to specify as `id_ldpath`"
+        )
         Config.predicate_uri(results, :id_predicate)
       end
 
       # Return results label_ldpath
-      # @return [String] the configured predicate to use to extract label values from the results
+      # @return [String] the configured ldpath to use to extract label values from the results
       def results_label_ldpath
         Config.config_value(results, :label_ldpath)
       end
@@ -67,11 +74,15 @@ module Qa::Authorities
       # Return results label_predicate
       # @return [String] the configured predicate to use to extract label values from the results
       def results_label_predicate
+        Qa.deprecation_warning(
+          in_msg: 'Qa::Authorities::LinkedData::SearchConfig',
+          msg: "`results_label_predicate` is deprecated; use `results_label_ldpath` by updating linked data search config results to specify as `label_ldpath`"
+        )
         Config.predicate_uri(results, :label_predicate)
       end
 
       # Return results altlabel_ldpath
-      # @return [String] the configured predicate to use to extract altlabel values from the results
+      # @return [String] the configured ldpath to use to extract altlabel values from the results
       def results_altlabel_ldpath
         Config.config_value(results, :altlabel_ldpath)
       end
@@ -79,18 +90,22 @@ module Qa::Authorities
       # Return results altlabel_predicate
       # @return [String] the configured predicate to use to extract altlabel values from the results
       def results_altlabel_predicate
+        Qa.deprecation_warning(
+          in_msg: 'Qa::Authorities::LinkedData::SearchConfig',
+          msg: "`results_altlabel_predicate` is deprecated; use `results_altlabel_ldpath` by updating linked data search config results to specify as `altlabel_ldpath`"
+        )
         Config.predicate_uri(results, :altlabel_predicate)
       end
 
       # Does this authority configuration support sorting of search results?
       # @return [True|False] true if sorting of search results is supported; otherwise, false
       def supports_sort?
-        return true unless results_sort_predicate.nil? || !results_sort_predicate.size.positive?
+        return true unless results_sort_ldpath.present? || !results_sort_predicate.present?
         false
       end
 
-      # Return results sort_predicate
-      # @return [String] the configured predicate to use for sorting results from the query search
+      # Return results sort_ldpath
+      # @return [String] the configured ldpath to use for sorting results from the query search
       def results_sort_ldpath
         Config.config_value(results, :sort_ldpath)
       end
@@ -98,6 +113,10 @@ module Qa::Authorities
       # Return results sort_predicate
       # @return [String] the configured predicate to use for sorting results from the query search
       def results_sort_predicate
+        Qa.deprecation_warning(
+          in_msg: 'Qa::Authorities::LinkedData::SearchConfig',
+          msg: "`results_sort_predicate` is deprecated; use `results_sort_ldpath` by updating linked data search config results to specify as `sort_ldpath`"
+        )
         Config.predicate_uri(results, :sort_predicate)
       end
 

--- a/spec/services/linked_data/mapper/graph_ldpath_mapper_service_spec.rb
+++ b/spec/services/linked_data/mapper/graph_ldpath_mapper_service_spec.rb
@@ -1,0 +1,118 @@
+require 'spec_helper'
+
+RSpec.describe Qa::LinkedData::Mapper::GraphLdpathMapperService do
+  let(:graph) { Qa::LinkedData::GraphService.load_graph(url: 'http://local.data') }
+  let(:prefixes) do
+    {
+      uri: :subject_uri,
+      dcterms: 'http://purl.org/dc/terms/',
+      skos: 'http://www.w3.org/2004/02/skos/core#',
+      vivoweb: 'http://vivoweb.org/ontology/core#'
+    }
+  end
+  let(:ldpath_map) do
+    {
+      uri: :subject_uri,
+      id: 'dcterms:identifier',
+      label: 'skos:prefLabel',
+      altlabel: 'skos:altLabel',
+      sameas: 'skos:sameAs',
+      sort: 'vivoweb:rank'
+    }
+  end
+
+  before do
+    stub_request(:get, 'http://local.data')
+      .to_return(status: 200, body: webmock_fixture('lod_3_ranked_varying_preds.nt'), headers: { 'Content-Type' => 'application/n-triples' })
+  end
+
+  describe '.map_values' do
+    subject { described_class.map_values(graph: graph, prefixes: prefixes, ldpath_map: ldpath_map, subject_uri: subject_uri) }
+
+    context 'when each predicate has one value' do
+      let(:subject_uri) { RDF::URI.new('http://id.worldcat.org/fast/530369') }
+
+      it 'maps graph values to predicates' do
+        expect(subject.count).to eq 6
+        expect(subject).to be_kind_of Hash
+        expect(subject.keys).to match_array [:uri, :id, :label, :altlabel, :sameas, :sort]
+
+        validate_entry(subject, :uri, [subject_uri.to_s], RDF::URI)
+        validate_entry(subject, :id, ['530369'], String)
+        validate_entry(subject, :label, ['Cornell University'], String)
+        validate_entry(subject, :altlabel, ['Ithaca (N.Y.). Cornell University'], String)
+        validate_entry(subject, :sameas, ['http://id.loc.gov/authorities/names/n79021621'], RDF::URI)
+        validate_entry(subject, :sort, ['1'], String)
+      end
+    end
+
+    context 'when some predicates have multiple values' do
+      let(:subject_uri) { RDF::URI.new('http://id.worldcat.org/fast/510103') }
+
+      it 'maps graph values to predicates' do
+        expect(subject.count).to eq 6
+        expect(subject).to be_kind_of Hash
+        expect(subject.keys).to match_array [:uri, :id, :label, :altlabel, :sameas, :sort]
+
+        validate_entry(subject, :uri, [subject_uri.to_s], RDF::URI)
+        validate_entry(subject, :id, ['510103'], String)
+        validate_entry(subject, :label, ['Cornell University. Libraries'], String)
+        validate_entry(subject, :altlabel, ['Cornell University. Central Libraries', 'Cornell University. John M. Olin Library', 'Cornell University. White Library'], String)
+        validate_entry(subject, :sameas, ['http://id.loc.gov/authorities/names/n50000040', 'https://viaf.org/viaf/147713418'], RDF::URI)
+        validate_entry(subject, :sort, ['2'], String)
+      end
+    end
+
+    context 'when some predicates has no values' do
+      let(:subject_uri) { RDF::URI.new('http://id.worldcat.org/fast/5140') }
+
+      it 'maps graph values to predicates' do
+        expect(subject.count).to eq 6
+        expect(subject).to be_kind_of Hash
+        expect(subject.keys).to match_array [:uri, :id, :label, :altlabel, :sameas, :sort]
+
+        validate_entry(subject, :uri, [subject_uri.to_s], RDF::URI)
+        validate_entry(subject, :id, ['5140'], String)
+        validate_entry(subject, :label, ['Cornell, Joseph'], String)
+        validate_entry(subject, :altlabel, [], NilClass)
+        validate_entry(subject, :sameas, [], NilClass)
+        validate_entry(subject, :sort, ['3'], String)
+      end
+    end
+
+    context 'when block is passed in' do
+      let(:subject_uri) { RDF::URI.new('http://id.worldcat.org/fast/5140') }
+      let(:context) do
+        { location: '42.4488° N, 76.4763° W' }
+      end
+      let(:subject) do
+        described_class.map_values(graph: graph, prefixes: prefixes, ldpath_map: ldpath_map, subject_uri: subject_uri) do |value_map|
+          value_map[:context] = context
+          value_map
+        end
+      end
+
+      it 'yields to passed in block' do
+        expect(subject.count).to eq 7
+        expect(subject).to be_kind_of Hash
+        expect(subject.keys).to match_array [:uri, :id, :label, :altlabel, :sameas, :sort, :context]
+
+        validate_entry(subject, :uri, [subject_uri.to_s], RDF::URI)
+        validate_entry(subject, :id, ['5140'], String)
+        validate_entry(subject, :label, ['Cornell, Joseph'], String)
+        validate_entry(subject, :altlabel, [], NilClass)
+        validate_entry(subject, :sameas, [], NilClass)
+        validate_entry(subject, :sort, ['3'], String)
+
+        expect(subject[:context]).to be_kind_of Hash
+        expect(subject[:context]).to include(context)
+      end
+    end
+  end
+
+  def validate_entry(results, key, values, entry_kind)
+    expect(results[key]).to be_kind_of Array
+    expect(results[key].first).to be_kind_of entry_kind
+    expect(results[key].map(&:to_s)).to match_array values
+  end
+end

--- a/spec/services/linked_data/mapper/graph_predicate_mapper_service_spec.rb
+++ b/spec/services/linked_data/mapper/graph_predicate_mapper_service_spec.rb
@@ -1,0 +1,110 @@
+require 'spec_helper'
+
+RSpec.describe Qa::LinkedData::Mapper::GraphPredicateMapperService do
+  let(:graph) { Qa::LinkedData::GraphService.load_graph(url: 'http://local.data') }
+  let(:predicate_map) do
+    {
+      uri: :subject_uri,
+      id: RDF::URI.new('http://purl.org/dc/terms/identifier'),
+      label: RDF::URI.new('http://www.w3.org/2004/02/skos/core#prefLabel'),
+      altlabel: RDF::URI.new('http://www.w3.org/2004/02/skos/core#altLabel'),
+      sameas: RDF::URI.new('http://www.w3.org/2004/02/skos/core#sameAs'),
+      sort: RDF::URI.new('http://vivoweb.org/ontology/core#rank')
+    }
+  end
+
+  before do
+    stub_request(:get, 'http://local.data')
+      .to_return(status: 200, body: webmock_fixture('lod_3_ranked_varying_preds.nt'), headers: { 'Content-Type' => 'application/n-triples' })
+  end
+
+  describe '.map_values' do
+    subject { described_class.map_values(graph: graph, predicate_map: predicate_map, subject_uri: subject_uri) }
+
+    context 'when each predicate has one value' do
+      let(:subject_uri) { RDF::URI.new('http://id.worldcat.org/fast/530369') }
+
+      it 'maps graph values to predicates' do
+        expect(subject.count).to eq 6
+        expect(subject).to be_kind_of Hash
+        expect(subject.keys).to match_array [:uri, :id, :label, :altlabel, :sameas, :sort]
+
+        validate_entry(subject, :uri, [subject_uri.to_s], RDF::URI)
+        validate_entry(subject, :id, ['530369'], RDF::Literal)
+        validate_entry(subject, :label, ['Cornell University'], RDF::Literal)
+        validate_entry(subject, :altlabel, ['Ithaca (N.Y.). Cornell University'], RDF::Literal)
+        validate_entry(subject, :sameas, ['http://id.loc.gov/authorities/names/n79021621'], RDF::URI)
+        validate_entry(subject, :sort, ['1'], RDF::Literal)
+      end
+    end
+
+    context 'when some predicates have multiple values' do
+      let(:subject_uri) { RDF::URI.new('http://id.worldcat.org/fast/510103') }
+
+      it 'maps graph values to predicates' do
+        expect(subject.count).to eq 6
+        expect(subject).to be_kind_of Hash
+        expect(subject.keys).to match_array [:uri, :id, :label, :altlabel, :sameas, :sort]
+
+        validate_entry(subject, :uri, [subject_uri.to_s], RDF::URI)
+        validate_entry(subject, :id, ['510103'], RDF::Literal)
+        validate_entry(subject, :label, ['Cornell University. Libraries'], RDF::Literal)
+        validate_entry(subject, :altlabel, ['Cornell University. Central Libraries', 'Cornell University. John M. Olin Library', 'Cornell University. White Library'], RDF::Literal)
+        validate_entry(subject, :sameas, ['http://id.loc.gov/authorities/names/n50000040', 'https://viaf.org/viaf/147713418'], RDF::URI)
+        validate_entry(subject, :sort, ['2'], RDF::Literal)
+      end
+    end
+
+    context 'when some predicates has no values' do
+      let(:subject_uri) { RDF::URI.new('http://id.worldcat.org/fast/5140') }
+
+      it 'maps graph values to predicates' do
+        expect(subject.count).to eq 6
+        expect(subject).to be_kind_of Hash
+        expect(subject.keys).to match_array [:uri, :id, :label, :altlabel, :sameas, :sort]
+
+        validate_entry(subject, :uri, [subject_uri.to_s], RDF::URI)
+        validate_entry(subject, :id, ['5140'], RDF::Literal)
+        validate_entry(subject, :label, ['Cornell, Joseph'], RDF::Literal)
+        validate_entry(subject, :altlabel, [], NilClass)
+        validate_entry(subject, :sameas, [], NilClass)
+        validate_entry(subject, :sort, ['3'], RDF::Literal)
+      end
+    end
+
+    context 'when block is passed in' do
+      let(:subject_uri) { RDF::URI.new('http://id.worldcat.org/fast/5140') }
+      let(:context) do
+        { location: '42.4488° N, 76.4763° W' }
+      end
+      let(:subject) do
+        described_class.map_values(graph: graph, predicate_map: predicate_map, subject_uri: subject_uri) do |value_map|
+          value_map[:context] = context
+          value_map
+        end
+      end
+
+      it 'yields to passed in block' do
+        expect(subject.count).to eq 7
+        expect(subject).to be_kind_of Hash
+        expect(subject.keys).to match_array [:uri, :id, :label, :altlabel, :sameas, :sort, :context]
+
+        validate_entry(subject, :uri, [subject_uri.to_s], RDF::URI)
+        validate_entry(subject, :id, ['5140'], RDF::Literal)
+        validate_entry(subject, :label, ['Cornell, Joseph'], RDF::Literal)
+        validate_entry(subject, :altlabel, [], NilClass)
+        validate_entry(subject, :sameas, [], NilClass)
+        validate_entry(subject, :sort, ['3'], RDF::Literal)
+
+        expect(subject[:context]).to be_kind_of Hash
+        expect(subject[:context]).to include(context)
+      end
+    end
+  end
+
+  def validate_entry(results, key, values, entry_kind)
+    expect(results[key]).to be_kind_of Array
+    expect(results[key].first).to be_kind_of entry_kind
+    expect(results[key].map(&:to_s)).to match_array values
+  end
+end


### PR DESCRIPTION
NOTE: Processing of the search config with results specified using predicates was NOT removed.  It is deprecated for backward compatibility.