### PR TITLE
Updating Rails development dependency

### DIFF
--- a/qa.gemspec
+++ b/qa.gemspec
@@ -22,11 +22,12 @@ Gem::Specification.new do |s|
   s.add_dependency 'geocoder'
   s.add_dependency 'ldpath'
   s.add_dependency 'nokogiri', '~> 1.6'
-  s.add_dependency 'rails', '>= 5.0', "< 6.1"
+  s.add_dependency 'rails', '>=5.0', "< 6.1"
   s.add_dependency 'rdf'
 
   # the hyrax style guide is based on `bixby`. see `.rubocop.yml`
   s.add_development_dependency 'bixby', '~> 1.0.0'
+  s.add_development_dependency 'rails', '!=5.2.0', '!=5.2.1', '!=5.2.2'
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'engine_cart', '~> 2.0'
   s.add_development_dependency 'linkeddata'


### PR DESCRIPTION
Prior to this commit, when running the EngineCart build task locally,
I encountered the following error:

```console
Could not find "README.md" in any of your source paths. Your current source paths are:

$HOME/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/railties-5.2.0/lib/rails/generators/rails/app/templates
```

With some poking around, I found the following:

> You may be using rails 5.2.0. Upgrading to 5.2.3 or later solves the problem.
>
> https://www.robotex.de/de/tags/dummy-app

With this commit, I'm still allowing upstream implementers to use Rails 5.2.0,
however, building the test app requires the generators to better behave. This
should have no impact on existing implementations.