### PR TITLE
prep for release 4.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 4.2.4 (2019-10-17)
+
+* use real discogs uri whenever available and discogs url when not
+
 ### 4.2.3 (2019-10-10)
 
 * bug fix for performance stat reported for fetch normalization

--- a/lib/qa/version.rb
+++ b/lib/qa/version.rb
@@ -1,3 +1,3 @@
 module Qa
-  VERSION = "4.2.3".freeze
+  VERSION = "4.2.4".freeze
 end


### PR DESCRIPTION
Includes update to discogs authority to set URI in search results to…
* real discogs URI whenever available
* discogs URL when not

Fetch data will use the same URI/URL as the subject_uri for triples when linked data is requested.