### PR TITLE
add bytes and bytes/s to performance data

### DIFF
--- a/lib/qa/authorities/linked_data/find_term.rb
+++ b/lib/qa/authorities/linked_data/find_term.rb
@@ -15,8 +15,8 @@ module Qa::Authorities
         @term_config = term_config
       end
 
-      attr_reader :term_config, :full_graph, :filtered_graph, :language, :id, :uri, :access_time_s, :normalize_time_s
-      private :full_graph, :filtered_graph, :language, :id, :uri, :access_time_s, :normalize_time_s
+      attr_reader :term_config, :full_graph, :filtered_graph, :language, :id, :uri, :access_time_s, :normalize_time_s, :fetched_size, :normalized_size
+      private :full_graph, :filtered_graph, :language, :id, :uri, :access_time_s, :normalize_time_s, :fetched_size, :normalized_size
 
       delegate :term_subauthority?, :prefixes, :authority_name, to: :term_config
 
@@ -60,6 +60,7 @@ module Qa::Authorities
 
           access_end_dt = Time.now.utc
           @access_time_s = access_end_dt - access_start_dt
+          @fetched_size = full_graph.triples.to_s.size if performance_data?
           Rails.logger.info("Time to receive data from authority: #{access_time_s}s")
         end
 
@@ -70,8 +71,9 @@ module Qa::Authorities
           json = perform_normalization
 
           @normalize_time_s = normalize_end_dt - normalize_start_dt
+          @normalized_size = json.to_s.size if performance_data?
           Rails.logger.info("Time to convert data to json: #{normalize_time_s}s")
-          json = append_performance_data(json) if performance_data? && !jsonld?
+          json = append_performance_data(json) if performance_data?
           json
         end
 
@@ -178,7 +180,7 @@ module Qa::Authorities
         end
 
         def performance_data?
-          @performance_data == true
+          @performance_data == true && !jsonld?
         end
 
         def preds_for_term
@@ -254,6 +256,10 @@ module Qa::Authorities
           performance = { predicate_count: pred_count,
                           fetch_time_s: access_time_s,
                           normalization_time_s: normalize_time_s,
+                          fetched_bytes: fetched_size,
+                          normalized_bytes: normalized_size,
+                          fetch_bytes_per_s: fetched_size / access_time_s,
+                          normalization_bytes_per_s: normalized_size / normalize_time_s,
                           total_time_s: (access_time_s + normalize_time_s) }
           { performance: performance, results: results }
         end

--- a/spec/controllers/linked_data_terms_controller_spec.rb
+++ b/spec/controllers/linked_data_terms_controller_spec.rb
@@ -307,7 +307,9 @@ describe Qa::LinkedDataTermsController, type: :controller do
         results = JSON.parse(response.body)
         expect(results).to be_kind_of Hash
         expect(results.keys).to match_array ['performance', 'results']
-        expect(results['performance'].keys).to match_array ['result_count', 'fetch_time_s', 'normalization_time_s', 'total_time_s']
+        expect(results['performance'].keys).to match_array ['result_count', 'fetch_time_s', 'normalization_time_s',
+                                                            'fetched_bytes', 'normalized_bytes', 'fetch_bytes_per_s',
+                                                            'normalization_bytes_per_s', 'total_time_s']
         expect(results['performance']['total_time_s']).to eq results['performance']['fetch_time_s'] + results['performance']['normalization_time_s']
         expect(results['performance']['result_count']).to eq 3
         expect(results['results'].count).to eq 3
@@ -475,7 +477,9 @@ describe Qa::LinkedDataTermsController, type: :controller do
         results = JSON.parse(response.body)
         expect(results).to be_kind_of Hash
         expect(results.keys).to match_array ['performance', 'results']
-        expect(results['performance'].keys).to match_array ['predicate_count', 'fetch_time_s', 'normalization_time_s', 'total_time_s']
+        expect(results['performance'].keys).to match_array ['predicate_count', 'fetch_time_s', 'normalization_time_s',
+                                                            'fetched_bytes', 'normalized_bytes', 'fetch_bytes_per_s',
+                                                            'normalization_bytes_per_s', 'total_time_s']
         expect(results['performance']['total_time_s']).to eq results['performance']['fetch_time_s'] + results['performance']['normalization_time_s']
         expect(results['performance']['predicate_count']).to eq 15
         expect(results['results']['predicates'].count).to eq 15
@@ -631,7 +635,9 @@ describe Qa::LinkedDataTermsController, type: :controller do
         results = JSON.parse(response.body)
         expect(results).to be_kind_of Hash
         expect(results.keys).to match_array ['performance', 'results']
-        expect(results['performance'].keys).to match_array ['predicate_count', 'fetch_time_s', 'normalization_time_s', 'total_time_s']
+        expect(results['performance'].keys).to match_array ['predicate_count', 'fetch_time_s', 'normalization_time_s',
+                                                            'fetched_bytes', 'normalized_bytes', 'fetch_bytes_per_s',
+                                                            'normalization_bytes_per_s', 'total_time_s']
         expect(results['performance']['total_time_s']).to eq results['performance']['fetch_time_s'] + results['performance']['normalization_time_s']
         expect(results['performance']['predicate_count']).to eq 7
         expect(results['results']['predicates'].count).to eq 7

--- a/spec/lib/authorities/linked_data/find_term_spec.rb
+++ b/spec/lib/authorities/linked_data/find_term_spec.rb
@@ -28,7 +28,9 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
         end
         it 'includes performance in return hash' do
           expect(results.keys).to match_array [:performance, :results]
-          expect(results[:performance].keys).to match_array [:predicate_count, :fetch_time_s, :normalization_time_s, :total_time_s]
+          expect(results[:performance].keys).to match_array [:predicate_count, :fetch_time_s, :normalization_time_s,
+                                                             :fetched_bytes, :normalized_bytes, :fetch_bytes_per_s,
+                                                             :normalization_bytes_per_s, :total_time_s]
           expect(results[:performance][:predicate_count]).to eq 7
           expect(results[:performance][:total_time_s]).to eq results[:performance][:fetch_time_s] + results[:performance][:normalization_time_s]
         end

--- a/spec/lib/authorities/linked_data/search_query_spec.rb
+++ b/spec/lib/authorities/linked_data/search_query_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe Qa::Authorities::LinkedData::SearchQuery do
         it 'includes performance in return hash' do
           expect(results).to be_kind_of Hash
           expect(results.keys).to match_array [:performance, :results]
-          expect(results[:performance].keys).to match_array [:result_count, :fetch_time_s, :normalization_time_s, :total_time_s]
+          expect(results[:performance].keys).to match_array [:result_count, :fetch_time_s, :normalization_time_s,
+                                                             :fetched_bytes, :normalized_bytes, :fetch_bytes_per_s,
+                                                             :normalization_bytes_per_s, :total_time_s]
           expect(results[:performance][:total_time_s]).to eq results[:performance][:fetch_time_s] + results[:performance][:normalization_time_s]
           expect(results[:performance][:result_count]).to eq 3
           expect(results[:results].count).to eq 3


### PR DESCRIPTION
New fetch performance data...
```
"performance":{
  "predicate_count":19,
  "fetch_time_s":1.563339,
  "normalization_time_s":8.0e-06,
  "fetched_bytes":241308,
  "normalized_bytes":19920,
  "fetch_bytes_per_s":154354.23794839124,
  "normalization_bytes_per_s":2490000000.0,
  "total_time_s":1.563347}
```

New search performance data...
```
"performance":{
  "result_count":20,
  "fetch_time_s":1.0732,
  "normalization_time_s":1.75178,
  "fetched_bytes":107856,
  "normalized_bytes":2159,
  "fetch_bytes_per_s":100499.44092433843,
  "normalization_bytes_per_s":1232.4606971195014,
  "total_time_s":2.82498}
```