### PR TITLE
do not overwrite passed in replacements hash

### DIFF
--- a/app/services/qa/linked_data/authority_url_service.rb
+++ b/app/services/qa/linked_data/authority_url_service.rb
@@ -29,7 +29,7 @@ module Qa
           end
 
           def combined_substitutions(action_config, action, action_request, request_header)
-            substitutions = request_header.fetch(:replacements, {})
+            substitutions = request_header.fetch(:replacements, {}).clone
             substitutions[action_request_variable(action_config, action)] = action_request
             substitutions[action_subauth_variable(action_config)] = action_subauth_variable_value(action_config, request_header)
             substitutions[action_language_variable(action_config)] = language_value(action_config, request_header)

--- a/spec/services/linked_data/authority_url_service_spec.rb
+++ b/spec/services/linked_data/authority_url_service_spec.rb
@@ -86,6 +86,12 @@ RSpec.describe Qa::LinkedData::AuthorityUrlService do
             expected_url = 'http://experimental.worldcat.org/fast/search?query=oclc.personalName+all+%22mark twain%22&sortKeys=usage&maximumRecords=10'
             expect(subject).to eq expected_url
           end
+
+          it 'does not mutate substitutions hash' do
+            before_substitutions = substitutions.clone
+            subject
+            expect(substitutions).to eq before_substitutions
+          end
         end
 
         context 'when no substitutions specified' do


### PR DESCRIPTION
Fixes 326

LinkedData::AuthorityUrlService #combined_substitutions updated the passed in replacements hash.  It now clones the hash to avoid having this side-effect.

NOTE: The new test fails without the fix in place.

@samvera/hyrax-code-reviewers
