### PR TITLE
refactor optional attributes for linked data search/fetch to pass as hash

### DIFF
--- a/app/services/qa/linked_data/authority_url_service.rb
+++ b/app/services/qa/linked_data/authority_url_service.rb
@@ -8,9 +8,9 @@ module Qa
         # @param action [Symbol] action with valid values :search or :term
         # @param action_request [String] the request the user is making of the authority (e.g. query text or term id/uri)
         # @param request_header [Hash] optional attributes that can be appended to the generated URL
-        # @option replacements [Hash] variable-value pairs to substitute into the URL template (optional)
-        # @option subauthority [String] name of a subauthority (optional)
-        # @option language [Array<Symbol>] languages for filtering returned literals (optional)
+        # @option replacements [Hash] variable-value pairs to substitute into the URL template
+        # @option subauthority [String] name of a subauthority
+        # @option language [Array<Symbol>] languages for filtering returned literals
         # @return a valid URL that submits the action request to the external authority
         # @note All parameters after request_header are deprecated and will be removed in the next major release.
         def build_url(action_config:, action:, action_request:, request_header: {}, substitutions: {}, subauthority: nil, language: nil) # rubocop:disable Metrics/ParameterLists
@@ -61,6 +61,8 @@ module Qa
             request_header.fetch(:language, []).first
           end
 
+          # This is providing support for calling build_url with individual parameters instead of the request_header.
+          # This is deprecated and will be removed in the next major release.
           def build_request_header(substitutions, subauthority, language) # rubocop:disable Metrics/CyclomaticComplexity
             return {} if substitutions.blank? && subauthority.blank? && language.blank?
             Qa.deprecation_warning(

--- a/app/services/qa/linked_data/authority_url_service.rb
+++ b/app/services/qa/linked_data/authority_url_service.rb
@@ -7,14 +7,17 @@ module Qa
         # @param action_config [Qa::Authorities::LinkedData::SearchConfig | Qa::Authorities::LinkedData::TermConfig] action configuration for the authority
         # @param action [Symbol] action with valid values :search or :term
         # @param action_request [String] the request the user is making of the authority (e.g. query text or term id/uri)
-        # @param substitutions [Hash] variable-value pairs to substitute into the URL template (optional)
-        # @param subauthority [String] name of a subauthority (optional)
-        # @param language [Array<Symbol>] languages for filtering returned literals (optional)
+        # @param request_header [Hash] optional attributes that can be appended to the generated URL
+        # @option replacements [Hash] variable-value pairs to substitute into the URL template (optional)
+        # @option subauthority [String] name of a subauthority (optional)
+        # @option language [Array<Symbol>] languages for filtering returned literals (optional)
         # @return a valid URL that submits the action request to the external authority
-        def build_url(action_config:, action:, action_request:, substitutions: {}, subauthority: nil, language: nil) # rubocop:disable Metrics/ParameterLists
+        # @note All parameters after request_header are deprecated and will be removed in the next major release.
+        def build_url(action_config:, action:, action_request:, request_header: {}, substitutions: {}, subauthority: nil, language: nil) # rubocop:disable Metrics/ParameterLists
+          request_header = build_request_header(substitutions, subauthority, language) if request_header.empty?
           action_validation(action)
           url_config = action_config.url_config
-          selected_substitutions = url_config.extract_substitutions(combined_substitutions(action_config, action, action_request, substitutions, subauthority, language))
+          selected_substitutions = url_config.extract_substitutions(combined_substitutions(action_config, action, action_request, request_header))
           Qa::IriTemplateService.build_url(url_config: url_config, substitutions: selected_substitutions)
         end
 
@@ -25,10 +28,12 @@ module Qa
             raise Qa::UnsupportedAction, "#{action} Not Supported - Action must be one of the supported actions (e.g. :term, :search)"
           end
 
-          def combined_substitutions(action_config, action, action_request, substitutions, subauthority, language) # rubocop:disable Metrics/ParameterLists
+          def combined_substitutions(action_config, action, action_request, request_header)
+            substitutions = request_header.fetch(:replacements, {})
             substitutions[action_request_variable(action_config, action)] = action_request
-            substitutions[action_subauth_variable(action_config)] = action_subauth_variable_value(action_config, subauthority) if supports_subauthorities?(action_config) && subauthority.present?
-            substitutions[action_language_variable(action_config)] = language_value(language) if supports_language_parameter?(action_config) && language.present?
+            substitutions[action_subauth_variable(action_config)] = action_subauth_variable_value(action_config, request_header)
+            substitutions[action_language_variable(action_config)] = language_value(action_config, request_header)
+            substitutions.reject { |_k, v| v.nil? }
             substitutions
           end
 
@@ -37,29 +42,36 @@ module Qa
             action_config.qa_replacement_patterns[key]
           end
 
-          def supports_subauthorities?(action_config)
-            action_config.supports_subauthorities?
-          end
-
           def action_subauth_variable(action_config)
             action_config.qa_replacement_patterns[:subauth]
           end
 
-          def action_subauth_variable_value(action_config, subauthority)
-            action_config.subauthorities[subauthority.to_sym]
-          end
-
-          def supports_language_parameter?(action_config)
-            action_config.supports_language_parameter?
+          def action_subauth_variable_value(action_config, request_header)
+            subauth = request_header.fetch(:subauthority, nil)
+            return nil unless subauth && action_config.supports_subauthorities?
+            action_config.subauthorities[subauth.to_sym]
           end
 
           def action_language_variable(action_config)
             action_config.qa_replacement_patterns[:lang]
           end
 
-          def language_value(language)
-            return nil if language.blank?
-            language.first
+          def language_value(action_config, request_header)
+            return nil unless action_config.supports_language_parameter?
+            request_header.fetch(:language, []).first
+          end
+
+          def build_request_header(substitutions, subauthority, language) # rubocop:disable Metrics/CyclomaticComplexity
+            return {} if substitutions.blank? && subauthority.blank? && language.blank?
+            Qa.deprecation_warning(
+              in_msg: 'Qa::LinkedData::AuthorityUrlService',
+              msg: "individual attributes for options (e.g. substitutions, subauthority, language) are deprecated; use request_header instead"
+            )
+            request_header = {}
+            request_header[:replacements] = substitutions unless substititions.blank?
+            request_header[:subauthority] = subauthority unless subauthority.blank?
+            request_header[:language] = language unless language.blank?
+            request_header
           end
       end
     end

--- a/app/services/qa/linked_data/request_header_service.rb
+++ b/app/services/qa/linked_data/request_header_service.rb
@@ -1,4 +1,4 @@
-# Service to determine which language to use for sorting and filtering.
+# Service to construct a request header that includes optional attributes for search and fetch requests.
 module Qa
   module LinkedData
     class RequestHeaderService
@@ -6,12 +6,12 @@ module Qa
 
       # @param request [HttpRequest] request from controller
       # @param params [Hash] attribute-value pairs holding the request parameters
-      # @option language [Symbol] language used to select literals when multi-language is supported (e.g. :en, :fr, etc.)
-      # @option replacements [Hash] replacement values with { pattern_name (defined in YAML config) => value }
-      # @option subauth [String] the subauthority to query
+      # @option subauthority [String] the subauthority to query
+      # @option lang [Symbol] language used to select literals when multi-language is supported (e.g. :en, :fr, etc.)
       # @option performance_data [Boolean] true if include_performance_data should be returned with the results; otherwise, false (default: false)
       # @option context [Boolean] true if context should be returned with the results; otherwise, false (default: false) (search only)
       # @option format [String] return data in this format (fetch only)
+      # @note params may have additional attribute-value pairs that are passed through via replacements (only configured replacements are used)
       def initialize(request, params)
         @request = request
         @params = params
@@ -23,9 +23,9 @@ module Qa
       def search_header
         header = {}
         header[:subauthority] = params.fetch(:subauthority, nil)
-        header[:language] = language
-        header[:context] = context?
+        header[:user_language] = user_language
         header[:performance_data] = performance_data?
+        header[:context] = context?
         header[:replacements] = replacements
         header
       end
@@ -36,9 +36,9 @@ module Qa
       def fetch_header
         header = {}
         header[:subauthority] = params.fetch(:subauthority, nil)
-        header[:language] = language
-        header[:format] = format
+        header[:user_language] = user_language
         header[:performance_data] = performance_data?
+        header[:format] = format
         header[:replacements] = replacements
         header
       end
@@ -59,23 +59,27 @@ module Qa
 
       private
 
-        def language
+        # filter literals in results to this language
+        def user_language
           request_language = request.env['HTTP_ACCEPT_LANGUAGE']
           request_language = request_language.scan(/^[a-z]{2}/).first if request_language.present?
           lang = params[:lang] || request_language
           lang.present? ? Array(lang) : nil
         end
 
+        # include extended context in the results if true (applies to search only)
         def context?
           context = params.fetch(:context, 'false')
           context.casecmp?('true')
         end
 
+        # include performance data in the results if true
         def performance_data?
           performance_data = params.fetch(:performance_data, 'false')
           performance_data.casecmp?('true')
         end
 
+        # any params not specifically handled are passed through via replacements
         def replacements
           params.reject do |k, _v|
             ['q', 'vocab', 'controller', 'action', 'subauthority', 'lang', 'id',
@@ -83,6 +87,7 @@ module Qa
           end
         end
 
+        # results are returned in the format (applies to fetch only)
         def format
           f = params.fetch(:format, 'json').downcase
           ['jsonld', 'n3', 'ntriples'].include?(f) ? f : 'json'

--- a/app/services/qa/linked_data/request_header_service.rb
+++ b/app/services/qa/linked_data/request_header_service.rb
@@ -1,0 +1,92 @@
+# Service to determine which language to use for sorting and filtering.
+module Qa
+  module LinkedData
+    class RequestHeaderService
+      attr_reader :request, :params
+
+      # @param request [HttpRequest] request from controller
+      # @param params [Hash] attribute-value pairs holding the request parameters
+      # @option language [Symbol] language used to select literals when multi-language is supported (e.g. :en, :fr, etc.)
+      # @option replacements [Hash] replacement values with { pattern_name (defined in YAML config) => value }
+      # @option subauth [String] the subauthority to query
+      # @option performance_data [Boolean] true if include_performance_data should be returned with the results; otherwise, false (default: false)
+      # @option context [Boolean] true if context should be returned with the results; otherwise, false (default: false) (search only)
+      # @option format [String] return data in this format (fetch only)
+      def initialize(request, params)
+        @request = request
+        @params = params
+      end
+
+      # Construct request parameters to pass to search_query (linked data module).
+      # @returns [Hash] parsed out attribute-value pairs that are required for the search query
+      # @see Qa::Authorities::LinkedData::SearchQuery
+      def search_header
+        header = {}
+        header[:subauthority] = params.fetch(:subauthority, nil)
+        header[:language] = language
+        header[:context] = context?
+        header[:performance_data] = performance_data?
+        header[:replacements] = replacements
+        header
+      end
+
+      # Construct request parameters to pass to fetching a term (linked data module).
+      # @returns [Hash] parsed out attribute-value pairs that are required for the term fetch.
+      # @see Qa::Authorities::LinkedData::FindTerm
+      def fetch_header
+        header = {}
+        header[:subauthority] = params.fetch(:subauthority, nil)
+        header[:language] = language
+        header[:format] = format
+        header[:performance_data] = performance_data?
+        header[:replacements] = replacements
+        header
+      end
+
+      # @returns [String] the response header content type based on requested format
+      def content_type_for_format
+        case format
+        when 'jsonld'
+          'application/ld+json'
+        when 'n3'
+          'text/n3'
+        when 'ntriples'
+          'application/n-triples'
+        else
+          'application/json'
+        end
+      end
+
+      private
+
+        def language
+          request_language = request.env['HTTP_ACCEPT_LANGUAGE']
+          request_language = request_language.scan(/^[a-z]{2}/).first if request_language.present?
+          lang = params[:lang] || request_language
+          lang.present? ? Array(lang) : nil
+        end
+
+        def context?
+          context = params.fetch(:context, 'false')
+          context.casecmp?('true')
+        end
+
+        def performance_data?
+          performance_data = params.fetch(:performance_data, 'false')
+          performance_data.casecmp?('true')
+        end
+
+        def replacements
+          params.reject do |k, _v|
+            ['q', 'vocab', 'controller', 'action', 'subauthority', 'lang', 'id',
+             'context', 'performance_data', 'response_header', 'format'].include?(k)
+          end
+        end
+
+        def format
+          f = params.fetch(:format, 'json').downcase
+          ['jsonld', 'n3', 'ntriples'].include?(f) ? f : 'json'
+        end
+    end
+  end
+end

--- a/spec/lib/authorities/linked_data/find_term_spec.rb
+++ b/spec/lib/authorities/linked_data/find_term_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
       end
       context 'when set to true' do
         let :results do
-          lod_oclc.find('530369', performance_data: true)
+          lod_oclc.find('530369', request_header: { performance_data: true })
         end
         it 'includes performance in return hash' do
           expect(results.keys).to match_array [:performance, :results]
@@ -38,7 +38,7 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
 
       context 'when set to false' do
         let :results do
-          lod_oclc.find('530369', performance_data: false)
+          lod_oclc.find('530369', request_header: { performance_data: false })
         end
         it 'does NOT include performance in return hash' do
           expect(results.keys).not_to include(:performance)
@@ -114,7 +114,7 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
               .to_return(status: 200, body: webmock_fixture('lod_loc_term_found.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
           end
 
-          let(:results) { lod_loc.find('sh 85118553', subauth: 'subjects') }
+          let(:results) { lod_loc.find('sh 85118553', request_header: { subauthority: 'subjects' }) }
 
           it 'has correct primary predicate values' do
             expect(results[:uri]).to eq 'http://id.loc.gov/authorities/subjects/sh85118553'
@@ -182,8 +182,8 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
               .to_return(status: 200, body: webmock_fixture('lod_loc_second_term_found.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
           end
 
-          let(:results) { lod_loc.find('sh 85118553', subauth: 'subjects') }
-          let(:second_results) { lod_loc.find('sh 1234', subauth: 'subjects') }
+          let(:results) { lod_loc.find('sh 85118553', request_header: { subauthority: 'subjects' }) }
+          let(:second_results) { lod_loc.find('sh 1234', request_header: { subauthority: 'subjects' }) }
 
           it 'has correct primary predicate values for second request' do
             expect(results[:uri]).to eq 'http://id.loc.gov/authorities/subjects/sh85118553'
@@ -201,7 +201,7 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
               .to_return(status: 200, body: webmock_fixture('lod_loc_term_found.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
           end
 
-          let(:results_without_blank) { lod_loc.find('sh85118553', subauth: 'subjects') }
+          let(:results_without_blank) { lod_loc.find('sh85118553', request_header: { subauthority: 'subjects' }) }
 
           it 'extracts correct uri' do
             expect(results_without_blank[:uri]).to eq 'http://id.loc.gov/authorities/subjects/sh85118553'
@@ -215,7 +215,7 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
           end
 
           it 'raises DataNormalizationError' do
-            expect { lod_loc.find('sh85118553', subauth: 'subjects') }.to raise_error Qa::DataNormalizationError, "Unable to extract URI based on ID: sh85118553"
+            expect { lod_loc.find('sh85118553', request_header: { subauthority: 'subjects' }) }.to raise_error Qa::DataNormalizationError, "Unable to extract URI based on ID: sh85118553"
           end
         end
 
@@ -226,7 +226,7 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
             allow(lod_loc.term_config).to receive(:authority_name).and_return('ALT_LOC_AUTHORITY')
           end
 
-          let(:results) { lod_loc.find('sh 85118553', subauth: 'subjects') }
+          let(:results) { lod_loc.find('sh 85118553', request_header: { subauthority: 'subjects' }) }
 
           it 'does special processing to remove blank from id' do
             expect(results[:uri]).to eq 'http://id.loc.gov/authorities/subjects/sh85118553'
@@ -313,7 +313,7 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
           let :results do
             stub_request(:get, "http://aims.fao.org/aos/agrovoc/c_9513")
               .to_return(status: 200, body: webmock_fixture("lod_lang_term_enfr.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
-            lod_lang_defaults.find('http://aims.fao.org/aos/agrovoc/c_9513', language: 'fr')
+            lod_lang_defaults.find('http://aims.fao.org/aos/agrovoc/c_9513', request_header: { language: 'fr' })
           end
           it "is filtered to specified language" do
             expect(results[:label]).to eq ['Babeurre']
@@ -328,7 +328,7 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
           let :results do
             stub_request(:get, "http://aims.fao.org/aos/agrovoc/c_9513")
               .to_return(status: 200, body: webmock_fixture("lod_lang_term_enfr_noalt.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
-            lod_lang_defaults.find('http://aims.fao.org/aos/agrovoc/c_9513', language: 'fr')
+            lod_lang_defaults.find('http://aims.fao.org/aos/agrovoc/c_9513', request_header: { language: 'fr' })
           end
           it "is filtered to specified language" do
             expect(results[:label]).to eq ['Babeurre']
@@ -357,7 +357,7 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
             let :results do
               stub_request(:get, "http://aims.fao.org/aos/agrovoc/c_9513?lang=fr")
                 .to_return(status: 200, body: webmock_fixture("lod_lang_term_fr.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
-              lod_lang_param.find('http://aims.fao.org/aos/agrovoc/c_9513', replacements: { 'lang' => 'fr' })
+              lod_lang_param.find('http://aims.fao.org/aos/agrovoc/c_9513', request_header: { replacements: { 'lang' => 'fr' } })
             end
             it "is correctly parsed" do
               expect(results[:label]).to eq ['Babeurre']

--- a/spec/lib/authorities/linked_data/search_query_spec.rb
+++ b/spec/lib/authorities/linked_data/search_query_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Qa::Authorities::LinkedData::SearchQuery do
       end
       context 'when set to true' do
         let :results do
-          lod_oclc.search('cornell', subauth: 'personal_name', replacements: { 'maximumRecords' => '3' }, performance_data: true)
+          lod_oclc.search('cornell', request_header: { subauthority: 'personal_name', replacements: { 'maximumRecords' => '3' }, performance_data: true })
         end
         it 'includes performance in return hash' do
           expect(results).to be_kind_of Hash
@@ -27,7 +27,7 @@ RSpec.describe Qa::Authorities::LinkedData::SearchQuery do
 
       context 'when set to false' do
         let :results do
-          lod_oclc.search('cornell', subauth: 'personal_name', replacements: { 'maximumRecords' => '3' }, performance_data: false)
+          lod_oclc.search('cornell', request_header: { subauthority: 'personal_name', replacements: { 'maximumRecords' => '3' }, performance_data: false })
         end
         it 'does NOT include performance in return hash' do
           expect(results).to be_kind_of Array
@@ -36,7 +36,7 @@ RSpec.describe Qa::Authorities::LinkedData::SearchQuery do
 
       context 'when using default setting' do
         let :results do
-          lod_oclc.search('cornell', subauth: 'personal_name', replacements: { 'maximumRecords' => '3' })
+          lod_oclc.search('cornell', request_header: { subauthority: 'personal_name', replacements: { 'maximumRecords' => '3' } })
         end
         it 'does NOT include performance in return hash' do
           expect(results).to be_kind_of Array
@@ -49,7 +49,7 @@ RSpec.describe Qa::Authorities::LinkedData::SearchQuery do
         let :results do
           stub_request(:get, 'http://experimental.worldcat.org/fast/search?maximumRecords=3&query=cql.any%20all%20%22supercalifragilisticexpialidocious%22&sortKeys=usage')
             .to_return(status: 200, body: webmock_fixture('lod_oclc_query_no_results.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
-          lod_oclc.search('supercalifragilisticexpialidocious', replacements: { 'maximumRecords' => '3' })
+          lod_oclc.search('supercalifragilisticexpialidocious', request_header: { replacements: { 'maximumRecords' => '3' } })
         end
         it 'returns an empty array' do
           expect(results).to eq([])
@@ -60,7 +60,7 @@ RSpec.describe Qa::Authorities::LinkedData::SearchQuery do
         let :results do
           stub_request(:get, 'http://experimental.worldcat.org/fast/search?maximumRecords=3&query=cql.any%20all%20%22cornell%22&sortKeys=usage')
             .to_return(status: 200, body: webmock_fixture('lod_oclc_all_query_3_results.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
-          lod_oclc.search('cornell', replacements: { 'maximumRecords' => '3' })
+          lod_oclc.search('cornell', request_header: { replacements: { 'maximumRecords' => '3' } })
         end
         it 'is correctly parsed' do
           expect(results.count).to eq(3)
@@ -76,7 +76,7 @@ RSpec.describe Qa::Authorities::LinkedData::SearchQuery do
         let :results do
           stub_request(:get, 'http://experimental.worldcat.org/fast/search?maximumRecords=3&query=oclc.personalName%20all%20%22supercalifragilisticexpialidocious%22&sortKeys=usage')
             .to_return(status: 200, body: webmock_fixture('lod_oclc_query_no_results.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
-          lod_oclc.search('supercalifragilisticexpialidocious', subauth: 'personal_name', replacements: { 'maximumRecords' => '3' })
+          lod_oclc.search('supercalifragilisticexpialidocious', request_header: { subauthority: 'personal_name', replacements: { 'maximumRecords' => '3' } })
         end
         it 'returns an empty array' do
           expect(results).to eq([])
@@ -87,7 +87,7 @@ RSpec.describe Qa::Authorities::LinkedData::SearchQuery do
         let :results do
           stub_request(:get, 'http://experimental.worldcat.org/fast/search?maximumRecords=3&query=oclc.personalName%20all%20%22cornell%22&sortKeys=usage')
             .to_return(status: 200, body: webmock_fixture('lod_oclc_personalName_query_3_results.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
-          lod_oclc.search('cornell', subauth: 'personal_name', replacements: { 'maximumRecords' => '3' })
+          lod_oclc.search('cornell', request_header: { subauthority: 'personal_name', replacements: { 'maximumRecords' => '3' } })
         end
         it 'is correctly parsed' do
           expect(results.count).to eq(3)
@@ -197,7 +197,7 @@ RSpec.describe Qa::Authorities::LinkedData::SearchQuery do
           let :results do
             stub_request(:get, "http://localhost/test_default/search?query=milk")
               .to_return(status: 200, body: webmock_fixture("lod_lang_search_enfr.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
-            lod_lang_defaults.search('milk', language: :fr)
+            lod_lang_defaults.search('milk', request_header: { language: :fr })
           end
           it "is filtered to specified language" do
             expect(results.first[:label]).to eq('Babeurre (délicieux)')
@@ -226,7 +226,7 @@ RSpec.describe Qa::Authorities::LinkedData::SearchQuery do
             let :results do
               stub_request(:get, "http://localhost/test_replacement/search?query=milk&lang=fr")
                 .to_return(status: 200, body: webmock_fixture("lod_lang_search_fr.rdf.xml"), headers: { 'Content-Type' => 'application/rdf+xml' })
-              lod_lang_param.search("milk", replacements: { 'lang' => 'fr' })
+              lod_lang_param.search("milk", request_header: { replacements: { 'lang' => 'fr' } })
             end
             it "is correctly parsed" do
               expect(results.first[:label]).to eq('Babeurre (délicieux)')

--- a/spec/services/linked_data/authority_url_service_spec.rb
+++ b/spec/services/linked_data/authority_url_service_spec.rb
@@ -14,13 +14,19 @@ RSpec.describe Qa::LinkedData::AuthorityUrlService do
   end
 
   describe '.build_url' do
+    let(:request_header) do
+      {
+        subauthority: subauthority,
+        replacements: substitutions
+      }
+    end
     context 'when authority is not registered' do
       let(:authority) { :BAD_AUTHORITY }
 
       it 'raises error' do
         expected_error = Qa::InvalidLinkedDataAuthority
         expected_error_message = "Unable to initialize linked data authority 'BAD_AUTHORITY'"
-        expect { described_class.build_url(action_config: action_config, subauthority: subauthority, action: action, action_request: action_request, substitutions: substitutions) }
+        expect { described_class.build_url(action_config: action_config, action: action, action_request: action_request, request_header: request_header) }
           .to raise_error(expected_error, expected_error_message)
       end
     end
@@ -33,7 +39,7 @@ RSpec.describe Qa::LinkedData::AuthorityUrlService do
         skip "Pending better handling of unsupported subauthorities"
         expected_error = Qa::InvalidLinkedDataAuthority
         expected_error_message = "Unable to initialize linked data sub-authority BAD_SUBAUTHORITY"
-        expect { described_class.build_url(action_config: action_config, subauthority: subauthority, action: action, action_request: action_request, substitutions: substitutions) }
+        expect { described_class.build_url(action_config: action_config, action: action, action_request: action_request, request_header: request_header) }
           .to raise_error(expected_error, expected_error_message)
       end
     end
@@ -44,7 +50,7 @@ RSpec.describe Qa::LinkedData::AuthorityUrlService do
       it 'raises error' do
         expected_error = Qa::UnsupportedAction
         expected_error_message = "BAD_ACTION Not Supported - Action must be one of the supported actions (e.g. :term, :search)"
-        expect { described_class.build_url(action_config: action_config, subauthority: subauthority, action: action, action_request: action_request, substitutions: substitutions) }
+        expect { described_class.build_url(action_config: action_config, action: action, action_request: action_request, request_header: request_header) }
           .to raise_error(expected_error, expected_error_message)
       end
     end
@@ -55,16 +61,16 @@ RSpec.describe Qa::LinkedData::AuthorityUrlService do
       it 'raises error' do
         expected_error = Qa::IriTemplate::MissingParameter
         expected_error_message = "query is required, but missing"
-        expect { described_class.build_url(action_config: action_config, subauthority: subauthority, action: action, action_request: action_request, substitutions: substitutions) }
+        expect { described_class.build_url(action_config: action_config, action: action, action_request: action_request, request_header: request_header) }
           .to raise_error(expected_error, expected_error_message)
       end
     end
 
-    subject do
-      described_class.build_url(action_config: action_config, subauthority: subauthority, action: action, action_request: action_request, substitutions: substitutions)
-    end
-
     context 'when no errors' do
+      subject do
+        described_class.build_url(action_config: action_config, action: action, action_request: action_request, request_header: request_header)
+      end
+
       context 'and performing search action' do
         context 'and all substitutions specified' do
           let(:substitutions) do

--- a/spec/services/linked_data/request_header_service_spec.rb
+++ b/spec/services/linked_data/request_header_service_spec.rb
@@ -1,0 +1,124 @@
+require 'spec_helper'
+
+RSpec.describe Qa::LinkedData::RequestHeaderService do
+  let(:request) { double }
+
+  describe '#search_header' do
+    context 'when optional params are defined' do
+      let(:search_params) do
+        {
+          'subauthority' => 'person',
+          'lang' => 'sp',
+          'maxRecords' => '4',
+          'context' => 'true',
+          'performance_data' => 'true'
+        }.with_indifferent_access
+      end
+      before { allow(request).to receive(:env).and_return('HTTP_ACCEPT_LANGUAGE' => 'de') }
+
+      it 'uses passed in params' do
+        expected_results =
+          {
+            subauthority: 'person',
+            language: ['sp'],
+            context: true,
+            performance_data: true,
+            replacements: { 'maxRecords' => '4' }
+          }
+        expect(described_class.new(request, search_params).search_header).to eq expected_results
+      end
+    end
+
+    context 'when none of the optional params are defined' do
+      context 'and request does not define language' do
+        before { allow(request).to receive(:env).and_return('HTTP_ACCEPT_LANGUAGE' => nil) }
+        it 'returns defaults' do
+          expected_results =
+            {
+              subauthority: nil,
+              language: nil,
+              context: false,
+              performance_data: false,
+              replacements: {}
+            }
+          expect(described_class.new(request, {}).search_header).to eq expected_results
+        end
+      end
+
+      context 'and request does define language' do
+        before { allow(request).to receive(:env).and_return('HTTP_ACCEPT_LANGUAGE' => 'de') }
+        it 'returns defaults with language set to request language' do
+          expected_results =
+            {
+              subauthority: nil,
+              language: ['de'],
+              context: false,
+              performance_data: false,
+              replacements: {}
+            }
+          expect(described_class.new(request, {}).search_header).to eq expected_results
+        end
+      end
+    end
+  end
+
+  describe '#fetch_header' do
+    context 'when optional params are defined' do
+      let(:fetch_params) do
+        {
+          'subauthority' => 'person',
+          'lang' => 'sp',
+          'extra' => 'data',
+          'even' => 'more data',
+          'format' => 'n3',
+          'performance_data' => 'true'
+        }.with_indifferent_access
+      end
+      before { allow(request).to receive(:env).and_return('HTTP_ACCEPT_LANGUAGE' => 'de') }
+
+      it 'uses passed in params' do
+        expected_results =
+          {
+            subauthority: 'person',
+            language: ['sp'],
+            format: 'n3',
+            performance_data: true,
+            replacements: { 'extra' => 'data', 'even' => 'more data' }
+          }
+        expect(described_class.new(request, fetch_params).fetch_header).to eq expected_results
+      end
+    end
+
+    context 'when none of the optional params are defined' do
+      context 'and request does not define language' do
+        before { allow(request).to receive(:env).and_return('HTTP_ACCEPT_LANGUAGE' => nil) }
+        it 'returns defaults' do
+          expected_results =
+            {
+              subauthority: nil,
+              language: nil,
+              format: 'json',
+              performance_data: false,
+              replacements: {}
+            }
+          expect(described_class.new(request, {}).fetch_header).to eq expected_results
+        end
+      end
+
+      context 'and request does define language' do
+        before { allow(request).to receive(:env).and_return('HTTP_ACCEPT_LANGUAGE' => 'de') }
+        it 'returns defaults with language set to request language' do
+          expected_results =
+            {
+              subauthority: nil,
+              language: ['de'],
+              format: 'json',
+              performance_data: false,
+              replacements: {}
+            }
+          expect(described_class.new(request, {}).fetch_header).to eq expected_results
+        end
+      end
+    end
+  end
+end

--- a/spec/services/linked_data/request_header_service_spec.rb
+++ b/spec/services/linked_data/request_header_service_spec.rb
@@ -19,11 +19,11 @@ RSpec.describe Qa::LinkedData::RequestHeaderService do
       it 'uses passed in params' do
         expected_results =
           {
-            subauthority: 'person',
-            language: ['sp'],
             context: true,
             performance_data: true,
-            replacements: { 'maxRecords' => '4' }
+            replacements: { 'maxRecords' => '4' },
+            subauthority: 'person',
+            user_language: ['sp']
           }
         expect(described_class.new(request, search_params).search_header).to eq expected_results
       end
@@ -35,11 +35,11 @@ RSpec.describe Qa::LinkedData::RequestHeaderService do
         it 'returns defaults' do
           expected_results =
             {
-              subauthority: nil,
-              language: nil,
               context: false,
               performance_data: false,
-              replacements: {}
+              replacements: {},
+              subauthority: nil,
+              user_language: nil
             }
           expect(described_class.new(request, {}).search_header).to eq expected_results
         end
@@ -50,11 +50,11 @@ RSpec.describe Qa::LinkedData::RequestHeaderService do
         it 'returns defaults with language set to request language' do
           expected_results =
             {
-              subauthority: nil,
-              language: ['de'],
               context: false,
               performance_data: false,
-              replacements: {}
+              replacements: {},
+              subauthority: nil,
+              user_language: ['de']
             }
           expect(described_class.new(request, {}).search_header).to eq expected_results
         end
@@ -79,11 +79,11 @@ RSpec.describe Qa::LinkedData::RequestHeaderService do
       it 'uses passed in params' do
         expected_results =
           {
-            subauthority: 'person',
-            language: ['sp'],
             format: 'n3',
             performance_data: true,
-            replacements: { 'extra' => 'data', 'even' => 'more data' }
+            replacements: { 'extra' => 'data', 'even' => 'more data' },
+            subauthority: 'person',
+            user_language: ['sp']
           }
         expect(described_class.new(request, fetch_params).fetch_header).to eq expected_results
       end
@@ -95,11 +95,11 @@ RSpec.describe Qa::LinkedData::RequestHeaderService do
         it 'returns defaults' do
           expected_results =
             {
-              subauthority: nil,
-              language: nil,
               format: 'json',
               performance_data: false,
-              replacements: {}
+              replacements: {},
+              subauthority: nil,
+              user_language: nil
             }
           expect(described_class.new(request, {}).fetch_header).to eq expected_results
         end
@@ -110,11 +110,11 @@ RSpec.describe Qa::LinkedData::RequestHeaderService do
         it 'returns defaults with language set to request language' do
           expected_results =
             {
-              subauthority: nil,
-              language: ['de'],
               format: 'json',
               performance_data: false,
-              replacements: {}
+              replacements: {},
+              subauthority: nil,
+              user_language: ['de']
             }
           expect(described_class.new(request, {}).fetch_header).to eq expected_results
         end


### PR DESCRIPTION
The list of parameters that are passed to search and find methods for the linked data module are long.  There is a need to add another parameter.  In prep for that, this refactors the optional parameters into a single request_header parameter.  This same change is also in AuthorityUrlService which builds the URLs used in search and find and is the primary consumer of the optional params.

All other changes are in the callers of these methods, which is coming from LinkdedDataTermsController actions.

The longer individual parameter lists are deprecated.