### PR TITLE
update tests to use real values found in the data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           project: qa
 
       - samvera/engine_cart_generate:
-          cache_key: v2-internal-test-app-{{ checksum "qa.gemspec" }}-{{ checksum "spec/test_app_templates/lib/generators/test_app_generator.rb" }}-{{ checksum "lib/generators/qa/install/install_generator.rb" }}-<< parameters.rails_version >>-<< parameters.ruby_version >>
+          cache_key: v4-internal-test-app-{{ checksum "qa.gemspec" }}-{{ checksum "spec/test_app_templates/lib/generators/test_app_generator.rb" }}-{{ checksum "lib/generators/qa/install/install_generator.rb" }}-<< parameters.rails_version >>-<< parameters.ruby_version >>
 
       - samvera/bundle_for_gem:
           ruby_version: << parameters.ruby_version >>

--- a/lib/qa/authorities/linked_data/config.rb
+++ b/lib/qa/authorities/linked_data/config.rb
@@ -32,7 +32,7 @@ module Qa::Authorities
       end
 
       def term
-        @term ||= Qa::Authorities::LinkedData::TermConfig.new(authority_config.fetch(:term), prefixes)
+        @term ||= Qa::Authorities::LinkedData::TermConfig.new(authority_config.fetch(:term), prefixes, self)
       end
 
       def prefixes

--- a/lib/qa/authorities/linked_data/config/term_config.rb
+++ b/lib/qa/authorities/linked_data/config/term_config.rb
@@ -5,16 +5,19 @@
 module Qa::Authorities
   module LinkedData
     class TermConfig
-      attr_reader :prefixes
+      attr_reader :prefixes, :full_config, :term_config
+      private :full_config, :term_config
+
+      delegate :authority_name, to: :full_config
 
       # @param [Hash] config the term portion of the config
-      def initialize(config, prefixes = {})
+      # @param [Hash<Symbol><String>] prefixes URL map of prefixes to use with ldpaths
+      # @param [Qa::Authorities::LinkedData::Config] full_config the full linked data configuration that the passed in search config is part of
+      def initialize(config, prefixes = {}, full_config = nil)
         @term_config = config
         @prefixes = prefixes
+        @full_config = full_config
       end
-
-      attr_reader :term_config
-      private :term_config
 
       # Does this authority configuration have term defined?
       # @return [True|False] true if term fetching is configured; otherwise, false

--- a/spec/controllers/linked_data_terms_controller_spec.rb
+++ b/spec/controllers/linked_data_terms_controller_spec.rb
@@ -378,7 +378,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
             .to_return(status: 200, body: webmock_fixture('lod_loc_term_found.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
         end
         it 'succeeds and defaults to json content type' do
-          get :show, params: { id: 'sh85118553', vocab: 'LOC', subauthority: 'subjects' }
+          get :show, params: { id: 'sh 85118553', vocab: 'LOC', subauthority: 'subjects' }
           expect(response).to be_successful
           expect(response.content_type).to eq 'application/json'
         end
@@ -390,36 +390,36 @@ describe Qa::LinkedDataTermsController, type: :controller do
     context 'producing internal server error' do
       context 'when server returns 500' do
         before do
-          stub_request(:get, 'http://localhost/test_default/term?uri=http://test.org/530369').to_return(status: 500)
+          stub_request(:get, 'http://localhost/test_default/term?uri=http://id.worldcat.org/fast/530369').to_return(status: 500)
         end
         it 'returns 500' do
-          expect(Rails.logger).to receive(:warn).with("Internal Server Error - Fetch term http://test.org/530369 unsuccessful for authority LOD_TERM_URI_PARAM_CONFIG")
-          get :fetch, params: { vocab: 'LOD_TERM_URI_PARAM_CONFIG', uri: 'http://test.org/530369' }
+          expect(Rails.logger).to receive(:warn).with("Internal Server Error - Fetch term http://id.worldcat.org/fast/530369 unsuccessful for authority LOD_TERM_URI_PARAM_CONFIG")
+          get :fetch, params: { vocab: 'LOD_TERM_URI_PARAM_CONFIG', uri: 'http://id.worldcat.org/fast/530369' }
           expect(response.code).to eq('500')
         end
       end
 
       context 'when rdf format error' do
         before do
-          stub_request(:get, 'http://localhost/test_default/term?uri=http://test.org/530369').to_return(status: 200)
+          stub_request(:get, 'http://localhost/test_default/term?uri=http://id.worldcat.org/fast/530369').to_return(status: 200)
           allow(RDF::Graph).to receive(:load).and_raise(RDF::FormatError)
         end
         it 'returns 500' do
-          msg = "RDF Format Error - Results from fetch term http://test.org/530369 for authority LOD_TERM_URI_PARAM_CONFIG was not identified as a valid RDF format.  " \
+          msg = "RDF Format Error - Results from fetch term http://id.worldcat.org/fast/530369 for authority LOD_TERM_URI_PARAM_CONFIG was not identified as a valid RDF format.  " \
                 "You may need to include the linkeddata gem."
           expect(Rails.logger).to receive(:warn).with(msg)
-          get :fetch, params: { uri: 'http://test.org/530369', vocab: 'LOD_TERM_URI_PARAM_CONFIG' }
+          get :fetch, params: { uri: 'http://id.worldcat.org/fast/530369', vocab: 'LOD_TERM_URI_PARAM_CONFIG' }
           expect(response.code).to eq('500')
         end
       end
 
       context "when error isn't specifically handled" do
         before do
-          stub_request(:get, 'http://localhost/test_default/term?uri=http://test.org/530369').to_return(status: 501)
+          stub_request(:get, 'http://localhost/test_default/term?uri=http://id.worldcat.org/fast/530369').to_return(status: 501)
         end
         it 'returns 500' do
-          expect(Rails.logger).to receive(:warn).with("Internal Server Error - Fetch term http://test.org/530369 unsuccessful for authority LOD_TERM_URI_PARAM_CONFIG")
-          get :fetch, params: { uri: 'http://test.org/530369', vocab: 'LOD_TERM_URI_PARAM_CONFIG' }
+          expect(Rails.logger).to receive(:warn).with("Internal Server Error - Fetch term http://id.worldcat.org/fast/530369 unsuccessful for authority LOD_TERM_URI_PARAM_CONFIG")
+          get :fetch, params: { uri: 'http://id.worldcat.org/fast/530369', vocab: 'LOD_TERM_URI_PARAM_CONFIG' }
           expect(response.code).to eq('500')
         end
       end
@@ -427,11 +427,11 @@ describe Qa::LinkedDataTermsController, type: :controller do
 
     context 'when service unavailable' do
       before do
-        stub_request(:get, 'http://localhost/test_default/term?uri=http://test.org/530369').to_return(status: 503)
+        stub_request(:get, 'http://localhost/test_default/term?uri=http://id.worldcat.org/fast/530369').to_return(status: 503)
       end
       it 'returns 503' do
-        expect(Rails.logger).to receive(:warn).with("Service Unavailable - Fetch term http://test.org/530369 unsuccessful for authority LOD_TERM_URI_PARAM_CONFIG")
-        get :fetch, params: { uri: 'http://test.org/530369', vocab: 'LOD_TERM_URI_PARAM_CONFIG' }
+        expect(Rails.logger).to receive(:warn).with("Service Unavailable - Fetch term http://id.worldcat.org/fast/530369 unsuccessful for authority LOD_TERM_URI_PARAM_CONFIG")
+        get :fetch, params: { uri: 'http://id.worldcat.org/fast/530369', vocab: 'LOD_TERM_URI_PARAM_CONFIG' }
         expect(response.code).to eq('503')
       end
     end
@@ -450,19 +450,19 @@ describe Qa::LinkedDataTermsController, type: :controller do
     context 'in LOD_TERM_URI_PARAM_CONFIG authority' do
       context 'term found' do
         before do
-          stub_request(:get, 'http://localhost/test_default/term?uri=http://test.org/530369')
+          stub_request(:get, 'http://localhost/test_default/term?uri=http://id.worldcat.org/fast/530369')
             .to_return(status: 200, body: webmock_fixture('lod_oclc_term_found.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
         end
 
         it 'succeeds and defaults to json content type' do
-          get :fetch, params: { uri: 'http://test.org/530369', vocab: 'LOD_TERM_URI_PARAM_CONFIG' }
+          get :fetch, params: { uri: 'http://id.worldcat.org/fast/530369', vocab: 'LOD_TERM_URI_PARAM_CONFIG' }
           expect(response).to be_successful
           expect(response.content_type).to eq 'application/json'
         end
 
         context 'and it was requested as json' do
           it 'succeeds and returns term data as json content type' do
-            get :fetch, params: { uri: 'http://test.org/530369', vocab: 'LOD_TERM_URI_PARAM_CONFIG', format: 'json' }
+            get :fetch, params: { uri: 'http://id.worldcat.org/fast/530369', vocab: 'LOD_TERM_URI_PARAM_CONFIG', format: 'json' }
             expect(response).to be_successful
             expect(response.content_type).to eq 'application/json'
           end
@@ -470,7 +470,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
 
         context 'and it was requested as jsonld' do
           it 'succeeds and returns term data as jsonld content type' do
-            get :fetch, params: { uri: 'http://test.org/530369', vocab: 'LOD_TERM_URI_PARAM_CONFIG', format: 'jsonld' }
+            get :fetch, params: { uri: 'http://id.worldcat.org/fast/530369', vocab: 'LOD_TERM_URI_PARAM_CONFIG', format: 'jsonld' }
             expect(response).to be_successful
             expect(response.content_type).to eq 'application/ld+json'
             expect(JSON.parse(response.body).keys).to match_array ["@context", "@graph"]
@@ -479,11 +479,11 @@ describe Qa::LinkedDataTermsController, type: :controller do
 
         context 'blank nodes not included in predicates list' do
           before do
-            stub_request(:get, 'http://localhost/test_default/term?uri=http://test.org/530369wbn')
+            stub_request(:get, 'http://localhost/test_default/term?uri=http://id.worldcat.org/fast/530369wbn')
               .to_return(status: 200, body: webmock_fixture('lod_term_with_blanknode_objects.nt'), headers: { 'Content-Type' => 'application/n-triples' })
           end
           it 'succeeds' do
-            get :fetch, params: { uri: 'http://test.org/530369wbn', vocab: 'LOD_TERM_URI_PARAM_CONFIG' }
+            get :fetch, params: { uri: 'http://id.worldcat.org/fast/530369wbn', vocab: 'LOD_TERM_URI_PARAM_CONFIG' }
             expect(response).to be_successful
           end
         end
@@ -492,11 +492,11 @@ describe Qa::LinkedDataTermsController, type: :controller do
       context 'when cors headers are enabled' do
         before do
           Qa.config.enable_cors_headers
-          stub_request(:get, 'http://localhost/test_default/term?uri=http://test.org/530369')
+          stub_request(:get, 'http://localhost/test_default/term?uri=http://id.worldcat.org/fast/530369')
             .to_return(status: 200, body: webmock_fixture('lod_oclc_term_found.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
         end
         it 'Access-Control-Allow-Origin is *' do
-          get :fetch, params: { uri: 'http://test.org/530369', vocab: 'LOD_TERM_URI_PARAM_CONFIG' }
+          get :fetch, params: { uri: 'http://id.worldcat.org/fast/530369', vocab: 'LOD_TERM_URI_PARAM_CONFIG' }
           expect(response.headers['Access-Control-Allow-Origin']).to eq '*'
         end
       end
@@ -504,11 +504,11 @@ describe Qa::LinkedDataTermsController, type: :controller do
       context 'when cors headers are disabled' do
         before do
           Qa.config.disable_cors_headers
-          stub_request(:get, 'http://localhost/test_default/term?uri=http://test.org/530369')
+          stub_request(:get, 'http://localhost/test_default/term?uri=http://id.worldcat.org/fast/530369')
             .to_return(status: 200, body: webmock_fixture('lod_oclc_term_found.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
         end
         it 'Access-Control-Allow-Origin is not present' do
-          get :fetch, params: { uri: 'http://test.org/530369', vocab: 'LOD_TERM_URI_PARAM_CONFIG' }
+          get :fetch, params: { uri: 'http://id.worldcat.org/fast/530369', vocab: 'LOD_TERM_URI_PARAM_CONFIG' }
           expect(response.headers.key?('Access-Control-Allow-Origin')).to be false
         end
       end

--- a/spec/fixtures/authorities/linked_data/lod_lang_defaults.json
+++ b/spec/fixtures/authorities/linked_data/lod_lang_defaults.json
@@ -4,21 +4,21 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type":    "IriTemplate",
-      "template": "http://localhost/test_default/term/{term_id}",
+      "template": "{term_uri}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
           "@type":    "IriTemplateMapping",
-          "variable": "term_id",
+          "variable": "term_uri",
           "property": "hydra:freetextQuery",
           "required": true
         }
       ]
     },
     "qa_replacement_patterns": {
-      "term_id": "term_id"
+      "term_id": "term_uri"
     },
-    "term_id": "ID",
+    "term_id": "URI",
     "language": [ "fr" ],
     "results": {
       "id_predicate":       "http://id.loc.gov/vocabulary/identifiers/lccn",

--- a/spec/fixtures/authorities/linked_data/lod_lang_multi_defaults.json
+++ b/spec/fixtures/authorities/linked_data/lod_lang_multi_defaults.json
@@ -4,21 +4,21 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type":    "IriTemplate",
-      "template": "http://localhost/test_default/term/{term_id}",
+      "template": "{term_uri}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
           "@type":    "IriTemplateMapping",
-          "variable": "term_id",
+          "variable": "term_uri",
           "property": "hydra:freetextQuery",
           "required": true
         }
       ]
     },
     "qa_replacement_patterns": {
-      "term_id": "term_id"
+      "term_id": "term_uri"
     },
-    "term_id": "ID",
+    "term_id": "URI",
     "language": [ "en", "fr" ],
     "results": {
       "id_predicate":       "http://purl.org/dc/terms/identifier",

--- a/spec/fixtures/authorities/linked_data/lod_lang_no_defaults.json
+++ b/spec/fixtures/authorities/linked_data/lod_lang_no_defaults.json
@@ -4,23 +4,22 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type":    "IriTemplate",
-      "template": "http://localhost/test_no_default/term/{term_id}",
+      "template": "{term_uri}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
           "@type":    "IriTemplateMapping",
-          "variable": "term_id",
+          "variable": "term_uri",
           "property": "hydra:freetextQuery",
           "required": true
         }
       ]
     },
     "qa_replacement_patterns": {
-      "term_id": "term_id"
+      "term_id": "term_uri"
     },
-    "term_id": "ID",
+    "term_id": "URI",
     "results": {
-      "id_predicate":       "http://id.loc.gov/vocabulary/identifiers/lccn",
       "label_predicate":    "http://www.w3.org/2004/02/skos/core#prefLabel",
       "altlabel_predicate": "http://www.w3.org/2004/02/skos/core#altLabel"
     }

--- a/spec/fixtures/authorities/linked_data/lod_lang_param.json
+++ b/spec/fixtures/authorities/linked_data/lod_lang_param.json
@@ -4,12 +4,12 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type":    "IriTemplate",
-      "template": "http://localhost/test_replacement/term/{term_id}?{?lang}",
+      "template": "{term_uri}?{?lang}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
           "@type":    "IriTemplateMapping",
-          "variable": "term_id",
+          "variable": "term_uri",
           "property": "hydra:freetextQuery",
           "required": true
         },
@@ -23,9 +23,9 @@
       ]
     },
     "qa_replacement_patterns": {
-      "term_id": "term_id"
+      "term_id": "term_uri"
     },
-    "term_id": "ID",
+    "term_id": "URI",
     "results": {
       "id_predicate":       "http://id.loc.gov/vocabulary/identifiers/lccn",
       "label_predicate":    "http://www.w3.org/2004/02/skos/core#prefLabel",

--- a/spec/fixtures/authorities/linked_data/lod_term_uri_param_config.json
+++ b/spec/fixtures/authorities/linked_data/lod_term_uri_param_config.json
@@ -20,7 +20,7 @@
     },
     "term_id": "URI",
     "results": {
-      "id_predicate":       "http://id.loc.gov/vocabulary/identifiers/lccn",
+      "id_predicate":       "http://purl.org/dc/terms/identifier",
       "label_predicate":    "http://www.w3.org/2004/02/skos/core#prefLabel"
     }
   },

--- a/spec/lib/authorities/linked_data/find_term_spec.rb
+++ b/spec/lib/authorities/linked_data/find_term_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
         let :results do
           stub_request(:get, 'http://id.loc.gov/authorities/subjects/sh85118553')
             .to_return(status: 200, body: webmock_fixture('lod_loc_term_found.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
-          lod_loc.find('sh85118553', subauth: 'subjects')
+          lod_loc.find('sh 85118553', subauth: 'subjects')
         end
         it 'has correct primary predicate values' do
           expect(results[:uri]).to eq 'http://id.loc.gov/authorities/subjects/sh85118553'
@@ -128,9 +128,9 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
             context "and NO language defined in Qa config" do
               let(:lod_lang_no_defaults) { described_class.new(term_config(:LOD_LANG_NO_DEFAULTS)) }
               let :results do
-                stub_request(:get, "http://localhost/test_no_default/term/c_9513")
+                stub_request(:get, "http://aims.fao.org/aos/agrovoc/c_9513")
                   .to_return(status: 200, body: webmock_fixture("lod_lang_term_enfr.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
-                lod_lang_no_defaults.find('c_9513')
+                lod_lang_no_defaults.find('http://aims.fao.org/aos/agrovoc/c_9513')
               end
 
               before do
@@ -151,9 +151,9 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
             context "and default_language is defined in Qa config" do
               let(:lod_lang_no_defaults) { described_class.new(term_config(:LOD_LANG_NO_DEFAULTS)) }
               let :results do
-                stub_request(:get, "http://localhost/test_no_default/term/c_9513")
+                stub_request(:get, "http://aims.fao.org/aos/agrovoc/c_9513")
                   .to_return(status: 200, body: webmock_fixture("lod_lang_term_enfr.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
-                lod_lang_no_defaults.find('c_9513')
+                lod_lang_no_defaults.find('http://aims.fao.org/aos/agrovoc/c_9513')
               end
               it "filters using Qa configured default for summary but not for predicates list" do
                 expect(results[:label]).to eq ['buttermilk']
@@ -166,9 +166,9 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
           context "and language IS defined in authority config" do
             let(:lod_lang_defaults) { described_class.new(term_config(:LOD_LANG_DEFAULTS)) }
             let :results do
-              stub_request(:get, "http://localhost/test_default/term/c_9513")
+              stub_request(:get, "http://aims.fao.org/aos/agrovoc/c_9513")
                 .to_return(status: 200, body: webmock_fixture("lod_lang_term_enfr.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
-              lod_lang_defaults.find('c_9513')
+              lod_lang_defaults.find('http://aims.fao.org/aos/agrovoc/c_9513')
             end
             it "filters using authority configured language for summary but not for predicates list" do
               expect(results[:label]).to eq ['Babeurre']
@@ -180,9 +180,9 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
           context "and multiple languages ARE defined in authority config" do
             let(:lod_lang_multi_defaults) { described_class.new(term_config(:LOD_LANG_MULTI_DEFAULTS)) }
             let :results do
-              stub_request(:get, "http://localhost/test_default/term/c_9513")
+              stub_request(:get, "http://aims.fao.org/aos/agrovoc/c_9513")
                 .to_return(status: 200, body: webmock_fixture("lod_lang_term_enfrde.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
-              lod_lang_multi_defaults.find('c_9513')
+              lod_lang_multi_defaults.find('http://aims.fao.org/aos/agrovoc/c_9513')
             end
             it "filters using authority configured languages for summary but not for predicates list" do
               expect(results[:label]).to eq ['buttermilk', 'Babeurre']
@@ -196,9 +196,9 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
         context "and lang IS passed in" do
           let(:lod_lang_defaults) { described_class.new(term_config(:LOD_LANG_DEFAULTS)) }
           let :results do
-            stub_request(:get, "http://localhost/test_default/term/c_9513")
+            stub_request(:get, "http://aims.fao.org/aos/agrovoc/c_9513")
               .to_return(status: 200, body: webmock_fixture("lod_lang_term_enfr.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
-            lod_lang_defaults.find('c_9513', language: 'fr')
+            lod_lang_defaults.find('http://aims.fao.org/aos/agrovoc/c_9513', language: 'fr')
           end
           it "is filtered to specified language" do
             expect(results[:label]).to eq ['Babeurre']
@@ -211,9 +211,9 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
         context "and result does not have altlabel" do
           let(:lod_lang_defaults) { described_class.new(term_config(:LOD_LANG_DEFAULTS)) }
           let :results do
-            stub_request(:get, "http://localhost/test_default/term/c_9513")
+            stub_request(:get, "http://aims.fao.org/aos/agrovoc/c_9513")
               .to_return(status: 200, body: webmock_fixture("lod_lang_term_enfr_noalt.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
-            lod_lang_defaults.find('c_9513', language: 'fr')
+            lod_lang_defaults.find('http://aims.fao.org/aos/agrovoc/c_9513', language: 'fr')
           end
           it "is filtered to specified language" do
             expect(results[:label]).to eq ['Babeurre']
@@ -225,9 +225,9 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
           context "and using default" do
             let(:lod_lang_param) { described_class.new(term_config(:LOD_LANG_PARAM)) }
             let :results do
-              stub_request(:get, "http://localhost/test_replacement/term/c_9513?lang=en")
+              stub_request(:get, "http://aims.fao.org/aos/agrovoc/c_9513?lang=en")
                 .to_return(status: 200, body: webmock_fixture("lod_lang_term_en.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
-              lod_lang_param.find("c_9513")
+              lod_lang_param.find('http://aims.fao.org/aos/agrovoc/c_9513')
             end
             it "is correctly parsed" do
               expect(results[:label]).to eq ['buttermilk']
@@ -240,9 +240,9 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
           context "and lang specified" do
             let(:lod_lang_param) { described_class.new(term_config(:LOD_LANG_PARAM)) }
             let :results do
-              stub_request(:get, "http://localhost/test_replacement/term/c_9513?lang=fr")
+              stub_request(:get, "http://aims.fao.org/aos/agrovoc/c_9513?lang=fr")
                 .to_return(status: 200, body: webmock_fixture("lod_lang_term_fr.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
-              lod_lang_param.find("c_9513", replacements: { 'lang' => 'fr' })
+              lod_lang_param.find('http://aims.fao.org/aos/agrovoc/c_9513', replacements: { 'lang' => 'fr' })
             end
             it "is correctly parsed" do
               expect(results[:label]).to eq ['Babeurre']


### PR DESCRIPTION
The particular stubbing that is happening when using graph filtering in QA does not seem to mind if bogus data is used.  But as we move to ldpath, it is looking for real data in the graph.

This is prep work for moving findterm to use ldpath.