### PR TITLE
add option to include authority details when getting list of authorities

### DIFF
--- a/app/controllers/qa/linked_data_terms_controller.rb
+++ b/app/controllers/qa/linked_data_terms_controller.rb
@@ -16,11 +16,12 @@ class Qa::LinkedDataTermsController < ::ApplicationController
     head :not_found
   end
 
-  # Return a list of supported authority names
-  # get "/list/linked_data/authorities"
+  # Return a list of supported authority names optionally with details about the authority
+  # get "/list/linked_data/authorities?details=true|false" (default details=false)
   # @see Qa::LinkedData::AuthorityService#authority_names
+  # @see Qa::LinkedData::AuthorityService#authority_details
   def list
-    render json: Qa::LinkedData::AuthorityService.authority_names.to_json
+    details? ? render_detail_list : render_simple_list
   end
 
   # Reload authority configurations
@@ -109,6 +110,14 @@ class Qa::LinkedDataTermsController < ::ApplicationController
   end
 
   private
+
+    def render_simple_list
+      render json: Qa::LinkedData::AuthorityService.authority_names.to_json
+    end
+
+    def render_detail_list
+      render json: Qa::LinkedData::AuthorityService.authority_details.to_json
+    end
 
     def check_authority
       if params[:vocab].nil? || !params[:vocab].size.positive? # rubocop:disable Style/GuardClause
@@ -210,6 +219,11 @@ class Qa::LinkedDataTermsController < ::ApplicationController
     def context?
       context = params.fetch(:context, 'false')
       context.casecmp('true').zero?
+    end
+
+    def details?
+      details = params.fetch(:details, 'false')
+      details.casecmp('true').zero?
     end
 
     def validate_auth_reload_token

--- a/app/services/qa/linked_data/authority_service.rb
+++ b/app/services/qa/linked_data/authority_service.rb
@@ -41,6 +41,14 @@ module Qa
       def self.authority_names
         authority_configs.keys.sort
       end
+
+      # Get the list of names and details of the loaded authorities
+      # @return [Array<String>] names of the authority config files that are currently loaded
+      def self.authority_details
+        details = []
+        authority_names.each { |auth_name| details << Qa::Authorities::LinkedData::Config.new(auth_name).authority_info }
+        details.flatten
+      end
     end
   end
 end

--- a/lib/qa/authorities/linked_data/config.rb
+++ b/lib/qa/authorities/linked_data/config.rb
@@ -47,6 +47,10 @@ module Qa::Authorities
         config_version == version
       end
 
+      def authority_info
+        search.info + term.info
+      end
+
       # Return the full configuration for an authority
       # @return [String] the authority configuration
       def authority_config

--- a/lib/qa/authorities/linked_data/config/search_config.rb
+++ b/lib/qa/authorities/linked_data/config/search_config.rb
@@ -4,7 +4,7 @@
 # @see Qa::Authorities::LinkedData::TermConfig
 module Qa::Authorities
   module LinkedData
-    class SearchConfig
+    class SearchConfig # rubocop:disable Metrics/ClassLength
       attr_reader :prefixes, :full_config, :search_config
       private :full_config, :search_config
 
@@ -175,6 +175,40 @@ module Qa::Authorities
         @subauthorities ||= {} if search_config.nil? || !(search_config.key? :subauthorities)
         @subauthorities ||= search_config.fetch(:subauthorities)
       end
+
+      def info
+        return [] unless supports_search?
+        auth_name = authority_name.downcase.to_s
+        language = Qa::LinkedData::LanguageService.preferred_language(authority_language: language).map(&:to_s)
+        details = summary_without_subauthority(auth_name, language)
+        subauthorities.each_key { |subauth_name| details << summary_with_subauthority(auth_name, subauth_name.downcase.to_s, language) }
+        details
+      end
+
+      private
+
+        def summary_without_subauthority(auth_name, language)
+          [
+            {
+              "label" => "#{auth_name} search (QA)",
+              "uri" => "urn:qa:search:#{auth_name}",
+              "authority" => auth_name,
+              "action" => "search",
+              "language" => language
+            }
+          ]
+        end
+
+        def summary_with_subauthority(auth_name, subauth_name, language)
+          {
+            "label" => "#{auth_name} search #{subauth_name} (QA)",
+            "uri" => "urn:qa:search:#{auth_name}:#{subauth_name}",
+            "authority" => auth_name,
+            "subauthority" => subauth_name,
+            "action" => "search",
+            "language" => language
+          }
+        end
     end
   end
 end

--- a/spec/controllers/linked_data_terms_controller_spec.rb
+++ b/spec/controllers/linked_data_terms_controller_spec.rb
@@ -81,14 +81,54 @@ describe Qa::LinkedDataTermsController, type: :controller do
   end
 
   describe '#list' do
-    let(:expected_results) { ['Auth1', 'Auth2', 'Auth3'] }
-    before do
-      allow(Qa::LinkedData::AuthorityService).to receive(:authority_names).and_return(expected_results)
+    context 'when details=false' do
+      let(:expected_results) { ['Auth1', 'Auth2', 'Auth3'] }
+      before do
+        allow(Qa::LinkedData::AuthorityService).to receive(:authority_names).and_return(expected_results)
+      end
+      it 'returns list of authorities' do
+        get :list
+        expect(response).to be_successful
+        expect(response.body).to eq expected_results.to_json
+      end
     end
-    it 'returns list of authorities' do
-      get :list
-      expect(response).to be_successful
-      expect(response.body).to eq expected_results.to_json
+
+    context 'when details=true' do
+      let(:expected_results) do
+        [
+          {
+            "label" => "oclc_fast term (QA)",
+            "uri" => "urn:qa:term:oclc_fast",
+            "authority" => "oclc_fast",
+            "action" => "term",
+            "language" => ["en"]
+          },
+          {
+            "label" => "oclc_fast search (QA)",
+            "uri" => "urn:qa:search:oclc_fast",
+            "authority" => "oclc_fast",
+            "action" => "search",
+            "language" => ["en"]
+          },
+          {
+            "label" => "oclc_fast search topic (QA)",
+            "uri" => "urn:qa:search:oclc_fast:topic",
+            "authority" => "oclc_fast",
+            "subauthority" => "topic",
+            "action" => "search",
+            "language" => ["en"]
+          }
+        ]
+      end
+
+      before do
+        allow(Qa::LinkedData::AuthorityService).to receive(:authority_details).and_return(expected_results)
+      end
+      it 'returns list of authorities' do
+        get :list, params: { details: 'true' }
+        expect(response).to be_successful
+        expect(response.body).to eq expected_results.to_json
+      end
     end
   end
 

--- a/spec/lib/authorities/linked_data/config_spec.rb
+++ b/spec/lib/authorities/linked_data/config_spec.rb
@@ -412,6 +412,53 @@ describe Qa::Authorities::LinkedData::Config do
     end
   end
 
+  describe '#authority_info' do
+    let(:term_details) do
+      {
+        "label" => "oclc_fast term (QA)",
+        "uri" => "urn:qa:term:oclc_fast",
+        "authority" => "oclc_fast",
+        "action" => "term",
+        "language" => ["en"]
+      }
+    end
+
+    let(:search_details) do
+      {
+        "label" => "oclc_fast search (QA)",
+        "uri" => "urn:qa:search:oclc_fast",
+        "authority" => "oclc_fast",
+        "action" => "search",
+        "language" => ["en"]
+      }
+    end
+
+    let(:search_details_with_subauth) do
+      {
+        "label" => "oclc_fast search topic (QA)",
+        "uri" => "urn:qa:search:oclc_fast:topic",
+        "authority" => "oclc_fast",
+        "subauthority" => "topic",
+        "action" => "search",
+        "language" => ["en"]
+      }
+    end
+
+    let(:details) { described_class.new(:OCLC_FAST).authority_info }
+
+    it "returns a list with details for term without subauthorities" do
+      expect(details).to include_hash(term_details)
+    end
+
+    it "returns a list with details for search without subauthorities" do
+      expect(details).to include_hash(search_details)
+    end
+
+    it "returns a list with details for search with a subauthority" do
+      expect(details).to include_hash(search_details_with_subauth)
+    end
+  end
+
   describe '#config_version' do
     context 'when version is NOT in the config file' do
       it 'returns default as 1.0' do

--- a/spec/lib/authorities/linked_data/search_config_spec.rb
+++ b/spec/lib/authorities/linked_data/search_config_spec.rb
@@ -407,4 +407,51 @@ RSpec.describe Qa::Authorities::LinkedData::SearchConfig do
       expect(full_config.subauthorities).to eq expected_hash
     end
   end
+
+  describe '#info' do
+    let(:term_details) do
+      {
+        "label" => "oclc_fast term (QA)",
+        "uri" => "urn:qa:term:oclc_fast",
+        "authority" => "oclc_fast",
+        "action" => "term",
+        "language" => ["en"]
+      }
+    end
+
+    let(:search_details) do
+      {
+        "label" => "oclc_fast search (QA)",
+        "uri" => "urn:qa:search:oclc_fast",
+        "authority" => "oclc_fast",
+        "action" => "search",
+        "language" => ["en"]
+      }
+    end
+
+    let(:search_details_with_subauth) do
+      {
+        "label" => "oclc_fast search topic (QA)",
+        "uri" => "urn:qa:search:oclc_fast:topic",
+        "authority" => "oclc_fast",
+        "subauthority" => "topic",
+        "action" => "search",
+        "language" => ["en"]
+      }
+    end
+
+    let(:details) { Qa::Authorities::LinkedData::Config.new(:OCLC_FAST).search.info }
+
+    it "does not return a list with details for term" do
+      expect(details).not_to include_hash(term_details)
+    end
+
+    it "returns a list with details for search without subauthorities" do
+      expect(details).to include_hash(search_details)
+    end
+
+    it "returns a list with details for search with a subauthority" do
+      expect(details).to include_hash(search_details_with_subauth)
+    end
+  end
 end

--- a/spec/lib/authorities/linked_data/term_config_spec.rb
+++ b/spec/lib/authorities/linked_data/term_config_spec.rb
@@ -443,4 +443,51 @@ describe Qa::Authorities::LinkedData::TermConfig do
       expect(full_config.term_subauthorities).to eq expected_hash
     end
   end
+
+  describe '#info' do
+    let(:term_details) do
+      {
+        "label" => "oclc_fast term (QA)",
+        "uri" => "urn:qa:term:oclc_fast",
+        "authority" => "oclc_fast",
+        "action" => "term",
+        "language" => ["en"]
+      }
+    end
+
+    let(:search_details) do
+      {
+        "label" => "oclc_fast search (QA)",
+        "uri" => "urn:qa:search:oclc_fast",
+        "authority" => "oclc_fast",
+        "action" => "search",
+        "language" => ["en"]
+      }
+    end
+
+    let(:search_details_with_subauth) do
+      {
+        "label" => "oclc_fast search topic (QA)",
+        "uri" => "urn:qa:search:oclc_fast:topic",
+        "authority" => "oclc_fast",
+        "subauthority" => "topic",
+        "action" => "search",
+        "language" => ["en"]
+      }
+    end
+
+    let(:details) { Qa::Authorities::LinkedData::Config.new(:OCLC_FAST).term.info }
+
+    it "returns a list with details for term without subauthorities" do
+      expect(details).to include_hash(term_details)
+    end
+
+    it "does not return a list with details for search without subauthorities" do
+      expect(details).not_to include_hash(search_details)
+    end
+
+    it "does not return a list with details for search with a subauthority" do
+      expect(details).not_to include_hash(search_details_with_subauth)
+    end
+  end
 end

--- a/spec/services/linked_data/authority_service_spec.rb
+++ b/spec/services/linked_data/authority_service_spec.rb
@@ -44,4 +44,51 @@ describe Qa::LinkedData::AuthorityService do
       expect(described_class.authority_names).to eq auth_names
     end
   end
+
+  describe '#authority_details' do
+    let(:term_details) do
+      {
+        "label" => "oclc_fast term (QA)",
+        "uri" => "urn:qa:term:oclc_fast",
+        "authority" => "oclc_fast",
+        "action" => "term",
+        "language" => ["en"]
+      }
+    end
+
+    let(:search_details) do
+      {
+        "label" => "oclc_fast search (QA)",
+        "uri" => "urn:qa:search:oclc_fast",
+        "authority" => "oclc_fast",
+        "action" => "search",
+        "language" => ["en"]
+      }
+    end
+
+    let(:search_details_with_subauth) do
+      {
+        "label" => "oclc_fast search topic (QA)",
+        "uri" => "urn:qa:search:oclc_fast:topic",
+        "authority" => "oclc_fast",
+        "subauthority" => "topic",
+        "action" => "search",
+        "language" => ["en"]
+      }
+    end
+
+    let(:details) { described_class.authority_details }
+
+    it "returns a list with details for term without subauthorities" do
+      expect(details).to include_hash(term_details)
+    end
+
+    it "returns a list with details for search without subauthorities" do
+      expect(details).to include_hash(search_details)
+    end
+
+    it "returns a list with details for search with a subauthority" do
+      expect(details).to include_hash(search_details_with_subauth)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,7 @@ require 'pry'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
-Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
   config.fixture_path = File.expand_path("../fixtures", __FILE__)

--- a/spec/support/matchers/include_hash.rb
+++ b/spec/support/matchers/include_hash.rb
@@ -1,0 +1,5 @@
+RSpec::Matchers.define :include_hash do |expected_hash|
+  match do |actual_array|
+    actual_array.any? { |a_hash| a_hash == expected_hash }
+  end
+end


### PR DESCRIPTION
## Simple Listing (what already exists)

http://localhost:3000/qa/list/linked_data/authorities
http://localhost:3000/qa/list/linked_data/authorities?details=false

Produces output like...

```
[ 'oclc_fast', 'loc', ...]
```

## Listing with Details (new)

http://localhost:3000/qa/list/linked_data/authorities?details=true

Produces output like...

**Term with no subauthorities OR fetching term across subauthorities**
```
{
  "label":"oclc_fast term (QA)",
  "uri":"urn:qa:term:oclc_fast",
  "authority":"oclc_fast",
  "action":"term",
  "language":["en"]
},
```

**Search across subauthorities**
```
{
  "label":"oclc_fast search (QA)",
  "uri":"urn:qa:search:oclc_fast",
  "authority":"oclc_fast",
  "action":"search",
  "language":["en"]
},
```

**Search within a subauthority**
```
{
  "label":"oclc_fast search topic (QA)",
  "uri":"urn:qa:search:oclc_fast:topic",
  "authority":"oclc_fast",
  "subauthority":"topic",
  "action":"search",
  "language":["en"]
},
```

NOTES ON LANGUAGE: 
* QA supports requests for results to be returned in multiple languages, so the language is an array.  * The language shown is what is configured in the authority. If not configured in the authority, it is the site default language.  
* The language does NOT specify what the authority defines as supported languages.  That information is not configured in QA authorities.information.
* A user (defined as the caller, which in this case is Sinopia) can request an alternate language by setting accept_language in the request header or by passing in the language in the `lang` parameter of the QA request URL.