### PR TITLE
prevent master branch; provide info on branch naming in README

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,16 @@ jobs:
     steps:
       - samvera/cached_checkout
 
+      - run:
+          name: Check for a branch named 'master'
+          command: |
+            git fetch --all --quiet --prune --prune-tags
+            if [[ -n "$(git branch --all --list master */master)" ]]; then
+              echo "A branch named 'master' was found. Please remove it."
+              echo "$(git branch --all --list master */master)"
+            fi
+            [[ -z "$(git branch --all --list master */master)" ]]
+
       - samvera/bundle_for_gem:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>

--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ rake ci
 
 Commit your features into a new branch and submit a pull request.
 
+## Contributing 
+
+If you're working on PR for this project, create a feature branch off of `main`. 
+
+This repository follows the [Samvera Community Code of Conduct](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405212316/Code+of+Conduct) and [language recommendations](https://github.com/samvera/maintenance/blob/master/templates/CONTRIBUTING.md#language).  Please ***do not*** create a branch called `master` for this repository or as part of your pull request; the branch will either need to be removed or renamed before it can be considered for inclusion in the code base and history of this repository.
+
 ## Compatibility
 
 - Ruby 2.5 or the latest 2.4 version is recommended. Later versions may also work.


### PR DESCRIPTION

Adds Circle CI step that fails if branch name is master
Fixes #336

Adds information for branch naming conventions to contributing section of the README.
Fixes #337