### PR TITLE
use new index_name_exists? method signature if rails6 too

### DIFF
--- a/lib/qa/authorities/local/mysql_table_based_authority.rb
+++ b/lib/qa/authorities/local/mysql_table_based_authority.rb
@@ -21,7 +21,7 @@ module Qa
 
         def self.index_name_exists?
           conn = ActiveRecord::Base.connection
-          if ActiveRecord::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 1
+          if (ActiveRecord::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR >= 1) || ActiveRecord::VERSION::MAJOR >= 6
             conn.index_name_exists?(table_name, table_index).blank?
           else
             conn.index_name_exists?(table_name, table_index, :default).blank?


### PR DESCRIPTION
Preparing for Rails 6.
https://github.com/samvera/questioning_authority/pull/291

qa gemspec still allows rails 5.0, so we will leave the "else" condition for rails 5.0 there (although rails 5.0 makes the third param optional and may work without it too, if it ain't broke why fix it).