### PR TITLE
move performance data output generation to a service

### DIFF
--- a/app/controllers/qa/linked_data_terms_controller.rb
+++ b/app/controllers/qa/linked_data_terms_controller.rb
@@ -154,7 +154,7 @@ class Qa::LinkedDataTermsController < ::ApplicationController
     end
 
     def create_request_header_service
-      @request_header_service = request_header_service_class.new(request, params)
+      @request_header_service = request_header_service_class.new(request: request, params: params)
     end
 
     def init_authority

--- a/app/services/qa/linked_data/performance_data_service.rb
+++ b/app/services/qa/linked_data/performance_data_service.rb
@@ -1,0 +1,26 @@
+# Service to construct a request header that includes optional attributes for search and fetch requests.
+module Qa
+  module LinkedData
+    class PerformanceDataService
+      # Construct performance data structure to include in the returned results (linked data module).
+      # @param access_time_s [Float] time to fetch the data from the external source and populate it in an RDF graph
+      # @param normalization_time_s [Float] time for QA to normalize the data
+      # @param fetched_size [Float] size of data in the RDF graph (in bytes)
+      # @param normalized_size [Float] size of the normalized data string (in bytes)
+      # @returns [Hash] performance data
+      # @see Qa::Authorities::LinkedData::SearchQuery
+      # @see Qa::Authorities::LinkedData::FindTerm
+      def self.performance_data(access_time_s:, normalize_time_s:, fetched_size:, normalized_size:)
+        {
+          fetch_time_s: access_time_s,
+          normalization_time_s: normalize_time_s,
+          fetched_bytes: fetched_size,
+          normalized_bytes: normalized_size,
+          fetch_bytes_per_s: fetched_size / access_time_s,
+          normalization_bytes_per_s: normalized_size / normalize_time_s,
+          total_time_s: (access_time_s + normalize_time_s)
+        }
+      end
+    end
+  end
+end

--- a/app/services/qa/linked_data/request_header_service.rb
+++ b/app/services/qa/linked_data/request_header_service.rb
@@ -12,7 +12,7 @@ module Qa
       # @option context [Boolean] true if context should be returned with the results; otherwise, false (default: false) (search only)
       # @option format [String] return data in this format (fetch only)
       # @note params may have additional attribute-value pairs that are passed through via replacements (only configured replacements are used)
-      def initialize(request, params)
+      def initialize(request:, params:)
         @request = request
         @params = params
       end

--- a/lib/qa/authorities/linked_data/find_term.rb
+++ b/lib/qa/authorities/linked_data/find_term.rb
@@ -15,8 +15,8 @@ module Qa::Authorities
         @term_config = term_config
       end
 
-      attr_reader :term_config, :full_graph, :filtered_graph, :language, :id, :uri, :access_time_s, :normalize_time_s, :fetched_size, :normalized_size, :subauthority
-      private :full_graph, :filtered_graph, :language, :id, :uri, :access_time_s, :normalize_time_s, :fetched_size, :normalized_size, :subauthority
+      attr_reader :term_config, :full_graph, :filtered_graph, :language, :id, :uri, :access_time_s, :normalize_time_s, :subauthority, :request_header
+      private :full_graph, :filtered_graph, :language, :id, :uri, :access_time_s, :normalize_time_s, :subauthority, :request_header
 
       delegate :term_subauthority?, :prefixes, :authority_name, to: :term_config
 
@@ -63,7 +63,6 @@ module Qa::Authorities
 
           access_end_dt = Time.now.utc
           @access_time_s = access_end_dt - access_start_dt
-          @fetched_size = full_graph.triples.to_s.size if performance_data?
           Rails.logger.info("Time to receive data from authority: #{access_time_s}s")
         end
 
@@ -74,9 +73,8 @@ module Qa::Authorities
 
           normalize_end_dt = Time.now.utc
           @normalize_time_s = normalize_end_dt - normalize_start_dt
-          @normalized_size = results.to_s.size if performance_data?
           Rails.logger.info("Time to normalize data: #{normalize_time_s}s")
-          results = append_performance_data(results) if performance_data?
+          results = append_data_outside_results(results)
           results
         end
 
@@ -93,6 +91,7 @@ module Qa::Authorities
         end
 
         def unpack_request_header(request_header)
+          @request_header = request_header
           @subauthority = request_header.fetch(:subauthority, nil)
           @format = request_header.fetch(:format, 'json')
           @performance_data = request_header.fetch(:performance_data, false)
@@ -282,17 +281,20 @@ module Qa::Authorities
           predicates_hash
         end
 
-        def append_performance_data(results)
-          pred_count = results['predicates'].present? ? results['predicates'].size : 0
-          performance = { predicate_count: pred_count,
-                          fetch_time_s: access_time_s,
-                          normalization_time_s: normalize_time_s,
-                          fetched_bytes: fetched_size,
-                          normalized_bytes: normalized_size,
-                          fetch_bytes_per_s: fetched_size / access_time_s,
-                          normalization_bytes_per_s: normalized_size / normalize_time_s,
-                          total_time_s: (access_time_s + normalize_time_s) }
-          { performance: performance, results: results }
+        def append_data_outside_results(results)
+          return results unless performance_data?
+          full_results = {}
+          full_results[:results] = results
+          full_results[:performance] = performance(results)
+          full_results
+        end
+
+        def performance(results)
+          normalized_size = results.to_s.size
+          fetched_size = full_graph.triples.to_s.size
+          perf_data = Qa::LinkedData::PerformanceDataService.performance_data(access_time_s: access_time_s, normalize_time_s: normalize_time_s,
+                                                                              fetched_size: fetched_size, normalized_size: normalized_size)
+          perf_data
         end
 
         # This is providing support for calling build_url with individual parameters instead of the request_header.

--- a/spec/controllers/linked_data_terms_controller_spec.rb
+++ b/spec/controllers/linked_data_terms_controller_spec.rb
@@ -307,12 +307,10 @@ describe Qa::LinkedDataTermsController, type: :controller do
         results = JSON.parse(response.body)
         expect(results).to be_kind_of Hash
         expect(results.keys).to match_array ['performance', 'results']
-        expect(results['performance'].keys).to match_array ['result_count', 'fetch_time_s', 'normalization_time_s',
+        expect(results['performance'].keys).to match_array ['fetch_time_s', 'normalization_time_s',
                                                             'fetched_bytes', 'normalized_bytes', 'fetch_bytes_per_s',
                                                             'normalization_bytes_per_s', 'total_time_s']
         expect(results['performance']['total_time_s']).to eq results['performance']['fetch_time_s'] + results['performance']['normalization_time_s']
-        expect(results['performance']['result_count']).to eq 3
-        expect(results['results'].count).to eq 3
       end
 
       it "returns basic data only when performance_data='false'" do
@@ -320,7 +318,6 @@ describe Qa::LinkedDataTermsController, type: :controller do
         expect(response).to be_successful
         results = JSON.parse(response.body)
         expect(results).to be_kind_of Array
-        expect(results.size).to eq 3
       end
     end
   end
@@ -495,12 +492,9 @@ describe Qa::LinkedDataTermsController, type: :controller do
         results = JSON.parse(response.body)
         expect(results).to be_kind_of Hash
         expect(results.keys).to match_array ['performance', 'results']
-        expect(results['performance'].keys).to match_array ['predicate_count', 'fetch_time_s', 'normalization_time_s',
-                                                            'fetched_bytes', 'normalized_bytes', 'fetch_bytes_per_s',
-                                                            'normalization_bytes_per_s', 'total_time_s']
+        expect(results['performance'].keys).to match_array ['fetch_time_s', 'normalization_time_s', 'fetched_bytes', 'normalized_bytes',
+                                                            'fetch_bytes_per_s', 'normalization_bytes_per_s', 'total_time_s']
         expect(results['performance']['total_time_s']).to eq results['performance']['fetch_time_s'] + results['performance']['normalization_time_s']
-        expect(results['performance']['predicate_count']).to eq 15
-        expect(results['results']['predicates'].count).to eq 15
       end
 
       it "returns basic data only when performance_data='false'" do
@@ -509,7 +503,6 @@ describe Qa::LinkedDataTermsController, type: :controller do
         results = JSON.parse(response.body)
         expect(results).to be_kind_of Hash
         expect(results.keys).not_to include('performance')
-        expect(results['predicates'].size).to eq 15
       end
     end
   end
@@ -671,12 +664,10 @@ describe Qa::LinkedDataTermsController, type: :controller do
         results = JSON.parse(response.body)
         expect(results).to be_kind_of Hash
         expect(results.keys).to match_array ['performance', 'results']
-        expect(results['performance'].keys).to match_array ['predicate_count', 'fetch_time_s', 'normalization_time_s',
+        expect(results['performance'].keys).to match_array ['fetch_time_s', 'normalization_time_s',
                                                             'fetched_bytes', 'normalized_bytes', 'fetch_bytes_per_s',
                                                             'normalization_bytes_per_s', 'total_time_s']
         expect(results['performance']['total_time_s']).to eq results['performance']['fetch_time_s'] + results['performance']['normalization_time_s']
-        expect(results['performance']['predicate_count']).to eq 7
-        expect(results['results']['predicates'].count).to eq 7
       end
 
       it "returns basic data only when performance_data='false'" do
@@ -685,7 +676,6 @@ describe Qa::LinkedDataTermsController, type: :controller do
         results = JSON.parse(response.body)
         expect(results).to be_kind_of Hash
         expect(results.keys).not_to include('performance')
-        expect(results['predicates'].size).to eq 7
       end
     end
   end

--- a/spec/lib/authorities/linked_data/find_term_spec.rb
+++ b/spec/lib/authorities/linked_data/find_term_spec.rb
@@ -28,10 +28,8 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
         end
         it 'includes performance in return hash' do
           expect(results.keys).to match_array [:performance, :results]
-          expect(results[:performance].keys).to match_array [:predicate_count, :fetch_time_s, :normalization_time_s,
-                                                             :fetched_bytes, :normalized_bytes, :fetch_bytes_per_s,
-                                                             :normalization_bytes_per_s, :total_time_s]
-          expect(results[:performance][:predicate_count]).to eq 7
+          expect(results[:performance].keys).to match_array [:fetch_time_s, :normalization_time_s, :fetched_bytes, :normalized_bytes,
+                                                             :fetch_bytes_per_s, :normalization_bytes_per_s, :total_time_s]
           expect(results[:performance][:total_time_s]).to eq results[:performance][:fetch_time_s] + results[:performance][:normalization_time_s]
         end
       end

--- a/spec/lib/authorities/linked_data/search_query_spec.rb
+++ b/spec/lib/authorities/linked_data/search_query_spec.rb
@@ -16,11 +16,10 @@ RSpec.describe Qa::Authorities::LinkedData::SearchQuery do
         it 'includes performance in return hash' do
           expect(results).to be_kind_of Hash
           expect(results.keys).to match_array [:performance, :results]
-          expect(results[:performance].keys).to match_array [:result_count, :fetch_time_s, :normalization_time_s,
+          expect(results[:performance].keys).to match_array [:fetch_time_s, :normalization_time_s,
                                                              :fetched_bytes, :normalized_bytes, :fetch_bytes_per_s,
                                                              :normalization_bytes_per_s, :total_time_s]
           expect(results[:performance][:total_time_s]).to eq results[:performance][:fetch_time_s] + results[:performance][:normalization_time_s]
-          expect(results[:performance][:result_count]).to eq 3
           expect(results[:results].count).to eq 3
         end
       end

--- a/spec/services/linked_data/performance_data_service_spec.rb
+++ b/spec/services/linked_data/performance_data_service_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe Qa::LinkedData::PerformanceDataService do
+  let(:request) { double }
+
+  describe '.performance_data' do
+    context 'when all data passed in' do
+      let(:access_time_s) { 0.5 }
+      let(:normalize_time_s) { 0.3 }
+      let(:fetched_size) { 11 }
+      let(:normalized_size) { 8 }
+      it 'uses passed in params' do
+        expected_results =
+          {
+            fetch_time_s: access_time_s,
+            normalization_time_s: normalize_time_s,
+            fetched_bytes: fetched_size,
+            normalized_bytes: normalized_size,
+            fetch_bytes_per_s: (fetched_size / access_time_s),
+            normalization_bytes_per_s: (normalized_size / normalize_time_s),
+            total_time_s: (access_time_s + normalize_time_s)
+          }
+        expect(described_class.performance_data(access_time_s: access_time_s, normalize_time_s: normalize_time_s, fetched_size: fetched_size, normalized_size: normalized_size)).to eq expected_results
+      end
+    end
+  end
+end

--- a/spec/services/linked_data/request_header_service_spec.rb
+++ b/spec/services/linked_data/request_header_service_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Qa::LinkedData::RequestHeaderService do
             subauthority: 'person',
             user_language: ['sp']
           }
-        expect(described_class.new(request, search_params).search_header).to eq expected_results
+        expect(described_class.new(request: request, params: search_params).search_header).to eq expected_results
       end
     end
 
@@ -41,7 +41,7 @@ RSpec.describe Qa::LinkedData::RequestHeaderService do
               subauthority: nil,
               user_language: nil
             }
-          expect(described_class.new(request, {}).search_header).to eq expected_results
+          expect(described_class.new(request: request, params: {}).search_header).to eq expected_results
         end
       end
 
@@ -56,7 +56,7 @@ RSpec.describe Qa::LinkedData::RequestHeaderService do
               subauthority: nil,
               user_language: ['de']
             }
-          expect(described_class.new(request, {}).search_header).to eq expected_results
+          expect(described_class.new(request: request, params: {}).search_header).to eq expected_results
         end
       end
     end
@@ -85,7 +85,7 @@ RSpec.describe Qa::LinkedData::RequestHeaderService do
             subauthority: 'person',
             user_language: ['sp']
           }
-        expect(described_class.new(request, fetch_params).fetch_header).to eq expected_results
+        expect(described_class.new(request: request, params: fetch_params).fetch_header).to eq expected_results
       end
     end
 
@@ -101,7 +101,7 @@ RSpec.describe Qa::LinkedData::RequestHeaderService do
               subauthority: nil,
               user_language: nil
             }
-          expect(described_class.new(request, {}).fetch_header).to eq expected_results
+          expect(described_class.new(request: request, params: {}).fetch_header).to eq expected_results
         end
       end
 
@@ -116,7 +116,7 @@ RSpec.describe Qa::LinkedData::RequestHeaderService do
               subauthority: nil,
               user_language: ['de']
             }
-          expect(described_class.new(request, {}).fetch_header).to eq expected_results
+          expect(described_class.new(request: request, params: {}).fetch_header).to eq expected_results
         end
       end
     end


### PR DESCRIPTION
Search queries and term fetch requests have the option to return performance data.  This applies to the linked data module.  Previously that output was generated in the SearchQuery class and separately in the FindTerm class.  The output generation process was moved to a service that both these classes now use.

Related work #281