### PR TITLE
subject uri, broader, narrower should be string instead of RDF::URI in json results

### DIFF
--- a/config/authorities/linked_data/loc.json
+++ b/config/authorities/linked_data/loc.json
@@ -38,7 +38,7 @@
       "id_ldpath": "loc:lccn",
       "label_ldpath": "skos:prefLabel :: xsd:string",
       "altlabel_ldpath": "skos:altLabel :: xsd:string",
-      "sameas_ldpath": "owl:sameAs :: xsd:anyURI",
+      "sameas_ldpath": "skos:exactMatch | owl:sameAs :: xsd:anyURI",
       "narrower_ldpath": "madsrdf:hasNarrowerAuthority :: xsd:anyURI",
       "broader_ldpath": "madsrdf:hasBroaderAuthority :: xsd:anyURI"
     },

--- a/lib/qa/authorities/linked_data/find_term.rb
+++ b/lib/qa/authorities/linked_data/find_term.rb
@@ -25,7 +25,7 @@ module Qa::Authorities
       # @param [Symbol] (optional) language: language used to select literals when multi-language is supported (e.g. :en, :fr, etc.)
       # @param [Hash] (optional) replacements: replacement values with { pattern_name (defined in YAML config) => value }
       # @param [String] subauth: the subauthority from which to fetch the term
-      # @return [String] json results
+      # @return [Hash] json results
       # @example Json Results for Linked Data Term
       #   { "uri":"http://id.worldcat.org/fast/530369",
       #     "id":"530369","label":"Cornell University",
@@ -133,8 +133,8 @@ module Qa::Authorities
         end
 
         def convert_results_to_json(results)
-          json_hash = { uri: uri }
-          json_hash[:id] = results.key?(:id) && results[:id].present? ? results[:id].first.to_s : uri
+          json_hash = { uri: uri.to_s }
+          json_hash[:id] = results.key?(:id) && results[:id].present? ? results[:id].first.to_s : uri.to_s
           json_hash[:label] = sort_literals(results, :label)
           json_hash.merge!(optional_results_to_json(results))
           predicates_hash = predicates_with_subject_uri(uri)
@@ -152,8 +152,8 @@ module Qa::Authorities
         end
 
         def extract_result(results, key)
-          return nil unless results.key?(key) || results[key].blank?
-          results[key]
+          return nil unless results.key?(key) && results[key].present?
+          results[key].map(&:to_s)
         end
 
         def sort_literals(results, key)

--- a/spec/fixtures/lod_loc_term_found.rdf.xml
+++ b/spec/fixtures/lod_loc_term_found.rdf.xml
@@ -119,6 +119,11 @@
     <identifiers:lccn xmlns:identifiers="http://id.loc.gov/vocabulary/identifiers/">sh 85118553</identifiers:lccn>
     <owl:sameAs rdf:resource="info:lc/authorities/sh85118553" xmlns:owl="http://www.w3.org/2002/07/owl#"/>
     <owl:sameAs rdf:resource="http://id.loc.gov/authorities/sh85118553#concept" xmlns:owl="http://www.w3.org/2002/07/owl#"/>
+    <madsrdf:hasNarrowerAuthority>
+      <madsrdf:Authority rdf:about="http://id.loc.gov/authorities/subjects/sh92004048">
+        <madsrdf:authoritativeLabel xml:lang="en">Environmental sciences</madsrdf:authoritativeLabel>
+      </madsrdf:Authority>
+    </madsrdf:hasNarrowerAuthority>
     <madsrdf:adminMetadata>
       <ri:RecordInfo xmlns:ri="http://id.loc.gov/ontologies/RecordInfo#">
 	<ri:recordChangeDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2000-06-20T00:00:00</ri:recordChangeDate>

--- a/spec/lib/authorities/linked_data/find_term_spec.rb
+++ b/spec/lib/authorities/linked_data/find_term_spec.rb
@@ -66,13 +66,16 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
         end
         it 'has correct primary predicate values' do
           expect(results[:uri]).to eq 'http://id.loc.gov/authorities/subjects/sh85118553'
+          expect(results[:uri]).to be_kind_of String
           expect(results[:id]).to eq 'sh 85118553'
           expect(results[:label]).to eq ['Science']
           expect(results[:altlabel]).to include('Natural science', 'Science of science', 'Sciences')
+          expect(results[:narrower]).to include('http://id.loc.gov/authorities/subjects/sh92004048')
+          expect(results[:narrower].first).to be_kind_of String
         end
 
         it 'has correct number of predicates in pred-obj list' do
-          expect(results['predicates'].count).to eq 14
+          expect(results['predicates'].count).to eq 15
         end
 
         it 'has primary predicates in pred-obj list' do


### PR DESCRIPTION
This was a regression from the output prior to refactoring that showed up in PR #233.

The tests didn't catch the bug because rspec turned the RDF::URI to a string in the related tests.  The tests were updated to specifically test for the subject uri and one of the other uris `to be_kind_of String`.