### PR TITLE
allow id to be identified by multiple paths using ldpath

### DIFF
--- a/app/services/qa/linked_data/ldpath_service.rb
+++ b/app/services/qa/linked_data/ldpath_service.rb
@@ -6,6 +6,9 @@ module Qa
     class LdpathService
       VALUE_ON_ERROR = [].freeze
 
+      class_attribute :predefined_prefixes
+      self.predefined_prefixes = Ldpath::Transform.default_prefixes.with_indifferent_access
+
       # Create the ldpath program for a given ldpath.
       # @param ldpath [String] ldpath to follow to get a value from a graph (documation: http://marmotta.apache.org/ldpath/language.html)
       # @param prefixes [Hash] shortcut names for URI prefixes with key = part of predicate that is the same for all terms (e.g. { "madsrdf": "http://www.loc.gov/mads/rdf/v1#" })

--- a/config/authorities/linked_data/loc.json
+++ b/config/authorities/linked_data/loc.json
@@ -41,12 +41,13 @@
       "broader_ldpath":  "madsrdf:hasBroaderAuthority :: xsd:anyURI"
     },
     "subauthorities": {
-      "subjects":       "subjects",
-      "names":          "names",
-      "classification": "classification",
-      "child_subject":  "childrensSubjects",
-      "genre":          "genreForms",
-      "demographic":    "demographicTerms"
+      "subjects":          "subjects",
+      "names":             "names",
+      "classification":    "classification",
+      "child_subject":     "childrensSubjects",
+      "genre":             "genreForms",
+      "demographic":       "demographicTerms",
+      "music_performance": "performanceMediums"
     }
   },
   "search": {}

--- a/config/authorities/linked_data/loc.json
+++ b/config/authorities/linked_data/loc.json
@@ -1,30 +1,28 @@
 {
   "QA_CONFIG_VERSION": "2.1",
   "prefixes": {
-    "loc": "http://id.loc.gov/vocabulary/identifiers/",
-    "skos": "http://www.w3.org/2004/02/skos/core#",
-    "madsrdf": "http://www.loc.gov/mads/rdf/v1#",
-    "owl": "http://www.w3.org/2002/07/owl#"
+    "loc":     "http://id.loc.gov/vocabulary/identifiers/",
+    "madsrdf": "http://www.loc.gov/mads/rdf/v1#"
   },
   "term": {
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
-      "@type": "IriTemplate",
+      "@type":    "IriTemplate",
       "template": "http://id.loc.gov/authorities/{subauth}/{term_id}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
-          "@type": "IriTemplateMapping",
+          "@type":    "IriTemplateMapping",
           "variable": "term_id",
           "property": "hydra:freetextQuery",
           "required": true
         },
         {
-          "@type": "IriTemplateMapping",
+          "@type":    "IriTemplateMapping",
           "variable": "subauth",
           "property": "hydra:freetextQuery",
           "required": false,
-          "default": "names"
+          "default":  "names"
         }
       ]
     },
@@ -35,20 +33,20 @@
     "term_id": "ID",
     "language": ["en"],
     "results": {
-      "id_ldpath": "loc:lccn",
-      "label_ldpath": "skos:prefLabel :: xsd:string",
+      "id_ldpath":       "loc:lccn | madsrdf:code",
+      "label_ldpath":    "skos:prefLabel :: xsd:string",
       "altlabel_ldpath": "skos:altLabel :: xsd:string",
-      "sameas_ldpath": "skos:exactMatch | owl:sameAs :: xsd:anyURI",
+      "sameas_ldpath":   "skos:exactMatch | owl:sameAs :: xsd:anyURI",
       "narrower_ldpath": "madsrdf:hasNarrowerAuthority :: xsd:anyURI",
-      "broader_ldpath": "madsrdf:hasBroaderAuthority :: xsd:anyURI"
+      "broader_ldpath":  "madsrdf:hasBroaderAuthority :: xsd:anyURI"
     },
     "subauthorities": {
-      "subjects": "subjects",
-      "names": "names",
+      "subjects":       "subjects",
+      "names":          "names",
       "classification": "classification",
-      "child_subject": "childrensSubjects",
-      "genre": "genreForms",
-      "demographic": "demographicTerms"
+      "child_subject":  "childrensSubjects",
+      "genre":          "genreForms",
+      "demographic":    "demographicTerms"
     }
   },
   "search": {}

--- a/lib/qa/authorities/linked_data/config/term_config.rb
+++ b/lib/qa/authorities/linked_data/config/term_config.rb
@@ -70,13 +70,31 @@ module Qa::Authorities
         Config.config_value(term_results, :id_ldpath)
       end
 
+      # Return results id_predicates
+      # @return [Array<String>] the configured predicate to use to extract the id from the results
+      def term_results_id_predicates
+        return @pred_ids unless @pred_ids.blank?
+        pred = Config.predicate_uri(term_results, :id_predicate)
+        @pred_ids = [pred] unless pred.blank?
+        return @pred_ids unless @pred_ids.blank?
+        @pred_ids = id_predicates_from_ldpath
+      end
+
       # Return results id_predicate
       # @return [String] the configured predicate to use to extract the id from the results
-      def term_results_id_predicate
-        return @pred_id unless @pred_id.blank?
-        @pred_id = Config.predicate_uri(term_results, :id_predicate)
-        return @pred_id unless @pred_id.blank?
-        @pred_id = pred_id_from_ldpath
+      # NOTE: Customizations using this method should be updated to use `term_results_id_predicates` which returns [Array<String>] of
+      #       id predicates.  This method remains for backward compatibility only but may cause issues if used in places expecting an Array
+      def term_results_id_predicate(suppress_deprecation_warning: false)
+        unless suppress_deprecation_warning
+          Qa.deprecation_warning(
+            in_msg: 'Qa::Authorities::LinkedData::TermConfig',
+            msg: "`term_results_id_predicate` is deprecated; use `term_results_id_ldpath` by updating linked data " \
+                 "term config results in authority #{authority_name} to specify as `id_ldpath`"
+          )
+        end
+        id_predicates = term_results_id_predicates
+        return nil if id_predicates.blank?
+        id_predicates.first
       end
 
       # Return results label_ldpath
@@ -222,16 +240,28 @@ module Qa::Authorities
 
       private
 
-        def pred_id_from_ldpath
+        def id_predicates_from_ldpath
           # prefix example: { skos: 'http://www.w3.org/2004/02/skos/core#' }
           # ldpath example: 'skos:id :: xsd:string'
+          predicates = []
           id_ldpath = term_results_id_ldpath
-          return nil if id_ldpath.blank?
-          tokens = id_ldpath.split(':')
+          return predicates if id_ldpath.blank?
+          multi_paths = id_ldpath.split('|').map(&:strip)
+          multi_paths.each do |path|
+            predicate = parse_predicate_from_single_path(path)
+            predicates << RDF::URI.new(predicate) if predicate.present?
+          end
+          predicates
+        end
+
+        def parse_predicate_from_single_path(path)
+          tokens = path.split(':')
           return nil if tokens.size < 2
           prefix = tokens.first.to_sym
           prefix_path = prefixes[prefix]
-          prefix_path + tokens.second.strip
+          prefix_path = Qa::LinkedData::LdpathService.predefined_prefixes[prefix] if prefix_path.blank?
+          raise Qa::InvalidConfiguration, "Prefix '#{prefix}' is not defined in term configuration for authority #{authority_name}" if prefix_path.blank?
+          "#{prefix_path}#{tokens.second.strip}"
         end
 
         def summary_without_subauthority(auth_name, language)

--- a/lib/qa/authorities/linked_data/find_term.rb
+++ b/lib/qa/authorities/linked_data/find_term.rb
@@ -110,13 +110,15 @@ module Qa::Authorities
                                             ldpath_map: ldpaths_for_term, predicate_map: preds_for_term)
         end
 
-        # special processing for loc ids for backward compatibility
+        # Special processing for loc ids for backward compatibility.  IDs may be in the form 'n123' or 'n 123'.  URIs do not
+        # have a blank.  This removes the <blank> from the ID.
         def normalize_id
           return id if expects_uri?
           loc? ? id.delete(' ') : id
         end
 
-        # special processing for loc ids for backward compatibility
+        # Special processing for loc ids for backward compatibility.  IDs may be in the form 'n123' or 'n 123'.  This adds
+        # the <blank> into the ID to allow it to be found as the object of a triple in the graph.
         def loc_id
           loc_id = URI.unescape(id)
           digit_idx = loc_id.index(/\d/)
@@ -148,6 +150,10 @@ module Qa::Authorities
                                                          predicate: id_predicate,
                                                          object_value: URI.unescape(id)).first
           return if @uri.present? || !loc?
+
+          # NOTE: Second call to try and extract using the loc_id allows for special processing on the id for LOC authorities.
+          #       LOC URIs do not include a blank (e.g. ends with 'n123'), but the ID in the data might (e.g. 'n 123').  If
+          #       the ID is provided without the <blank>, this tries a second time to find it with the <blank>.
           @uri = graph_service.subjects_for_object_value(graph: @filtered_graph,
                                                          predicate: id_predicate,
                                                          object_value: URI.unescape(loc_id)).first

--- a/spec/services/linked_data/ldpath_service_spec.rb
+++ b/spec/services/linked_data/ldpath_service_spec.rb
@@ -58,4 +58,13 @@ RSpec.describe Qa::LinkedData::LdpathService do
       end
     end
   end
+
+  describe '.predefined_prefixes' do
+    subject { described_class.predefined_prefixes }
+    it 'includes prefixes defined by ldpath' do
+      # only checking for a few prefixes as opposed to the entire list since the gem may expand the list
+      expect(subject.keys).to include("rdf", "rdfs", "owl", "skos", "dc")
+      expect(subject[:rdf]).to be_present
+    end
+  end
 end


### PR DESCRIPTION
Closes #244

This supports the id being defined with multiple paths...

```
      "id_ldpath":       "loc:lccn | madsrdf:code",
```

such that the id value can come from either path. 