### PR TITLE
use response.media_type instead of .content_type in tests

### DIFF
--- a/spec/controllers/linked_data_terms_controller_spec.rb
+++ b/spec/controllers/linked_data_terms_controller_spec.rb
@@ -403,14 +403,14 @@ describe Qa::LinkedDataTermsController, type: :controller do
         it 'succeeds and defaults to json content type' do
           get :show, params: { id: '530369', vocab: 'OCLC_FAST' }
           expect(response).to be_successful
-          expect(response.content_type).to eq 'application/json'
+          expect(response.media_type).to eq 'application/json'
         end
 
         context 'and it was requested as json' do
           it 'succeeds and returns term data as json content type' do
             get :show, params: { id: '530369', vocab: 'OCLC_FAST', format: 'json' }
             expect(response).to be_successful
-            expect(response.content_type).to eq 'application/json'
+            expect(response.media_type).to eq 'application/json'
           end
         end
 
@@ -418,7 +418,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
           it 'succeeds and returns term data as jsonld content type' do
             get :show, params: { id: '530369', vocab: 'OCLC_FAST', format: 'jsonld' }
             expect(response).to be_successful
-            expect(response.content_type).to eq 'application/ld+json'
+            expect(response.media_type).to eq 'application/ld+json'
             expect(JSON.parse(response.body).keys).to match_array ["@context", "@graph"]
           end
         end
@@ -427,7 +427,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
           it 'succeeds and returns term data as n3 content type' do
             get :show, params: { id: '530369', vocab: 'OCLC_FAST', format: 'n3' }
             expect(response).to be_successful
-            expect(response.content_type).to eq 'text/n3'
+            expect(response.media_type).to eq 'text/n3'
             expect(response.body).to start_with "@prefix"
           end
         end
@@ -436,7 +436,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
           it 'succeeds and returns term data as ntriples content type' do
             get :show, params: { id: '530369', vocab: 'OCLC_FAST', format: 'ntriples' }
             expect(response).to be_successful
-            expect(response.content_type).to eq 'application/n-triples'
+            expect(response.media_type).to eq 'application/n-triples'
             expect(response.body).to include('<http://id.worldcat.org/fast/530369> <http://www.w3.org/2004/02/skos/core#prefLabel> "Cornell University"')
           end
         end
@@ -476,7 +476,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
         it 'succeeds and defaults to json content type' do
           get :show, params: { id: 'sh 85118553', vocab: 'LOC', subauthority: 'subjects' }
           expect(response).to be_successful
-          expect(response.content_type).to eq 'application/json'
+          expect(response.media_type).to eq 'application/json'
         end
       end
     end
@@ -578,14 +578,14 @@ describe Qa::LinkedDataTermsController, type: :controller do
         it 'succeeds and defaults to json content type' do
           get :fetch, params: { uri: 'http://id.worldcat.org/fast/530369', vocab: 'LOD_TERM_URI_PARAM_CONFIG' }
           expect(response).to be_successful
-          expect(response.content_type).to eq 'application/json'
+          expect(response.media_type).to eq 'application/json'
         end
 
         context 'and it was requested as json' do
           it 'succeeds and returns term data as json content type' do
             get :fetch, params: { uri: 'http://id.worldcat.org/fast/530369', vocab: 'LOD_TERM_URI_PARAM_CONFIG', format: 'json' }
             expect(response).to be_successful
-            expect(response.content_type).to eq 'application/json'
+            expect(response.media_type).to eq 'application/json'
           end
         end
 
@@ -593,7 +593,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
           it 'succeeds and returns term data as jsonld content type' do
             get :fetch, params: { uri: 'http://id.worldcat.org/fast/530369', vocab: 'LOD_TERM_URI_PARAM_CONFIG', format: 'jsonld' }
             expect(response).to be_successful
-            expect(response.content_type).to eq 'application/ld+json'
+            expect(response.media_type).to eq 'application/ld+json'
             expect(JSON.parse(response.body).keys).to match_array ["@context", "@graph"]
           end
         end
@@ -602,7 +602,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
           it 'succeeds and returns term data as n3 content type' do
             get :fetch, params: { uri: 'http://id.worldcat.org/fast/530369', vocab: 'LOD_TERM_URI_PARAM_CONFIG', format: 'n3' }
             expect(response).to be_successful
-            expect(response.content_type).to eq 'text/n3'
+            expect(response.media_type).to eq 'text/n3'
             expect(response.body).to start_with "@prefix"
           end
         end
@@ -611,7 +611,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
           it 'succeeds and returns term data as ntriples content type' do
             get :fetch, params: { uri: 'http://id.worldcat.org/fast/530369', vocab: 'LOD_TERM_URI_PARAM_CONFIG', format: 'ntriples' }
             expect(response).to be_successful
-            expect(response.content_type).to eq 'application/n-triples'
+            expect(response.media_type).to eq 'application/n-triples'
             expect(response.body).to include('<http://id.worldcat.org/fast/530369> <http://www.w3.org/2004/02/skos/core#prefLabel> "Cornell University"')
           end
         end

--- a/spec/controllers/terms_controller_spec.rb
+++ b/spec/controllers/terms_controller_spec.rb
@@ -236,7 +236,7 @@ describe Qa::TermsController, type: :controller do
       it 'Access-Control-Allow-Origin is not present' do
         get :show, params: { vocab: "discogs", subauthority: "release", id: "3380671", format: 'n3' }
         expect(response).to be_successful
-        expect(response.content_type).to eq 'text/n3'
+        expect(response.media_type).to eq 'text/n3'
         expect(response.body).to start_with "@prefix"
       end
     end
@@ -248,7 +248,7 @@ describe Qa::TermsController, type: :controller do
       it 'Access-Control-Allow-Origin is not present' do
         get :show, params: { vocab: "discogs", subauthority: "release", id: "3380671", format: 'ntriples' }
         expect(response).to be_successful
-        expect(response.content_type).to eq 'application/n-triples'
+        expect(response.media_type).to eq 'application/n-triples'
         expect(response.body).to include('_:agentn1 <http://www.w3.org/2000/01/rdf-schema#label> "Dexter Gordon"')
       end
     end


### PR DESCRIPTION
Preparing for Rails6. In Rails6, response.content_type includes entire content type header, like 'application/n-triples; charset=utf-8' when previously it was just application/n-triples, which is what tests are expecting. This is only a change to test code, not actual code under test, to make tests test the right thing under a future Rails 6.0.

https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#actiondispatch-response-content-type-now-returned-content-type-header-as-it-is
https://github.com/samvera/questioning_authority/pull/291
https://circleci.com/gh/samvera/questioning_authority/1295