### PR TITLE
Fix the test that broke during merge of multiple PRs

### DIFF
--- a/spec/lib/authorities/linked_data/find_term_spec.rb
+++ b/spec/lib/authorities/linked_data/find_term_spec.rb
@@ -218,9 +218,13 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
         end
 
         context 'when alternate authority name is used to access loc' do
-          let(:results) { lod_loc.find('sh 85118553', subauth: 'subjects') }
+          before do
+            stub_request(:get, 'http://id.loc.gov/authorities/subjects/sh85118553')
+              .to_return(status: 200, body: webmock_fixture('lod_loc_term_found.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
+            allow(lod_loc.term_config).to receive(:authority_name).and_return('ALT_LOC_AUTHORITY')
+          end
 
-          before { allow(lod_loc.term_config).to receive(:authority_name).and_return('ALT_LOC_AUTHORITY') }
+          let(:results) { lod_loc.find('sh 85118553', subauth: 'subjects') }
 
           it 'does special processing to remove blank from id' do
             expect(results[:uri]).to eq 'http://id.loc.gov/authorities/subjects/sh85118553'


### PR DESCRIPTION
There was a refactor of the stubbing in find_term_spec.rb in PR #249 that was not done PR #248.  When both merged, this broke one of the tests in the second PR.

This fixes that broken test by applying the same refactor to that test.