### PR TITLE
Basic refactoring of findterm to make it easier to update and more inline with searchquery

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           project: qa
 
       - samvera/engine_cart_generate:
-          cache_key: v4-internal-test-app-{{ checksum "qa.gemspec" }}-{{ checksum "spec/test_app_templates/lib/generators/test_app_generator.rb" }}-{{ checksum "lib/generators/qa/install/install_generator.rb" }}-<< parameters.rails_version >>-<< parameters.ruby_version >>
+          cache_key: v5-internal-test-app-{{ checksum "qa.gemspec" }}-{{ checksum "spec/test_app_templates/lib/generators/test_app_generator.rb" }}-{{ checksum "lib/generators/qa/install/install_generator.rb" }}-<< parameters.rails_version >>-<< parameters.ruby_version >>
 
       - samvera/bundle_for_gem:
           ruby_version: << parameters.ruby_version >>

--- a/app/services/qa/linked_data/deep_sort_service.rb
+++ b/app/services/qa/linked_data/deep_sort_service.rb
@@ -2,8 +2,9 @@
 module Qa
   module LinkedData
     class DeepSortService
-      # @params [Array<Hash<Symbol,Array<RDF::Literal>>>] the array of hashes to sort
-      # @params [sort_key] the key in the hash on whose value the array will be sorted
+      # @param [Array<Hash<Symbol,Array<RDF::Literal>>>] the array of hashes to sort
+      # @param [sort_key] the key in the hash on whose value the array will be sorted
+      # @param [Symbol] preferred language to appear first in the list; defaults to no preference
       # @return instance of this class
       # @example the_array parameter
       #   [

--- a/app/services/qa/linked_data/graph_service.rb
+++ b/app/services/qa/linked_data/graph_service.rb
@@ -41,6 +41,19 @@ module Qa
           values
         end
 
+        # Get subjects that have the object value for the predicate in the graph.
+        # @param graph [RDF::Graph] the graph to search
+        # @param predicate [RDF::URI] the URI of the predicate
+        # @param object_value [String] the object value
+        # @return [Array] all subjects for the predicate-object_value pair
+        def subjects_for_object_value(graph:, predicate:, object_value:)
+          subjects = []
+          graph.query([:subject, predicate, object_value]) do |statement|
+            subjects << statement.subject
+          end
+          subjects
+        end
+
         def deep_copy(graph:)
           new_graph = RDF::Graph.new
           graph.statements.each do |st|

--- a/app/services/qa/linked_data/language_service.rb
+++ b/app/services/qa/linked_data/language_service.rb
@@ -5,12 +5,21 @@ module Qa
       WILDCARD = '*'.freeze
 
       class << self
+        # @param user_langauge [Symbol|String] the language code (e.g. :en, :fr) specified as URL parameter or on URL header
+        # @param authority_language [Symbol|String|Array<Symbol|String>] the default language specified in the authority's configuration file
+        # @return [Array<Symbol>] the selected language(s) normalized as an array of symbols (e.g. [:en, :fr])
+        # @note Precedence from high to low:
+        #       * user_language (with URL parameter preferred over URL header)
+        #       * authority_language (defined in authority config)
+        #       * site default_language (defined in QA initializer)
         def preferred_language(user_language: nil, authority_language: nil)
           return normalize_language(user_language) if user_language.present?
           return normalize_language(authority_language) if authority_language.present?
           normalize_language(Qa.config.default_language)
         end
 
+        # @param [RDF::Literal] the literal to check
+        # @return [Boolean] true if literal has a language tag; otherwise, false
         def literal_has_language_marker?(literal)
           return false unless literal.respond_to?(:language)
           literal.language.present?

--- a/app/services/qa/linked_data/language_sort_service.rb
+++ b/app/services/qa/linked_data/language_sort_service.rb
@@ -7,7 +7,6 @@ module Qa
       attr_reader :literals, :preferred_language
       attr_reader :languages, :bins
       private :literals, :preferred_language, :languages, :bins
-      # private :literals, :preferred_language, :languages, :languages=, :bins, :bins=
 
       # @param [Array<RDF::Literals>] string literals to sort
       # @param [Symbol] preferred language to appear first in the list; defaults to no preference
@@ -20,7 +19,7 @@ module Qa
       end
 
       # Sort the literals stored in this instance of the service
-      # @return sorted version of literals
+      # @return [Array<RDF::Literals] sorted version of literals
       def sort
         return literals unless literals.present?
         return @sorted_literals if @sorted_literals.present?
@@ -28,6 +27,12 @@ module Qa
         sort_languages
         sort_language_bins
         @sorted_literals = construct_sorted_literals
+      end
+
+      # Sort the literals and return as an array of strings with only unique literals and empty strings removed
+      # @return [Array<String>] sorted version of literals as strings
+      def uniq_sorted_strings
+        sort.map(&:to_s).uniq.delete_if(&:blank?)
       end
 
       private

--- a/app/services/qa/linked_data/mapper/search_results_mapper_service.rb
+++ b/app/services/qa/linked_data/mapper/search_results_mapper_service.rb
@@ -39,16 +39,28 @@ module Qa
           #     sort: 'http://vivoweb.org/ontology/core#rank'
           #   }
           # @param sort_key [Symbol] the key in the predicate map for the value on which to sort
+          # @param preferred_language [Array<Symbol>] limit results to the preferred_language(s)
           # @param context_map [Qa::LinkedData::Config::ContextMap] map of additional context to include in the results
           # @return [Array<Hash<Symbol><Array<Object>>>] mapped result values with each result as an element in the array
           #    with hash of map key = array of object values for predicates identified in map parameter.
           # @example value map for a single result
           #   [
-          #     {:uri=>[#<RDF::URI:0x3fcff54a829c URI:http://id.loc.gov/authorities/names/n2010043281>],
-          #      :id=>[#<RDF::Literal:0x3fcff4a367b4("n 2010043281")>],
-          #      :label=>[#<RDF::Literal:0x3fcff54a9a98("Valli, Sabrina"@en)>],
-          #      :altlabel=>[],
-          #      :sort=>[#<RDF::Literal:0x3fcff54b4c18("2")>]}
+          #     { "uri":"http://id.loc.gov/authorities/genreForms/gf2011026181","id":"gf2011026181","label":"Stop-motion animation films",
+          #       "context":[
+          #         { "property":"Authoritative Label","values":["Stop-motion animation films"],"selectable":true,"drillable":false },
+          #         { "property":"Variant Label","values":["Object animation films, Frame-by-frame animation films"],"selectable":false,"drillable":false },
+          #         { "group":"Hierarchy","property":"Narrower: ",
+          #           "values":[
+          #             { "uri":"http://id.loc.gov/authorities/genreForms/gf2011026140","id":"gf2011026140","label":"Clay animation films"}
+          #           ],
+          #           "selectable":true,"drillable":true },
+          #         { "group":"Hierarchy","property":"Broader: ",
+          #           "values":[
+          #             { "uri":"http://id.loc.gov/authorities/genreForms/gf2011026049","id":"gf2011026049","label":"Animated films"}
+          #           ],
+          #           "selectable":true,"drillable":true }
+          #       ]
+          #     }
           #   ]
           def map_values(graph:, prefixes: {}, ldpath_map: nil, predicate_map: nil, sort_key:, preferred_language: nil, context_map: nil) # rubocop:disable Metrics/ParameterLists
             search_matches = []

--- a/lib/qa/authorities/linked_data/config/term_config.rb
+++ b/lib/qa/authorities/linked_data/config/term_config.rb
@@ -57,14 +57,14 @@ module Qa::Authorities
         @term_language = lang.collect(&:to_sym)
       end
 
-      # Return results predicates
-      # @return [Hash] all the configured predicates to pull out of the results
+      # Return results ldpaths or predicates
+      # @return [Hash] all the configured ldpaths or predicates to pull out of the results
       def term_results
         Config.config_value(term_config, :results)
       end
 
       # Return results id_ldpath
-      # @return [String] the configured predicate to use to extract the id from the results
+      # @return [String] the configured ldpath to use to extract the id from the results
       def term_results_id_ldpath
         Config.config_value(term_results, :id_ldpath)
       end
@@ -76,7 +76,7 @@ module Qa::Authorities
       end
 
       # Return results label_ldpath
-      # @return [String] the configured predicate to use to extract label values from the results
+      # @return [String] the configured ldpath to use to extract label values from the results
       def term_results_label_ldpath
         Config.config_value(term_results, :label_ldpath)
       end
@@ -88,7 +88,7 @@ module Qa::Authorities
       end
 
       # Return results altlabel_ldpath
-      # @return [String] the configured predicate to use to extract altlabel values from the results
+      # @return [String] the configured ldpath to use to extract altlabel values from the results
       def term_results_altlabel_ldpath
         Config.config_value(term_results, :altlabel_ldpath)
       end
@@ -100,7 +100,7 @@ module Qa::Authorities
       end
 
       # Return results broader_ldpath
-      # @return [String] the configured predicate to use to extract URIs for broader terms from the results
+      # @return [String] the configured ldpath to use to extract URIs for broader terms from the results
       def term_results_broader_ldpath
         Config.config_value(term_results, :broader_ldpath)
       end
@@ -112,7 +112,7 @@ module Qa::Authorities
       end
 
       # Return results narrower_ldpath
-      # @return [String] the configured predicate to use to extract URIs for narrower terms from the results
+      # @return [String] the configured ldpath to use to extract URIs for narrower terms from the results
       def term_results_narrower_ldpath
         Config.config_value(term_results, :narrower_ldpath)
       end
@@ -124,7 +124,7 @@ module Qa::Authorities
       end
 
       # Return results sameas_ldpath
-      # @return [String] the configured predicate to use to extract URIs for sameas terms from the results
+      # @return [String] the configured ldpath to use to extract URIs for sameas terms from the results
       def term_results_sameas_ldpath
         Config.config_value(term_results, :sameas_ldpath)
       end

--- a/lib/qa/authorities/linked_data/rdf_helper.rb
+++ b/lib/qa/authorities/linked_data/rdf_helper.rb
@@ -37,13 +37,6 @@ module Qa::Authorities
             end
           end
         end
-
-        def sort_string_by_language(str_literals)
-          return str_literals if str_literals.blank?
-          str_literals = Qa::LinkedData::LanguageSortService.new(str_literals).sort
-          str_literals.map!(&:to_s).uniq!
-          str_literals.delete_if { |s| s.nil? || s.length <= 0 }
-        end
     end
   end
 end

--- a/lib/qa/authorities/linked_data/search_query.rb
+++ b/lib/qa/authorities/linked_data/search_query.rb
@@ -38,7 +38,8 @@ module Qa::Authorities
         url = authority_service.build_url(action_config: search_config, action: :search, action_request: query, substitutions: replacements, subauthority: subauth, language: @language)
         Rails.logger.info "QA Linked Data search url: #{url}"
         load_graph(url: url)
-        parse_search_authority_response
+        results = process_results
+        convert_results_to_json(results)
       end
 
       private
@@ -48,7 +49,7 @@ module Qa::Authorities
           @graph = graph_service.filter(graph: @graph, language: language, remove_blanknode_subjects: true)
         end
 
-        def parse_search_authority_response
+        def process_results
           predicate_map = preds_for_search
           ldpath_map = ldpaths_for_search
 
@@ -62,10 +63,9 @@ module Qa::Authorities
             )
           end
 
-          results = results_mapper_service.map_values(graph: @graph, prefixes: prefixes, ldpath_map: ldpath_map,
-                                                      predicate_map: predicate_map, sort_key: :sort,
-                                                      preferred_language: @language, context_map: context_map)
-          convert_results_to_json(results)
+          results_mapper_service.map_values(graph: @graph, prefixes: prefixes, ldpath_map: ldpath_map,
+                                            predicate_map: predicate_map, sort_key: :sort,
+                                            preferred_language: @language, context_map: context_map)
         end
 
         def context_map


### PR DESCRIPTION
**[WIP]  This is marked WIP because it is better to merge PR #230 first and then rebase this PR before merging it.**

----

Prep for using ldpath with findterm:

* provide access to full config/authority
* use class variables to identify services used in findterm
* use Qa::LinkedData::LanguageSortService for sorting an array of literals instead of rdf_helper module

Part of the goal for the refactoring is to remove the need for the rdf_helper include.  The code in that module should be replaced by service calls instead.  This refactor did this for language sorting.  The next refactor should swap out more of the other methods. 