### PR TITLE
pin Faraday gem to < 2.0

### DIFF
--- a/qa.gemspec
+++ b/qa.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activerecord-import'
   s.add_dependency 'deprecation'
-  s.add_dependency 'faraday'
+  s.add_dependency 'faraday', '< 2.0'
   s.add_dependency 'geocoder'
   s.add_dependency 'ldpath'
   s.add_dependency 'nokogiri', '~> 1.6'


### PR DESCRIPTION
Pinning Faraday to postpone upgrade to 2.0.  ActiveFedora currently pins to `’~> 0.12’` which is more strict, but compatible with the current pin in QA to `’< 2.0’`.

The 2.0 upgrade requires a configuration that is not supported in earlier versions.  See [upgrade doc](https://github.com/lostisland/faraday/blob/main/UPGRADING.md) for more information.