### PR TITLE
allow rails 6.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,10 @@ workflows:
   ci:
     jobs:
       - bundle_and_test:
+          name: "ruby2-7_rails6-1"
+          ruby_version: 2.7.2
+          rails_version: 6.1.1
+      - bundle_and_test:
           name: "ruby2-7_rails6-0"
           ruby_version: 2.7.0
           rails_version: 6.0.2

--- a/qa.gemspec
+++ b/qa.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'geocoder'
   s.add_dependency 'ldpath'
   s.add_dependency 'nokogiri', '~> 1.6'
-  s.add_dependency 'rails', '>=5.0', "< 6.1"
+  s.add_dependency 'rails', '>=5.0', "< 6.2"
   s.add_dependency 'rdf'
 
   # the hyrax style guide is based on `bixby`. see `.rubocop.yml`


### PR DESCRIPTION
This PR does nothing except change the gemspec to allow Rails 6.1. Curious if CI will pass like this?

I am unable to run tests locally per #331, so this is a way to see if CI will run tests for me to see what happens, sorry. 

Closes #330