### PR TITLE
Update Geonames URIs to https

### DIFF
--- a/lib/qa/authorities/geonames.rb
+++ b/lib/qa/authorities/geonames.rb
@@ -39,7 +39,7 @@ module Qa::Authorities
       def parse_authority_response(response)
         response['geonames'].map do |result|
           # Note: the trailing slash is meaningful.
-          { 'id' => "http://sws.geonames.org/#{result['geonameId']}/",
+          { 'id' => "https://sws.geonames.org/#{result['geonameId']}/",
             'label' => label.call(result) }
         end
       end

--- a/spec/lib/authorities/geonames_spec.rb
+++ b/spec/lib/authorities/geonames_spec.rb
@@ -28,9 +28,9 @@ describe Qa::Authorities::Geonames do
 
       context "with default label" do
         it "has id and label keys" do
-          expect(subject.first).to eq("id" => 'http://sws.geonames.org/2088122/',
+          expect(subject.first).to eq("id" => 'https://sws.geonames.org/2088122/',
                                       "label" => "Port Moresby, National Capital, Papua New Guinea")
-          expect(subject.last).to eq("id" => 'http://sws.geonames.org/377039/',
+          expect(subject.last).to eq("id" => 'https://sws.geonames.org/377039/',
                                      "label" => "Port Sudan, Red Sea, Sudan")
           expect(subject.size).to eq(10)
         end


### PR DESCRIPTION
Geonames now uses HTTPS URIs for its resources. Since QA constructs the URIs
from JSON ids manually, it missed this change. The update fixes subject
mismatches for clients.

Fixes #306.