### PR TITLE
add fetch action allowing for uri parameter

### DIFF
--- a/app/controllers/qa/terms_controller.rb
+++ b/app/controllers/qa/terms_controller.rb
@@ -27,8 +27,17 @@ class Qa::TermsController < ::ApplicationController
   end
 
   # If the subauthority supports it, return all the information for a given term
+  # Expects id to be part of the request path (e.g. http://my.app/qa/show/auth/subauth/{:id})
   def show
     term = @authority.method(:find).arity == 2 ? @authority.find(params[:id], self) : @authority.find(params[:id])
+    cors_allow_origin_header(response)
+    render json: term, content_type: content_type_for_format
+  end
+
+  # If the subauthority supports it, return all the information for a given term
+  # Expects uri to be a request parameter (e.g. http://my.app/qa/show/auth/subauth?uri={:uri})
+  def fetch
+    term = @authority.method(:find).arity == 2 ? @authority.find(params[:uri], self) : @authority.find(params[:uri])
     cors_allow_origin_header(response)
     render json: term, content_type: content_type_for_format
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Qa::Engine.routes.draw do
   get "/search/:vocab(/:subauthority)", controller: :terms, action: :search
   get "/show/:vocab/:id", controller: :terms, action: :show
   get "/show/:vocab/:subauthority/:id", controller: :terms, action: :show
+  get "/fetch/:vocab", controller: :terms, action: :fetch
+  get "/fetch/:vocab/:subauthority", controller: :terms, action: :fetch
 
   match "/search/linked_data/:vocab(/:subauthority)", to: 'application#options', via: [:options]
   match "/show/linked_data/:vocab/:id", to: 'application#options', via: [:options]
@@ -17,4 +19,6 @@ Qa::Engine.routes.draw do
   match "/search/:vocab(/:subauthority)", to: 'application#options', via: [:options]
   match "/show/:vocab/:id", to: 'application#options', via: [:options]
   match "/show/:vocab/:subauthority/:id", to: 'application#options', via: [:options]
+  match "/fetch/:vocab", to: 'application#options', via: [:options]
+  match "/fetch/:vocab/:subauthority", to: 'application#options', via: [:options]
 end

--- a/spec/controllers/terms_controller_spec.rb
+++ b/spec/controllers/terms_controller_spec.rb
@@ -253,4 +253,33 @@ describe Qa::TermsController, type: :controller do
       end
     end
   end
+
+  describe "#fetch" do
+    context "with supported authorities" do
+      it "returns an individual state term" do
+        get :fetch, params: { vocab: "local", subauthority: "authority_U", uri: "http://my.domain/terms/a2" }
+        expect(response).to be_successful
+      end
+
+      context 'when cors headers are enabled' do
+        before do
+          Qa.config.enable_cors_headers
+        end
+        it 'Access-Control-Allow-Origin is *' do
+          get :fetch, params: { vocab: "local", subauthority: "authority_U", uri: "http://my.domain/terms/a2" }
+          expect(response.headers['Access-Control-Allow-Origin']).to eq '*'
+        end
+      end
+
+      context 'when cors headers are disabled' do
+        before do
+          Qa.config.disable_cors_headers
+        end
+        it 'Access-Control-Allow-Origin is not present' do
+          get :fetch, params: { vocab: "local", subauthority: "authority_U", uri: "http://my.domain/terms/a2" }
+          expect(response.headers.key?('Access-Control-Allow-Origin')).to be false
+        end
+      end
+    end
+  end
 end

--- a/spec/fixtures/authorities/authority_U.yml
+++ b/spec/fixtures/authorities/authority_U.yml
@@ -1,0 +1,13 @@
+:terms:
+    - :id: A1
+      :term: Abc Term A1
+      :uri: http://my.domain/terms/a1
+      :active: true
+    - :id: A2
+      :term: Term A2
+      :uri: http://my.domain/terms/a2
+      :active: false
+    - :id: A3
+      :term: Abc Term A3
+      :uri: http://my.domain/terms/a3
+      :active: true


### PR DESCRIPTION
Prior to this PR, the way to get the details of a term was to use the `show` action.  The term is identified by appending the term's id to the end of the URL request path in the form:

```
http://my.app/qa/show/vocab/123
```

This approach does not work for IDs that are URIs.  The slashes in the URI get interpreted as part of the path.  The introduction of the `fetch` action allows the URI to be passed in as a parameter instead of as part of the path.

```
http://my.app/qa/fetch/vocab?uri=http://my.vocab/terms/123
```

_NOTE: The linked data module already uses `fetch` to pass in a URI since almost all IDs are URIs._