### PR TITLE
add new configurations for identifying parameters related to pagination of linked data results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
           project: qa
 
       - samvera/engine_cart_generate:
-          cache_key: v6-internal-test-app-{{ checksum "qa.gemspec" }}-{{ checksum "spec/test_app_templates/lib/generators/test_app_generator.rb" }}-{{ checksum "lib/generators/qa/install/install_generator.rb" }}-<< parameters.rails_version >>-<< parameters.ruby_version >>
+          cache_key: v7-internal-test-app-{{ checksum "qa.gemspec" }}-{{ checksum "spec/test_app_templates/lib/generators/test_app_generator.rb" }}-{{ checksum "lib/generators/qa/install/install_generator.rb" }}-<< parameters.rails_version >>-<< parameters.ruby_version >>
 
       - samvera/bundle_for_gem:
           ruby_version: << parameters.ruby_version >>

--- a/lib/qa/authorities/linked_data/config.rb
+++ b/lib/qa/authorities/linked_data/config.rb
@@ -39,6 +39,10 @@ module Qa::Authorities
         @prefixes ||= authority_config.fetch(:prefixes, {})
       end
 
+      def service_uri
+        @service_uri ||= authority_config.fetch(:service_uri, nil)
+      end
+
       def config_version
         @config_version ||= authority_config.fetch(:QA_CONFIG_VERSION, '1.0')
       end

--- a/lib/qa/authorities/linked_data/config/search_config.rb
+++ b/lib/qa/authorities/linked_data/config/search_config.rb
@@ -8,7 +8,7 @@ module Qa::Authorities
       attr_reader :prefixes, :full_config, :search_config
       private :full_config, :search_config
 
-      delegate :authority_name, to: :full_config
+      delegate :authority_name, :service_uri, to: :full_config
 
       # @param [Hash] config the search portion of the config
       # @param [Hash<Symbol><String>] prefixes URL map of prefixes to use with ldpaths
@@ -146,7 +146,7 @@ module Qa::Authorities
         search_config.fetch(:qa_replacement_patterns, {})
       end
 
-      # @return [Boolean] true if supports language parameter; otherwise, false
+      # @return [Boolean] true if supports subauthorities; otherwise, false
       def supports_subauthorities?
         qa_replacement_patterns.key?(:subauth) && subauthorities?
       end
@@ -180,6 +180,22 @@ module Qa::Authorities
       def subauthorities
         @subauthorities ||= {} if search_config.nil? || !(search_config.key? :subauthorities)
         @subauthorities ||= search_config.fetch(:subauthorities)
+      end
+
+      # @return [String] name of parameter holding start record number
+      def start_record_parameter
+        qa_replacement_patterns.key?(:start_record) ? qa_replacement_patterns[:start_record] : nil
+      end
+
+      # @return [String] name of parameter holding number of requested records
+      def requested_records_parameter
+        qa_replacement_patterns.key?(:requested_records) ? qa_replacement_patterns[:requested_records] : nil
+      end
+
+      # @return [String] ldpath of the triple that holds the total number of available records for a search
+      # @see #service_subject_uri
+      def total_count_ldpath
+        search_config.key?(:total_count_ldpath) ? search_config[:total_count_ldpath] : nil
       end
 
       def info

--- a/spec/fixtures/authorities/linked_data/lod_full_config.json
+++ b/spec/fixtures/authorities/linked_data/lod_full_config.json
@@ -1,5 +1,6 @@
 {
-  "QA_CONFIG_VERSION": "2.0",
+  "QA_CONFIG_VERSION": "2.2",
+  "service_uri": "http://ld4l.org/ld4l_services/cache",
   "prefixes": {
     "schema": "http://www.w3.org/2000/01/rdf-schema#",
     "skos": "http://www.w3.org/2004/02/skos/core#"
@@ -114,9 +115,12 @@
     "qa_replacement_patterns": {
       "query": "query",
       "subauth": "subauth",
-      "lang": "lang"
+      "lang": "lang",
+      "start_record": "startRecord",
+      "requested_records": "maxRecords"
     },
     "language": [ "en", "fr", "de" ],
+    "total_count_ldpath": "vivo:count",
     "results": {
       "id_predicate":       "http://purl.org/dc/terms/identifier",
       "label_predicate":    "http://www.w3.org/2004/02/skos/core#prefLabel",

--- a/spec/lib/authorities/linked_data/config_spec.rb
+++ b/spec/lib/authorities/linked_data/config_spec.rb
@@ -25,7 +25,8 @@ describe Qa::Authorities::LinkedData::Config do
   describe '#authority_config' do
     let(:full_auth_config) do
       {
-        QA_CONFIG_VERSION: "2.0",
+        QA_CONFIG_VERSION: "2.2",
+        service_uri: "http://ld4l.org/ld4l_services/cache",
         prefixes: {
           schema: "http://www.w3.org/2000/01/rdf-schema#",
           skos: "http://www.w3.org/2004/02/skos/core#"
@@ -140,9 +141,12 @@ describe Qa::Authorities::LinkedData::Config do
           qa_replacement_patterns: {
             query: 'query',
             subauth: 'subauth',
-            lang: 'lang'
+            lang: 'lang',
+            start_record: 'startRecord',
+            requested_records: 'maxRecords'
           },
           language: ['en', 'fr', 'de'],
+          total_count_ldpath: "vivo:count",
           results: {
             id_predicate: 'http://purl.org/dc/terms/identifier',
             label_predicate: 'http://www.w3.org/2004/02/skos/core#prefLabel',
@@ -377,7 +381,7 @@ describe Qa::Authorities::LinkedData::Config do
     let(:authority_config) { full_config.authority_config }
     let(:authority_config_1_0) { full_config_1_0.authority_config }
 
-    it 'returns hash of the full authority 2.0 configuration' do
+    it 'returns hash of the full authority 2.2 configuration' do
       expect(authority_config).to eq full_auth_config
     end
 
@@ -468,18 +472,18 @@ describe Qa::Authorities::LinkedData::Config do
 
     context 'when version is specified in the config file' do
       it 'returns the version from the config file' do
-        expect(full_config.config_version).to eq '2.0'
+        expect(full_config.config_version).to eq '2.2'
       end
     end
   end
 
   describe '#config_version?' do
     it "returns true if the passed in version matches the authority's version" do
-      expect(full_config.config_version?('2.0')).to eq true
+      expect(full_config.config_version?('2.2')).to eq true
     end
 
     it "returns false if the passed in version does NOT match the authority's version" do
-      expect(full_config_1_0.config_version?('2.0')).to eq false
+      expect(full_config_1_0.config_version?('2.2')).to eq false
     end
   end
 end

--- a/spec/lib/authorities/linked_data/search_config_spec.rb
+++ b/spec/lib/authorities/linked_data/search_config_spec.rb
@@ -68,9 +68,12 @@ RSpec.describe Qa::Authorities::LinkedData::SearchConfig do
         qa_replacement_patterns: {
           query: 'query',
           subauth: 'subauth',
-          lang: 'lang'
+          lang: 'lang',
+          start_record: 'startRecord',
+          requested_records: 'maxRecords'
         },
         language: ['en', 'fr', 'de'],
+        total_count_ldpath: "vivo:count",
         results: {
           id_predicate: 'http://purl.org/dc/terms/identifier',
           label_predicate: 'http://www.w3.org/2004/02/skos/core#prefLabel',
@@ -405,6 +408,42 @@ RSpec.describe Qa::Authorities::LinkedData::SearchConfig do
         search_sub3_key: 'search_sub3_name'
       }
       expect(full_config.subauthorities).to eq expected_hash
+    end
+  end
+
+  describe '#start_record_parameter' do
+    it 'returns nil if only term configuration is defined' do
+      expect(term_only_config.start_record_parameter).to eq nil
+    end
+    it 'returns nil if not defined' do
+      expect(min_config.start_record_parameter).to eq nil
+    end
+    it 'returns parameter name if defined' do
+      expect(full_config.start_record_parameter).to eq 'startRecord'
+    end
+  end
+
+  describe '#requested_records_parameter' do
+    it 'returns nil if only term configuration is defined' do
+      expect(term_only_config.requested_records_parameter).to eq nil
+    end
+    it 'returns nil if not defined' do
+      expect(min_config.requested_records_parameter).to eq nil
+    end
+    it 'returns parameter name if defined' do
+      expect(full_config.requested_records_parameter).to eq 'maxRecords'
+    end
+  end
+
+  describe '#total_count_ldpath' do
+    it 'returns nil if only term configuration is defined' do
+      expect(term_only_config.total_count_ldpath).to eq nil
+    end
+    it 'returns nil if not defined' do
+      expect(min_config.total_count_ldpath).to eq nil
+    end
+    it 'returns parameter name if defined' do
+      expect(full_config.total_count_ldpath).to eq 'vivo:count'
     end
   end
 


### PR DESCRIPTION
### New authority level configs

* service_uri - the uri for the authority provider that allows the service to send general information as part of a search query or term fetch

### New search level configs

* total_count_ldpath - the ldpath within the results graph that holds the total number of available search result records.  The service_uri will be the subject URI of the triple holding this value.

#### configs in qa_replacement_patterns subsection

These configs identify parameters that are passed to QA and play a specific role.

* start_record - number of the first record returned in search results
* requested_records - number of records to return in search results

## Using configs for pagination support

start_record and requested_records are used to identify the page number and the number of records to display on a page.  For example...

```
start_record = 1 AND requested_records = 10 equates to page 1 records 1..10
start_record = 11 AND requested_records = 10 equates to page 2 records 11..20
start_record = 21 AND requested_records = 10 equates to page 3 records 21..30
etc.
```

The total number of pages can be calculated by getting the total number of search results from triple...

```
<service_uri> <total_count_ldpath> total_count .
```

```
number_of_pages = total_count / requested_records
```