### PR TITLE
Changes LoC authorities to use https

### DIFF
--- a/lib/qa/authorities/loc/generic_authority.rb
+++ b/lib/qa/authorities/loc/generic_authority.rb
@@ -26,7 +26,7 @@ module Qa::Authorities
     def build_query_url(q)
       escaped_query = ERB::Util.url_encode(q)
       authority_fragment = Loc.get_url_for_authority(subauthority) + ERB::Util.url_encode(subauthority)
-      "http://id.loc.gov/search/?q=#{escaped_query}&q=#{authority_fragment}&format=json"
+      "https://id.loc.gov/search/?q=#{escaped_query}&q=#{authority_fragment}&format=json"
     end
 
     def find(id)
@@ -34,7 +34,7 @@ module Qa::Authorities
     end
 
     def find_url(id)
-      "http://id.loc.gov/authorities/#{@subauthority}/#{id}.json"
+      "https://id.loc.gov/authorities/#{@subauthority}/#{id}.json"
     end
 
     private

--- a/lib/qa/authorities/loc_subauthority.rb
+++ b/lib/qa/authorities/loc_subauthority.rb
@@ -70,18 +70,18 @@ module Qa::Authorities::LocSubauthority
   private
 
     def vocab_base_url
-      "cs%3Ahttp%3A%2F%2Fid.loc.gov%2Fvocabulary%2F"
+      "cs%3Ahttps%3A%2F%2Fid.loc.gov%2Fvocabulary%2F"
     end
 
     def authority_base_url
-      "cs%3Ahttp%3A%2F%2Fid.loc.gov%2Fauthorities%2F"
+      "cs%3Ahttps%3A%2F%2Fid.loc.gov%2Fauthorities%2F"
     end
 
     def datatype_base_url
-      "cs%3Ahttp%3A%2F%2Fid.loc.gov%2Fdatatypes%2F"
+      "cs%3Ahttps%3A%2F%2Fid.loc.gov%2Fdatatypes%2F"
     end
 
     def vocab_preservation_base_url
-      "cs%3Ahttp%3A%2F%2Fid.loc.gov%2Fvocabulary%2Fpreservation%2F"
+      "cs%3Ahttps%3A%2F%2Fid.loc.gov%2Fvocabulary%2Fpreservation%2F"
     end
 end

--- a/spec/controllers/terms_controller_spec.rb
+++ b/spec/controllers/terms_controller_spec.rb
@@ -82,7 +82,7 @@ describe Qa::TermsController, type: :controller do
 
     context "loc" do
       before do
-        stub_request(:get, "http://id.loc.gov/search/?format=json&q=Berry&q=cs:http://id.loc.gov/authorities/names")
+        stub_request(:get, "https://id.loc.gov/search/?format=json&q=Berry&q=cs:https://id.loc.gov/authorities/names")
           .with(headers: { 'Accept' => 'application/json' })
           .to_return(body: webmock_fixture("loc-names-response.txt"), status: 200)
       end
@@ -188,7 +188,7 @@ describe Qa::TermsController, type: :controller do
   describe "#show" do
     context "with supported authorities" do
       before do
-        stub_request(:get, "http://id.loc.gov/authorities/subjects/sh85077565.json")
+        stub_request(:get, "https://id.loc.gov/authorities/subjects/sh85077565.json")
           .with(headers: { 'Accept' => 'application/json' })
           .to_return(status: 200, body: webmock_fixture("loc-names-response.txt"), headers: {})
       end

--- a/spec/lib/authorities/loc_spec.rb
+++ b/spec/lib/authorities/loc_spec.rb
@@ -28,14 +28,14 @@ describe Qa::Authorities::Loc do
     end
 
     context "for searching" do
-      let(:url) { 'http://id.loc.gov/search/?q=foo&q=cs%3Ahttp%3A%2F%2Fid.loc.gov%2Fauthorities%2Fsubjects&format=json' }
+      let(:url) { 'https://id.loc.gov/search/?q=foo&q=cs%3Ahttps%3A%2F%2Fid.loc.gov%2Fauthorities%2Fsubjects&format=json' }
       it "returns a url" do
         expect(authority.build_query_url("foo")).to eq(url)
       end
     end
 
     context "for returning single terms" do
-      let(:url) { "http://id.loc.gov/authorities/subjects/sh2002003586.json" }
+      let(:url) { "https://id.loc.gov/authorities/subjects/sh2002003586.json" }
       it "returns a url with an authority and id" do
         expect(authority.find_url("sh2002003586")).to eq(url)
       end
@@ -49,15 +49,15 @@ describe Qa::Authorities::Loc do
     end
 
     before do
-      stub_request(:get, "http://id.loc.gov/search/?format=json&q=cs:http://id.loc.gov/authorities/subjects")
+      stub_request(:get, "https://id.loc.gov/search/?format=json&q=cs:https://id.loc.gov/authorities/subjects")
         .with(headers: { 'Accept' => 'application/json' })
         .to_return(status: 200, body: "")
     end
 
     context "with flat params encoded" do
-      let(:url) { 'http://id.loc.gov/search/?q=foo&q=cs%3Ahttp%3A%2F%2Fid.loc.gov%2Fauthorities%2Fsubjects&format=json' }
+      let(:url) { 'https://id.loc.gov/search/?q=foo&q=cs%3Ahttps%3A%2F%2Fid.loc.gov%2Fauthorities%2Fsubjects&format=json' }
       it "returns a response" do
-        flat_params_url = "http://id.loc.gov/search/?format=json&q=foo&q=cs%3Ahttp%3A%2F%2Fid.loc.gov%2Fauthorities%2Fsubjects"
+        flat_params_url = "https://id.loc.gov/search/?format=json&q=foo&q=cs%3Ahttps%3A%2F%2Fid.loc.gov%2Fauthorities%2Fsubjects"
         expect(subject.env.url.to_s).to eq(flat_params_url)
       end
     end
@@ -66,7 +66,7 @@ describe Qa::Authorities::Loc do
   describe "#search" do
     context "any LOC authorities" do
       let :authority do
-        stub_request(:get, "http://id.loc.gov/search/?format=json&q=s&q=cs:http://id.loc.gov/vocabulary/geographicAreas")
+        stub_request(:get, "https://id.loc.gov/search/?format=json&q=s&q=cs:https://id.loc.gov/vocabulary/geographicAreas")
           .with(headers: { 'Accept' => 'application/json' })
           .to_return(body: webmock_fixture("loc-response.txt"), status: 200)
         described_class.subauthority_for("geographicAreas")
@@ -95,7 +95,7 @@ describe Qa::Authorities::Loc do
 
     context "subject terms" do
       let :results do
-        stub_request(:get, "http://id.loc.gov/search/?format=json&q=History--&q=cs:http://id.loc.gov/authorities/subjects")
+        stub_request(:get, "https://id.loc.gov/search/?format=json&q=History--&q=cs:https://id.loc.gov/authorities/subjects")
           .with(headers: { 'Accept' => 'application/json' })
           .to_return(body: webmock_fixture("loc-subjects-response.txt"), status: 200)
         described_class.subauthority_for("subjects").search("History--")
@@ -111,7 +111,7 @@ describe Qa::Authorities::Loc do
 
     context "name terms" do
       let :results do
-        stub_request(:get, "http://id.loc.gov/search/?format=json&q=Berry&q=cs:http://id.loc.gov/authorities/names")
+        stub_request(:get, "https://id.loc.gov/search/?format=json&q=Berry&q=cs:https://id.loc.gov/authorities/names")
           .with(headers: { 'Accept' => 'application/json' })
           .to_return(body: webmock_fixture("loc-names-response.txt"), status: 200)
         described_class.subauthority_for("names").search("Berry")
@@ -125,7 +125,7 @@ describe Qa::Authorities::Loc do
   describe "#find" do
     context "using a subject id" do
       let :results do
-        stub_request(:get, "http://id.loc.gov/authorities/subjects/sh2002003586.json")
+        stub_request(:get, "https://id.loc.gov/authorities/subjects/sh2002003586.json")
           .with(headers: { 'Accept' => 'application/json' })
           .to_return(status: 200, body: webmock_fixture("loc-subject-find-response.txt"), headers: {})
         described_class.subauthority_for("subjects").find("sh2002003586")


### PR DESCRIPTION
Fixes #320

LoC is now redirecting `http` requests to `https`, and QA is not following redirects, so applications would see HTTP 500 errors, because the response would not parse as JSON. This commit fixes that issue by changing all the LoC urls to use `https`.