### PR TITLE
allow property_map.optional? default value to be configurable

### DIFF
--- a/app/models/qa/linked_data/config/context_property_map.rb
+++ b/app/models/qa/linked_data/config/context_property_map.rb
@@ -37,7 +37,7 @@ module Qa
           @ldpath = Qa::LinkedData::Config::Helper.fetch_required(property_map, :ldpath, false)
           @selectable = Qa::LinkedData::Config::Helper.fetch_boolean(property_map, :selectable, false)
           @drillable = Qa::LinkedData::Config::Helper.fetch_boolean(property_map, :drillable, false)
-          @optional = Qa::LinkedData::Config::Helper.fetch_boolean(property_map, :optional, false)
+          @optional = Qa::LinkedData::Config::Helper.fetch_boolean(property_map, :optional, Qa.config.property_map_default_for_optional)
           @expansion_label_ldpath = Qa::LinkedData::Config::Helper.fetch(property_map, :expansion_label_ldpath, nil)
           @expansion_id_ldpath = Qa::LinkedData::Config::Helper.fetch(property_map, :expansion_id_ldpath, nil)
           @prefixes = prefixes

--- a/lib/generators/qa/install/templates/config/initializers/qa.rb
+++ b/lib/generators/qa/install/templates/config/initializers/qa.rb
@@ -18,4 +18,9 @@ Qa.config do |config|
   # When true, prevents ldpath requests from making additional network calls.  All values will come from the context graph
   # passed to the ldpath request.
   # config.limit_ldpath_to_context = true
+
+  # Define default behavior for property_map.optional? when it is not defined in the configuration for a property.
+  # When false, properties that do not override default optional behavior will be shown whether or not the property has a value in the graph.
+  # When true, properties that do not override default optional behavior will not be shown whn the property does not have a value in the graph.
+  # config.property_map_default_for_optional = false
 end

--- a/lib/qa/configuration.rb
+++ b/lib/qa/configuration.rb
@@ -42,8 +42,17 @@ module Qa
     # passed to the ldpath request.
     attr_writer :limit_ldpath_to_context
     def limit_ldpath_to_context?
-      return true if @limit_ldpath_to_context.nil?
+      @limit_ldpath_to_context = true if @limit_ldpath_to_context.nil?
       @limit_ldpath_to_context
+    end
+
+    # Define default behavior for property_map.optional? when it is not defined in the configuration for a property.
+    # When false, properties that do not override default optional behavior will be shown whether or not the property has a value in the graph.
+    # When true, properties that do not override default optional behavior will not be shown whn the property does not have a value in the graph.
+    attr_writer :property_map_default_for_optional
+    def property_map_default_for_optional
+      @property_map_default_for_optional = false if @property_map_default_for_optional.nil?
+      @property_map_default_for_optional
     end
   end
 end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -76,13 +76,51 @@ RSpec.describe Qa::Configuration do
       end
     end
 
-    context 'when configured' do
+    context 'when configured as true' do
+      before do
+        subject.limit_ldpath_to_context = true
+      end
+
+      it 'returns true' do
+        expect(subject.limit_ldpath_to_context?).to be true
+      end
+    end
+
+    context 'when configured as false' do
       before do
         subject.limit_ldpath_to_context = false
       end
 
-      it 'returns the configured value' do
+      it 'returns false' do
         expect(subject.limit_ldpath_to_context?).to be false
+      end
+    end
+  end
+
+  describe '#property_map_default_for_optional' do
+    context 'when NOT configured' do
+      it 'returns false' do
+        expect(subject.property_map_default_for_optional).to be false
+      end
+    end
+
+    context 'when configured as true' do
+      before do
+        subject.property_map_default_for_optional = true
+      end
+
+      it 'returns the true' do
+        expect(subject.property_map_default_for_optional).to be true
+      end
+    end
+
+    context 'when configured as false' do
+      before do
+        subject.property_map_default_for_optional = false
+      end
+
+      it 'returns false' do
+        expect(subject.property_map_default_for_optional).to be false
       end
     end
   end

--- a/spec/models/linked_data/config/context_property_map_spec.rb
+++ b/spec/models/linked_data/config/context_property_map_spec.rb
@@ -109,6 +109,43 @@ RSpec.describe Qa::LinkedData::Config::ContextPropertyMap do
     end
   end
 
+  describe '#optional?' do
+    context 'when map has optional: true' do
+      before { property_map[:optional] = true }
+
+      it 'returns true' do
+        expect(subject.optional?).to be true
+      end
+    end
+
+    context 'when map has optional: false' do
+      before { property_map[:optional] = false }
+
+      it 'returns false' do
+        expect(subject.optional?).to be false
+      end
+    end
+
+    context 'when optional: is not defined in the map' do
+      before { property_map.delete(:optional) }
+
+      context 'and property_map_default_for_optional is true' do
+        before { allow(Qa.config).to receive(:property_map_default_for_optional).and_return(true) }
+        it 'returns true' do
+          Qa.config.property_map_default_for_optional = true
+          expect(subject.optional?).to be true
+        end
+      end
+
+      context 'and property_map_default_for_optional is false' do
+        before { allow(Qa.config).to receive(:property_map_default_for_optional).and_return(false) }
+        it 'returns false' do
+          expect(subject.optional?).to be false
+        end
+      end
+    end
+  end
+
   describe '#label' do
     context 'when map defines property_label_i18n key' do
       context 'and i18n translation is defined in locales' do


### PR DESCRIPTION
Closes 255

Adds `:property_map_default_for_optional` to `Qa.config` with a default value of `false` for backward compatibility.
