### PR TITLE
improve deprecation warnings

### DIFF
--- a/lib/qa/authorities/linked_data/config/search_config.rb
+++ b/lib/qa/authorities/linked_data/config/search_config.rb
@@ -60,7 +60,8 @@ module Qa::Authorities
       def results_id_predicate
         Qa.deprecation_warning(
           in_msg: 'Qa::Authorities::LinkedData::SearchConfig',
-          msg: "`results_id_predicate` is deprecated; use `results_id_ldpath` by updating linked data search config results to specify as `id_ldpath`"
+          msg: "`results_id_predicate` is deprecated; use `results_id_ldpath` by updating linked data search config results " \
+               "in authority #{authority_name} to specify as `id_ldpath`"
         )
         Config.predicate_uri(results, :id_predicate)
       end
@@ -73,11 +74,14 @@ module Qa::Authorities
 
       # Return results label_predicate
       # @return [String] the configured predicate to use to extract label values from the results
-      def results_label_predicate
-        Qa.deprecation_warning(
-          in_msg: 'Qa::Authorities::LinkedData::SearchConfig',
-          msg: "`results_label_predicate` is deprecated; use `results_label_ldpath` by updating linked data search config results to specify as `label_ldpath`"
-        )
+      def results_label_predicate(suppress_deprecation_warning: false)
+        unless suppress_deprecation_warning
+          Qa.deprecation_warning(
+            in_msg: 'Qa::Authorities::LinkedData::SearchConfig',
+            msg: "`results_label_predicate` is deprecated; use `results_label_ldpath` by updating linked data search config results " \
+                 "in authority #{authority_name} to specify as `label_ldpath`"
+          )
+        end
         Config.predicate_uri(results, :label_predicate)
       end
 
@@ -92,7 +96,8 @@ module Qa::Authorities
       def results_altlabel_predicate
         Qa.deprecation_warning(
           in_msg: 'Qa::Authorities::LinkedData::SearchConfig',
-          msg: "`results_altlabel_predicate` is deprecated; use `results_altlabel_ldpath` by updating linked data search config results to specify as `altlabel_ldpath`"
+          msg: "`results_altlabel_predicate` is deprecated; use `results_altlabel_ldpath` by updating linked data " \
+               "search config results in authority #{authority_name} to specify as `altlabel_ldpath`"
         )
         Config.predicate_uri(results, :altlabel_predicate)
       end
@@ -115,7 +120,8 @@ module Qa::Authorities
       def results_sort_predicate
         Qa.deprecation_warning(
           in_msg: 'Qa::Authorities::LinkedData::SearchConfig',
-          msg: "`results_sort_predicate` is deprecated; use `results_sort_ldpath` by updating linked data search config results to specify as `sort_ldpath`"
+          msg: "`results_sort_predicate` is deprecated; use `results_sort_ldpath` by updating linked data " \
+               "search config results in authority #{authority_name} to specify as `sort_ldpath`"
         )
         Config.predicate_uri(results, :sort_predicate)
       end

--- a/lib/qa/authorities/linked_data/config/term_config.rb
+++ b/lib/qa/authorities/linked_data/config/term_config.rb
@@ -12,7 +12,7 @@ module Qa::Authorities
 
       # @param [Hash] config the term portion of the config
       # @param [Hash<Symbol><String>] prefixes URL map of prefixes to use with ldpaths
-      # @param [Qa::Authorities::LinkedData::Config] full_config the full linked data configuration that the passed in search config is part of
+      # @param [Qa::Authorities::LinkedData::Config] full_config the full linked data configuration that the passed in term config is part of
       def initialize(config, prefixes = {}, full_config = nil)
         @term_config = config
         @prefixes = prefixes
@@ -87,7 +87,14 @@ module Qa::Authorities
 
       # Return results label_predicate
       # @return [String] the configured predicate to use to extract label values from the results
-      def term_results_label_predicate
+      def term_results_label_predicate(suppress_deprecation_warning: false)
+        unless suppress_deprecation_warning
+          Qa.deprecation_warning(
+            in_msg: 'Qa::Authorities::LinkedData::TermConfig',
+            msg: "`term_results_label_predicate` is deprecated; use `term_results_label_ldpath` by updating linked data " \
+                 "term config results in authority #{authority_name} to specify as `label_ldpath`"
+          )
+        end
         Config.predicate_uri(term_results, :label_predicate)
       end
 
@@ -100,6 +107,11 @@ module Qa::Authorities
       # Return results altlabel_predicate
       # @return [String] the configured predicate to use to extract altlabel values from the results
       def term_results_altlabel_predicate
+        Qa.deprecation_warning(
+          in_msg: 'Qa::Authorities::LinkedData::TermConfig',
+          msg: "`term_results_altlabel_predicate` is deprecated; use `term_results_altlabel_ldpath` by updating linked data " \
+               "term config results in authority #{authority_name} to specify as `altlabel_ldpath`"
+        )
         Config.predicate_uri(term_results, :altlabel_predicate)
       end
 
@@ -112,6 +124,11 @@ module Qa::Authorities
       # Return results broader_predicate
       # @return [String] the configured predicate to use to extract URIs for broader terms from the results
       def term_results_broader_predicate
+        Qa.deprecation_warning(
+          in_msg: 'Qa::Authorities::LinkedData::TermConfig',
+          msg: "`term_results_broader_predicate` is deprecated; use `term_results_broader_ldpath` by updating linked data " \
+               "term config results in authority #{authority_name} to specify as `broader_ldpath`"
+        )
         Config.predicate_uri(term_results, :broader_predicate)
       end
 
@@ -124,6 +141,11 @@ module Qa::Authorities
       # Return results narrower_predicate
       # @return [String] the configured predicate to use to extract URIs for narrower terms from the results
       def term_results_narrower_predicate
+        Qa.deprecation_warning(
+          in_msg: 'Qa::Authorities::LinkedData::TermConfig',
+          msg: "`term_results_narrower_predicate` is deprecated; use `term_results_narrower_ldpath` by updating linked data " \
+               "term config results in authority #{authority_name} to specify as `narrower_ldpath`"
+        )
         Config.predicate_uri(term_results, :narrower_predicate)
       end
 
@@ -136,6 +158,11 @@ module Qa::Authorities
       # Return results sameas_predicate
       # @return [String] the configured predicate to use to extract URIs for sameas terms from the results
       def term_results_sameas_predicate
+        Qa.deprecation_warning(
+          in_msg: 'Qa::Authorities::LinkedData::TermConfig',
+          msg: "`term_results_sameas_predicate` is deprecated; use `term_results_sameas_ldpath` by updating linked data " \
+               "term config results in authority #{authority_name} to specify as `sameas_ldpath`"
+        )
         Config.predicate_uri(term_results, :sameas_predicate)
       end
 

--- a/lib/qa/authorities/linked_data/find_term.rb
+++ b/lib/qa/authorities/linked_data/find_term.rb
@@ -93,13 +93,13 @@ module Qa::Authorities
           predicate_map = preds_for_term
           ldpath_map = ldpaths_for_term
 
-          raise Qa::InvalidConfiguration, "do not specify results using both predicates and ldpath in term configuration for LOD authority #{authority_name} (ldpath is preferred)" if predicate_map.present? && ldpath_map.present? # rubocop:disable Metrics/LineLength
-          raise Qa::InvalidConfiguration, "must specify label_ldpath or label_predicate in term configuration for LOD authority #{authority_name} (label_ldpath is preferred)" unless ldpath_map.key?(:label) || predicate_map.key?(:label) # rubocop:disable Metrics/LineLength
+          raise Qa::InvalidConfiguration, "do not specify results using both predicates and ldpath in term configuration for linked data authority #{authority_name} (ldpath is preferred)" if predicate_map.present? && ldpath_map.present? # rubocop:disable Metrics/LineLength
+          raise Qa::InvalidConfiguration, "must specify label_ldpath or label_predicate in term configuration for linked data authority #{authority_name} (label_ldpath is preferred)" unless ldpath_map.key?(:label) || predicate_map.key?(:label) # rubocop:disable Metrics/LineLength
 
           if predicate_map.present?
             Qa.deprecation_warning(
               in_msg: 'Qa::Authorities::LinkedData::FindTerm',
-              msg: 'defining results using predicates in term config is deprecated; update to define using ldpaths'
+              msg: "defining results using predicates in term config is deprecated; update to define using ldpaths (authority: #{authority_name})"
             )
           end
 
@@ -148,7 +148,7 @@ module Qa::Authorities
         end
 
         def preds_for_term
-          label_pred_uri = term_config.term_results_label_predicate
+          label_pred_uri = term_config.term_results_label_predicate(suppress_deprecation_warning: true)
           return {} if label_pred_uri.blank?
           preds = { label: label_pred_uri }
           preds.merge(optional_preds)

--- a/lib/qa/authorities/linked_data/search_query.rb
+++ b/lib/qa/authorities/linked_data/search_query.rb
@@ -73,13 +73,13 @@ module Qa::Authorities
           predicate_map = preds_for_search
           ldpath_map = ldpaths_for_search
 
-          raise Qa::InvalidConfiguration, "do not specify results using both predicates and ldpath in search configuration for LOD authority #{authority_name} (ldpath is preferred)" if predicate_map.present? && ldpath_map.present? # rubocop:disable Metrics/LineLength
-          raise Qa::InvalidConfiguration, "must specify label_ldpath or label_predicate in search configuration for LOD authority #{authority_name} (label_ldpath is preferred)" unless ldpath_map.key?(:label) || predicate_map.key?(:label) # rubocop:disable Metrics/LineLength
+          raise Qa::InvalidConfiguration, "do not specify results using both predicates and ldpath in search configuration for linked data authority #{authority_name} (ldpath is preferred)" if predicate_map.present? && ldpath_map.present? # rubocop:disable Metrics/LineLength
+          raise Qa::InvalidConfiguration, "must specify label_ldpath or label_predicate in search configuration for linked data authority #{authority_name} (label_ldpath is preferred)" unless ldpath_map.key?(:label) || predicate_map.key?(:label) # rubocop:disable Metrics/LineLength
 
           if predicate_map.present?
             Qa.deprecation_warning(
               in_msg: 'Qa::Authorities::LinkedData::SearchQuery',
-              msg: 'defining results using predicates in search config is deprecated; update to define using ldpaths'
+              msg: "defining results using predicates in search config is deprecated; update to define using ldpaths (authority: #{authority_name})"
             )
           end
 
@@ -119,7 +119,7 @@ module Qa::Authorities
         end
 
         def preds_for_search
-          label_pred_uri = search_config.results_label_predicate
+          label_pred_uri = search_config.results_label_predicate(suppress_deprecation_warning: true)
           return {} if label_pred_uri.blank?
           preds = { label: label_pred_uri, uri: :subject_uri }
           preds[:altlabel] = search_config.results_altlabel_predicate unless search_config.results_altlabel_predicate.nil?


### PR DESCRIPTION
* term_config depercation warnings for `_predicate` methods were added
* results_label_predicates have parameter to optionally suppress the deprecation warning
* add in `authority_name` so it is clear which authority is using the deprecated feature