### PR TITLE
encode query for linked data access to OCLC FAST

### DIFF
--- a/config/authorities/linked_data/oclc_fast.json
+++ b/config/authorities/linked_data/oclc_fast.json
@@ -2,14 +2,13 @@
   "QA_CONFIG_VERSION": "2.1",
   "prefixes": {
     "dcterms": "http://purl.org/dc/terms/",
-    "skos": "http://www.w3.org/2004/02/skos/core#",
-    "schema": "http://schema.org/"
+    "schema":  "http://schema.org/"
   },
   "term": {
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type":    "IriTemplate",
-      "template": "http://id.worldcat.org/fast/{term_id}",
+      "template": "http://id.worldcat.org/fast/{term_id}.rdf.xml",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -35,14 +34,15 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type": "IriTemplate",
-      "template": "http://experimental.worldcat.org/fast/search?query={subauth}+all+%22{query}%22&sortKeys=usage&{?maximumRecords}",
+      "template": "http://experimental.worldcat.org/fast/search?query={subauth}+all+%22{query}%22&sortKeys=usage&maximumRecords={maximumRecords}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
           "@type": "IriTemplateMapping",
           "variable": "query",
           "property": "hydra:freetextQuery",
-          "required": true
+          "required": true,
+          "encode": true
         },
         {
           "@type": "IriTemplateMapping",

--- a/spec/controllers/linked_data_terms_controller_spec.rb
+++ b/spec/controllers/linked_data_terms_controller_spec.rb
@@ -357,7 +357,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
     context 'producing internal server error' do
       context 'when server returns 500' do
         before do
-          stub_request(:get, 'http://id.worldcat.org/fast/530369').to_return(status: 500)
+          stub_request(:get, 'http://id.worldcat.org/fast/530369.rdf.xml').to_return(status: 500)
         end
         it 'returns 500' do
           expect(Rails.logger).to receive(:warn).with(graph_load_failure)
@@ -369,7 +369,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
 
       context 'when data normalization error' do
         before do
-          stub_request(:get, 'http://id.worldcat.org/fast/530369')
+          stub_request(:get, 'http://id.worldcat.org/fast/530369.rdf.xml')
             .to_return(status: 200, body: webmock_fixture('lod_oclc_term_bad_id.nt'), headers: { 'Content-Type' => 'application/ntriples' })
         end
         it 'returns 500' do
@@ -381,7 +381,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
 
       context 'when rdf format error' do
         before do
-          stub_request(:get, 'http://id.worldcat.org/fast/530369').to_return(status: 200)
+          stub_request(:get, 'http://id.worldcat.org/fast/530369.rdf.xml').to_return(status: 200)
           allow(RDF::Graph).to receive(:load).and_raise(RDF::FormatError)
         end
         it 'returns 500' do
@@ -395,7 +395,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
 
       context "when error isn't specifically handled" do
         before do
-          stub_request(:get, 'http://id.worldcat.org/fast/530369').to_return(status: 501)
+          stub_request(:get, 'http://id.worldcat.org/fast/530369.rdf.xml').to_return(status: 501)
         end
         it 'returns 500' do
           expect(Rails.logger).to receive(:warn).with(graph_load_failure)
@@ -408,7 +408,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
 
     context 'when service unavailable' do
       before do
-        stub_request(:get, 'http://id.worldcat.org/fast/530369').to_return(status: 503)
+        stub_request(:get, 'http://id.worldcat.org/fast/530369.rdf.xml').to_return(status: 503)
       end
       it 'returns 503' do
         expect(Rails.logger).to receive(:warn).with(graph_load_failure)
@@ -420,7 +420,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
 
     context 'when requested term is not found at the server' do
       before do
-        stub_request(:get, 'http://id.worldcat.org/fast/FAKE_ID').to_return(status: 404, body: '', headers: {})
+        stub_request(:get, 'http://id.worldcat.org/fast/FAKE_ID.rdf.xml').to_return(status: 404, body: '', headers: {})
       end
       it 'returns 404' do
         expect(Rails.logger).to receive(:warn).with(graph_load_failure)
@@ -433,7 +433,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
     context 'in OCLC_FAST authority' do
       context 'term found' do
         before do
-          stub_request(:get, 'http://id.worldcat.org/fast/530369')
+          stub_request(:get, 'http://id.worldcat.org/fast/530369.rdf.xml')
             .to_return(status: 200, body: webmock_fixture('lod_oclc_term_found.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
         end
         it 'succeeds and defaults to json content type' do
@@ -481,7 +481,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
       context 'when cors headers are enabled' do
         before do
           Qa.config.enable_cors_headers
-          stub_request(:get, 'http://id.worldcat.org/fast/530369')
+          stub_request(:get, 'http://id.worldcat.org/fast/530369.rdf.xml')
             .to_return(status: 200, body: webmock_fixture('lod_oclc_term_found.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
         end
         it 'Access-Control-Allow-Origin is *' do
@@ -493,7 +493,7 @@ describe Qa::LinkedDataTermsController, type: :controller do
       context 'when cors headers are disabled' do
         before do
           Qa.config.disable_cors_headers
-          stub_request(:get, 'http://id.worldcat.org/fast/530369')
+          stub_request(:get, 'http://id.worldcat.org/fast/530369.rdf.xml')
             .to_return(status: 200, body: webmock_fixture('lod_oclc_term_found.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
         end
         it 'Access-Control-Allow-Origin is not present' do

--- a/spec/lib/authorities/linked_data/find_term_spec.rb
+++ b/spec/lib/authorities/linked_data/find_term_spec.rb
@@ -8,18 +8,18 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
     context 'basic parameter testing' do
       context 'with bad id' do
         before do
-          stub_request(:get, 'http://id.worldcat.org/fast/FAKE_ID')
+          stub_request(:get, 'http://id.worldcat.org/fast/FAKE_ID.rdf.xml')
             .to_return(status: 404, body: '', headers: {})
         end
         it 'raises a TermNotFound exception' do
-          expect { lod_oclc.find('FAKE_ID') }.to raise_error Qa::TermNotFound, /.*\/FAKE_ID\ Not Found - Term may not exist at LOD Authority./
+          expect { lod_oclc.find('FAKE_ID') }.to raise_error Qa::TermNotFound, /.*\/FAKE_ID.rdf.xml\ Not Found - Term may not exist at LOD Authority./
         end
       end
     end
 
     context 'performance stats' do
       before do
-        stub_request(:get, 'http://id.worldcat.org/fast/530369')
+        stub_request(:get, 'http://id.worldcat.org/fast/530369.rdf.xml')
           .to_return(status: 200, body: webmock_fixture('lod_oclc_term_found.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
       end
       context 'when set to true' do
@@ -55,7 +55,7 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
 
     context 'response header' do
       before do
-        stub_request(:get, 'http://id.worldcat.org/fast/530369')
+        stub_request(:get, 'http://id.worldcat.org/fast/530369.rdf.xml')
           .to_return(status: 200, body: webmock_fixture('lod_oclc_term_found.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
       end
       context 'when set to true' do
@@ -91,7 +91,7 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
     context 'in OCLC_FAST authority' do
       context 'term found' do
         let :results do
-          stub_request(:get, 'http://id.worldcat.org/fast/530369')
+          stub_request(:get, 'http://id.worldcat.org/fast/530369.rdf.xml')
             .to_return(status: 200, body: webmock_fixture('lod_oclc_term_found.rdf.xml'), headers: { 'Content-Type' => 'application/rdf+xml' })
           lod_oclc.find('530369')
         end
@@ -128,7 +128,7 @@ RSpec.describe Qa::Authorities::LinkedData::FindTerm do
 
         context "ID in graph doesn't match ID in request URI" do
           before do
-            stub_request(:get, 'http://id.worldcat.org/fast/530369')
+            stub_request(:get, 'http://id.worldcat.org/fast/530369.rdf.xml')
               .to_return(status: 200, body: webmock_fixture('lod_oclc_term_bad_id.nt'), headers: { 'Content-Type' => 'application/ntriples' })
           end
 

--- a/spec/services/linked_data/authority_url_service_spec.rb
+++ b/spec/services/linked_data/authority_url_service_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Qa::LinkedData::AuthorityUrlService do
           let(:action_request) { 'mark twain' }
 
           it 'returns template with substitutions' do
-            expected_url = 'http://experimental.worldcat.org/fast/search?query=oclc.personalName+all+%22mark twain%22&sortKeys=usage&maximumRecords=10'
+            expected_url = 'http://experimental.worldcat.org/fast/search?query=oclc.personalName+all+%22mark%20twain%22&sortKeys=usage&maximumRecords=10'
             expect(subject).to eq expected_url
           end
         end
@@ -92,7 +92,7 @@ RSpec.describe Qa::LinkedData::AuthorityUrlService do
           let(:action_request) { 'mark twain' }
 
           it 'returns template with substitutions' do
-            expected_url = 'http://experimental.worldcat.org/fast/search?query=cql.any+all+%22mark twain%22&sortKeys=usage&maximumRecords=20'
+            expected_url = 'http://experimental.worldcat.org/fast/search?query=cql.any+all+%22mark%20twain%22&sortKeys=usage&maximumRecords=20'
             expect(subject).to eq expected_url
           end
         end
@@ -104,7 +104,7 @@ RSpec.describe Qa::LinkedData::AuthorityUrlService do
         let(:action_request) { 'n79021164' }
 
         it 'returns template with substitutions' do
-          expected_url = 'http://id.worldcat.org/fast/n79021164'
+          expected_url = 'http://id.worldcat.org/fast/n79021164.rdf.xml'
           expect(subject).to eq expected_url
         end
       end


### PR DESCRIPTION
Fixes #327 

Encoding the query before passing it to OCLC FAST avoids the timeout.  There are a few other changes that bring the config in line with changes in other configs.  These are annotated in the code view of the PR.

@samvera/hyrax-code-reviewers