### PR TITLE
add ability to return a single term as n3 format for linked data

### DIFF
--- a/lib/qa/authorities/discogs/discogs_translation.rb
+++ b/lib/qa/authorities/discogs/discogs_translation.rb
@@ -11,14 +11,14 @@ module Qa::Authorities
       # to the URIs of corresponding objects in the Library of Congress vocabulary.
       # @param [Hash] the http response from discogs
       # @param [String] the subauthority
-      # @return [Array] jsonld
-      def build_graph(response, subauthority = "")
+      # @return [Array, String] requested RDF serialzation (supports: jsonld Array, n3 String)
+      def build_graph(response, subauthority = "", format: :jsonld)
         graph = RDF::Graph.new
 
         rdf_statements = compile_rdf_statements(response, subauthority)
         graph.insert_statements(rdf_statements)
 
-        graph.dump(:jsonld, standard_prefixes: true)
+        graph.dump(format, standard_prefixes: true)
       end
 
       # @param [Hash] the http response from discogs

--- a/spec/controllers/linked_data_terms_controller_spec.rb
+++ b/spec/controllers/linked_data_terms_controller_spec.rb
@@ -425,6 +425,15 @@ describe Qa::LinkedDataTermsController, type: :controller do
             expect(JSON.parse(response.body).keys).to match_array ["@context", "@graph"]
           end
         end
+
+        context 'and it was requested as n3' do
+          it 'succeeds and returns term data as n3 content type' do
+            get :show, params: { id: '530369', vocab: 'OCLC_FAST', format: 'n3' }
+            expect(response).to be_successful
+            expect(response.content_type).to eq 'text/n3'
+            expect(response.body).to start_with "@prefix"
+          end
+        end
       end
 
       context 'when cors headers are enabled' do
@@ -584,6 +593,15 @@ describe Qa::LinkedDataTermsController, type: :controller do
             expect(response).to be_successful
             expect(response.content_type).to eq 'application/ld+json'
             expect(JSON.parse(response.body).keys).to match_array ["@context", "@graph"]
+          end
+        end
+
+        context 'and it was requested as n3' do
+          it 'succeeds and returns term data as n3 content type' do
+            get :fetch, params: { uri: 'http://id.worldcat.org/fast/530369', vocab: 'LOD_TERM_URI_PARAM_CONFIG', format: 'n3' }
+            expect(response).to be_successful
+            expect(response.content_type).to eq 'text/n3'
+            expect(response.body).to start_with "@prefix"
           end
         end
 

--- a/spec/lib/authorities/discogs/generic_authority_spec.rb
+++ b/spec/lib/authorities/discogs/generic_authority_spec.rb
@@ -136,6 +136,28 @@ describe Qa::Authorities::Discogs::GenericAuthority do
         end
       end
 
+      context "n3 format and subauthority master" do
+        let(:tc) { instance_double(Qa::TermsController) }
+        let :results do
+          authority.find("950011", tc)
+        end
+        before do
+          allow(Qa::TermsController).to receive(:new).and_return(tc)
+          allow(tc).to receive(:params).and_return('format' => "n3", 'subauthority' => "master")
+        end
+
+        it "returns the Discogs data converted to n3 for a given id" do
+          expect(results).to start_with "@prefix"
+          expect(results).to include("Blue Moon / You Go To My Head")
+          expect(results).to include("Billie Holiday And Her Orchestra")
+          expect(results).to include("Haven Gillespie")
+          expect(results).to include("1952")
+          expect(results).to include("Jazz")
+          expect(results).to include("Barney Kessel")
+          expect(results).to include("Guitar")
+        end
+      end
+
       context "json-ld format and subauthority all" do
         let(:tc) { instance_double(Qa::TermsController) }
         let :results do
@@ -149,6 +171,31 @@ describe Qa::Authorities::Discogs::GenericAuthority do
         it "returns the Discogs data converted to json-ld for a given id" do
           expect(JSON.parse(results).keys).to match_array ["@context", "@graph"]
           expect(JSON.parse(results)["@context"]["bf2"]).to eq("http://id.loc.gov/ontologies/bibframe/")
+          expect(results).to include("You Go To My Head")
+          expect(results).to include("Rodgers & Hart")
+          expect(results).to include("Ray Brown")
+          expect(results).to include("1952")
+          expect(results).to include("Single")
+          expect(results).to include("mono")
+          expect(results).to include("45 RPM")
+          expect(results).to include("Vinyl")
+          expect(results).to include("http://id.loc.gov/vocabulary/carriers/sd")
+          expect(results).to include("1952")
+        end
+      end
+
+      context "n3 format and subauthority all" do
+        let(:tc) { instance_double(Qa::TermsController) }
+        let :results do
+          authority.find("7143179", tc)
+        end
+        before do
+          allow(Qa::TermsController).to receive(:new).and_return(tc)
+          allow(tc).to receive(:params).and_return('format' => "n3", 'subauthority' => "all")
+        end
+
+        it "returns the Discogs data converted to n3 for a given id" do
+          expect(results).to start_with "@prefix"
           expect(results).to include("You Go To My Head")
           expect(results).to include("Rodgers & Hart")
           expect(results).to include("Ray Brown")


### PR DESCRIPTION
This impacts all authorities supported through the linked data module (i.e., lib/qa/authorities/linked_data/find_term) and the discogs authority (i.e. lib/qa/authorities/discogs).