### PR TITLE
allow error from RDF::Graph to be parsed with or without paren around code

### DIFF
--- a/app/services/qa/linked_data/graph_service.rb
+++ b/app/services/qa/linked_data/graph_service.rb
@@ -106,12 +106,10 @@ module Qa
             end
           end
 
+          # process ioerror_code from RDF::Graph.load whether the code is in parentheses (i.e. "... (404)"), or not (i.e. "... 404")
           def ioerror_code(e)
             msg = e.message
-            return 'format' if msg.start_with? "Unknown RDF format"
-            a = msg.size - 4
-            z = msg.size - 2
-            msg[a..z]
+            msg[/(\(?)(\d\d\d)(\)?)$/, 2]
           end
       end
     end

--- a/spec/services/linked_data/graph_service_spec.rb
+++ b/spec/services/linked_data/graph_service_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe Qa::LinkedData::GraphService do
       subject { described_class.load_graph(url: url) }
 
       let(:url) { 'http://experimental.worldcat.org/fast/search?maximumRecords=3&query=cql.any%20all%20%22cornell%22&sortKeys=usage' }
+      let(:regurl) { 'http:\/\/experimental.worldcat.org\/fast\/search\?maximumRecords=3&query=cql.any%20all%20%22cornell%22&sortKeys=usage' }
       let(:uri) { URI(url) }
 
       before do
@@ -74,7 +75,7 @@ RSpec.describe Qa::LinkedData::GraphService do
       end
 
       it 'raises error' do
-        expect { subject }.to raise_error(Qa::ServiceError, "Unknown error for #{uri.hostname} on port #{uri.port}.  Try again later. (Cause - <#{url}>: (504))")
+        expect { subject }.to raise_error(Qa::ServiceError, /Unknown error for #{uri.hostname} on port #{uri.port}.  Try again later. \(Cause - <#{regurl}>: \(?504\)?\)/)
       end
     end
   end


### PR DESCRIPTION
### Problem

Multiple webmock tests, but not all, were randomly failing on CCI only.  These were first seen when PR #259 was merged into master, but were not caused by the PR.  They appeared to be related to dependency changes or infrastructure change at CCI.  

After extensive investigation (many thanks to @botimer and @jrgriffiniii), it was determined that the addition of rest-client gem caused an error to surface.  The error occurs because when rest-client gem is present, RDF::Graph.load method returns its error messages in a different form.  Sometimes the error message includes parentheses around the error code (i.e., "... (503)") and sometimes not (i.e., "... 503").  QA parses the error code from the error message to pass back a more meaningful error to the caller.  

### Solution

QA was doing a positional parse expecting the message to be consistent.  It was updated to use regex which is less fragile.

### A Better Solution

Ultimately, the fix would be for RDF::Graph.load to...
1) minimally return the error message in the same format every time
2) improve exceptions by throwing specific exceptions based on the error code that can be captured in the calling application