### PR TITLE
add pagination service and use it for yml file authorities

### DIFF
--- a/app/services/qa/pagination_service.rb
+++ b/app/services/qa/pagination_service.rb
@@ -1,0 +1,513 @@
+module Qa
+  # Provide pagination processing that authority modules can use to respond to
+  # requests for paginated results.
+  class PaginationService # rubocop:disable Metrics/ClassLength
+    # Default page_limit to use if not passed in with the request.
+    DEFAULT_PAGE_LIMIT = 10
+
+    # Error code for page_limit and page_offset when the value is not an integer.
+    ERROR_NOT_INTEGER = 901
+    # Error code for page_limit and page_offset when the value is below the acceptable range (e.g. < 1).
+    ERROR_OUT_OF_RANGE_TOO_SMALL = 902
+    # Error code for page_offset when the value is above the acceptable range (e.g. > total_num_found).
+    ERROR_OUT_OF_RANGE_TOO_LARGE = 903
+
+    # @param request [ActionDispatch::Request] The request from the controller.
+    #   To support pagination, it's params need to respond to:
+    #   * #page_offset [Integer] - the offset into the results for the start of the page (counts from 1; default: 1)
+    #   * #page_limit [Integer] - the max number of records to return in a page
+    #     * if not paginating, defaults to: all
+    #     * if `default_to_all_terms == true` AND neither page_offset nor page_limit are set, defaults to: all
+    #     * else defaults to: DEFAULT_PAGE_LIMIT
+    # @param results [Array<Hash>] results of a search query as processed by the authority module.
+    # @param format [String] - if present, supported values are [:json | :jsonapi]
+    #     * when :json, the response is an array of results
+    #     * when :json-api, the response follows the JSON API specification
+    #
+    # @see https://jsonapi.org/format/#fetching-pagination Pagination section of JSON API specification
+    # @see https://jsonapi.org/examples/#pagination JSON API example pagination
+    def initialize(request:, results:, format: :json)
+      @request = request
+      @results = results
+      @requested_format = format
+      @page_offset_error = false
+      @page_limit_error = false
+    end
+
+    # @return json results, optionally limited to requested page and optionally
+    #     formatted according to the JSON-API standard.  The default is to return
+    #     just the results for backward compatibility.  See examples.
+    #
+    # @example json without pagination (backward compatible)
+    #   # request: q=term
+    #   # response: format=json, no pagination, all results
+    #   [
+    #     { "id": "1", "label": "term 1" },
+    #     { "id": "2", "label": "term 2" },
+    #     ...
+    #     { "id": "28", "label": "term 28" }
+    #   ]
+    #
+    # @example json with pagination
+    #   # request: q=term, page_offset=3, page_limit=2
+    #   # response: format=json, paginated, results 3..4
+    #   [
+    #     { "id": "3", "label": "term 3" },
+    #     { "id": "4", "label": "term 4" }
+    #   ]
+    #
+    # @example json-api with pagination using default page_offset and page_limit
+    #   # request: q=term, format=json-api
+    #   # response: format=json-api, paginated, results 1..8
+    #   {
+    #     "data": [
+    #       { "id": "1", "label": "term 1" },
+    #       { "id": "2", "label": "term 2" },
+    #       ...
+    #       { "id": "8", "label": "term 8" }
+    #     ],
+    #     "meta": {
+    #       "page": {
+    #         "page_offset": "1",
+    #         "page_limit": "8",
+    #         "actual_page_size": "8",
+    #         "total_num_found": "28",
+    #       }
+    #     }
+    #     "links": {
+    #       "self_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=8&page_offset=1",
+    #       "first_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=8&page_offset=1",
+    #       "prev_url": nil,
+    #       "next_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=8&page_offset=9",
+    #       "last_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=8&page_offset=25"
+    #     }
+    #   }
+    #
+    # @example json-api with pagination for page_offset=7 and page_limit=2
+    #   # request: q=term, format=json-api, page_offset=7, page_limit=2
+    #   # response: format=json, paginated, results 7..8
+    #   {
+    #     "data": [
+    #       { "id": "7", "label": "term 7" },
+    #       { "id": "8", "label": "term 8" }
+    #     ],
+    #     "meta": {
+    #       "page": {
+    #         "page_offset": "7",
+    #         "page_limit": "2",
+    #         "actual_page_size": "2",
+    #         "total_num_found": "28",
+    #       }
+    #     }
+    #     "links": {
+    #       "self_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=2&page_offset=7",
+    #       "first_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=2&page_offset=1",
+    #       "prev_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=2&page_offset=5",
+    #       "next_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=2&page_offset=9",
+    #       "last_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=2&page_offset=27"
+    #     }
+    #   }
+    #
+    # @example json-api with page_offset and page_limit errors
+    #   # request: q=term, format=json-api, page_offset=0, page_limit=-1
+    #   # response: format=json-api, paginated, no results, errors
+    #   {
+    #     "data": [],
+    #     "meta": {
+    #       "page": {
+    #         "page_offset": "0",
+    #         "page_limit": "-1",
+    #         "actual_page_size": nil,
+    #         "total_num_found": "28",
+    #       }
+    #     }
+    #     "links": {
+    #       "self_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=-1&page_offset=0",
+    #       "first_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=8&page_offset=1",
+    #       "prev_url": nil,
+    #       "next_url": nil,
+    #       "last_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=8&page_offset=25"
+    #     }
+    #     "errors": [
+    #       {
+    #         "status" => "200",
+    #         "source" => { "page_offset" => "0" },
+    #         "title" => "Page Offset Out of Range",
+    #         "detail" => "Offset 0 < 1 (first result).  Returning empty results."
+    #       },
+    #       {
+    #         "status" => "200",
+    #         "source" => { "page_limit" => "-1" },
+    #         "title" => "Page Limit Out of Range",
+    #         "detail" => "Page limit -1 < 1 (minimum limit).  Returning empty results."
+    #
+    #       }
+    #     ]
+    #   }
+    #
+    # @see DEFAULT_PAGE_LIMIT
+    # @see ERROR_NOT_INTEGER
+    # @see ERROR_OUT_OF_RANGE_TOO_SMALL
+    # @see ERROR_OUT_OF_RANGE_TOO_LARGE
+    def build_response
+      json_api? ? build_json_api_response : build_json_response
+    end
+
+    private
+
+      def errors?
+        page_offset_error? || page_limit_error?
+      end
+
+      def page_offset_error?
+        page_offset
+        @page_offset_error
+      end
+
+      def page_limit_error?
+        page_limit
+        @page_limit_error
+      end
+
+      # @return just the data as a JSON array
+      def build_json_response
+        errors? ? [] : build_data
+      end
+
+      # @return pages of results following the JSON API standard
+      def build_json_api_response
+        errors? ? build_json_api_response_with_errors : build_json_api_response_without_errors
+      end
+
+      def build_json_api_response_without_errors
+        {
+          "data" => build_data,
+          "meta" => build_meta,
+          "links" => build_links
+        }
+      end
+
+      def build_json_api_response_with_errors
+        {
+          "data" => [],
+          "meta" => build_meta,
+          "links" => build_links_when_errors,
+          "errors" => build_errors
+        }
+      end
+
+      def build_data
+        @results[start_index..last_index]
+      end
+
+      def build_meta
+        meta = {}
+        meta['page_offset'] = page_offset_error? ? @requested_page_offset.to_s : page_offset.to_s
+        meta['page_limit'] = page_limit_error? ? @requested_page_limit.to_s : page_limit.to_s
+        meta['actual_page_size'] = errors? ? "0" : actual_page_size.to_s
+        meta['total_num_found'] = total_num_found.to_s
+        { "page" => meta }
+      end
+
+      def build_links
+        links = {}
+        links['self'] = self_link
+        links['first'] = first_link
+        links['prev'] = prev_link
+        links['next'] = next_link
+        links['last'] = last_link
+        links
+      end
+
+      def build_links_when_errors
+        links = {}
+        links['self'] = "#{request_base_url}#{request_path}?#{request_query_string}"
+        links['first'] = first_link
+        links['prev'] = nil
+        links['next'] = nil
+        links['last'] = last_link
+        links
+      end
+
+      def build_errors
+        errors = []
+        errors << build_page_offset_error if page_offset_error?
+        errors << build_page_limit_error if page_limit_error?
+        errors
+      end
+
+      def build_page_offset_error
+        case @page_offset_error
+        when ERROR_NOT_INTEGER
+          build_page_offset_not_integer
+        when ERROR_OUT_OF_RANGE_TOO_LARGE
+          build_page_offset_too_large
+        when ERROR_OUT_OF_RANGE_TOO_SMALL
+          build_page_offset_too_small
+        end
+      end
+
+      def build_page_limit_error
+        case @page_limit_error
+        when ERROR_NOT_INTEGER
+          build_page_limit_not_integer
+        when ERROR_OUT_OF_RANGE_TOO_SMALL
+          build_page_limit_too_small
+        end
+      end
+
+      def build_page_offset_not_integer
+        {
+          "status" => "200",
+          "source" => { "page_offset" => @requested_page_offset },
+          "title" => "Page Offset Invalid",
+          "detail" => "Page offset #{@requested_page_offset} is not an Integer.  Returning empty results."
+        }
+      end
+
+      def build_page_offset_too_large
+        {
+          "status" => "200",
+          "source" => { "page_offset" => @requested_page_offset },
+          "title" => "Page Offset Out of Range",
+          "detail" => "Page offset #{@requested_page_offset} > #{total_num_found} (total number of results).  Returning empty results."
+        }
+      end
+
+      def build_page_offset_too_small
+        {
+          "status" => "200",
+          "source" => { "page_offset" => page_offset.to_s },
+          "title" => "Page Offset Out of Range",
+          "detail" => "Page offset #{@requested_page_offset} < 1 (first result).  Returning empty results."
+        }
+      end
+
+      def build_page_limit_not_integer
+        {
+          "status" => "200",
+          "source" => { "page_limit" => @requested_page_limit },
+          "title" => "Page Limit Invalid",
+          "detail" => "Page limit #{@requested_page_limit} is not an Integer.  Returning empty results."
+        }
+      end
+
+      def build_page_limit_too_small
+        {
+          "status" => "200",
+          "source" => { "page_limit" => @requested_page_limit.to_s },
+          "title" => "Page Limit Out of Range",
+          "detail" => "Page limit #{@requested_page_limit} < 1 (minimum limit).  Returning empty results."
+        }
+      end
+
+      def request_params
+        @request_params ||= @request.params
+      end
+
+      def request_query_params
+        @request_query_params ||= @request.query_parameters
+      end
+
+      def request_query_string
+        @request_query_string ||= @request.query_string
+      end
+
+      def request_base_url
+        @request_base_url ||= @request.base_url
+      end
+
+      def request_path
+        @request_path ||= @request.path
+      end
+
+      # @return [Boolean] true if results should be formatted according to JSON API standard
+      def json_api?
+        format == :jsonapi
+      end
+
+      # @param [Symbol] The requested format of the response (default=:json)
+      # @note Supported formats include [:json | :json-api].  For backward compatibility,
+      #   it defaults to :json.
+      def format
+        return @format if @format.present?
+        return @format = @requested_format if [:json, :jsonapi].include? @requested_format
+        Rails.logger.warn("Format '#{@requested_format}' is not a valid format for search.  Supported formats are [:json, :jsonapi].  Defaulting to :json.")
+        @format = :json
+      end
+
+      # @return [Integer] The first record to include in the response data. (default=1).
+      # @note The first record may be out of range (i.e., < 1 or > total_num_of_results),
+      # but it will always be numeric, defaulting to 1 if not specified or not an Integer.
+      def page_offset
+        return @page_offset if @page_offset.present?
+        return @page_offset = 1 unless page_offset_specified?
+        @page_offset = validated_request_page_offset || 1
+      end
+
+      # @return [Boolean] true if the request specifies the page offset; otherwise, false
+      def page_offset_specified?
+        request_params.keys.include?("page_offset") || request_params.keys.include?("startRecord")
+      end
+
+      # @return [Integer] The page offset as specified in the request_params, nil if invalid.
+      # @note The page offset can be specified with page_offset (preferred) or
+      #       startRecord (deprecated, supported for backward compatibility with
+      #       linked_data module pagination).
+      def requested_page_offset
+        return @requested_page_offset if @requested_page_offset.present?
+        @requested_page_offset = (request_params['page_offset'] || request_params['startRecord'])
+      end
+
+      # @return [Integer] The first record to include in the response data as
+      #     requested as long as it is an Integer; otherwise, returns nil.
+      def validated_request_page_offset
+        @page_offset_error = false
+        offset = Integer(requested_page_offset)
+        return offset if offset == 1
+        @page_offset_error = ERROR_OUT_OF_RANGE_TOO_SMALL if offset < 1
+        @page_offset_error = ERROR_OUT_OF_RANGE_TOO_LARGE if offset > total_num_found
+        offset
+      rescue
+        @page_offset_error = ERROR_NOT_INTEGER
+        nil
+      end
+
+      # @return [Integer] The requested maximum number of results to return (default=DEFAULT_PAGE_LIMIT | ALL)
+      # @see #default_page_limit
+      # @see DEFAULT_PAGE_LIMIT
+      def page_limit
+        return @page_limit if @page_limit.present?
+        return @page_limit = default_page_limit unless page_limit_specified?
+        @page_limit = validated_request_page_limit || default_page_limit
+      end
+
+      # @return [Boolean] true if the request specifies the page limit; otherwise, false
+      def page_limit_specified?
+        request_params.keys.include?("page_limit") || request_params.keys.include?("maxRecords")
+      end
+
+      # @return [Integer] The max number of records for a page as specified in the request_params.
+      # @note The page size limit can be specified with page_limit (preferred) or
+      #       maxRecords (deprecated, supported for backward compatibility with
+      #       linked_data module pagination).
+      def requested_page_limit
+        return @requested_page_limit if @requested_page_limit.present?
+        @requested_page_limit ||= (request_params['page_limit'] || request_params['maxRecords'])
+      end
+
+      # @return [Integer] The max number of records to include in response data as
+      #     requested as long as it is a positive Integer; otherwise, returns nil.
+      def validated_request_page_limit
+        @page_limit_error = false
+        limit = Integer(requested_page_limit)
+        @page_limit_error = ERROR_OUT_OF_RANGE_TOO_SMALL if limit < 1
+        limit.positive? ? limit : nil
+      rescue
+        @page_limit_error = ERROR_NOT_INTEGER
+        nil
+      end
+
+      # @return [Integer] The default to use when page_limit isn't specified.
+      # @note To maintain backward compatibility, the limit will be all results
+      #   if format is json and neither page_limit nor page_offset were specified.
+      def default_page_limit
+        return total_num_found unless json_api? || page_offset_specified? || page_limit_specified?
+        DEFAULT_PAGE_LIMIT
+      end
+
+      # @return [Integer] the index into the terms Array for the first record to
+      #     include in the page data
+      # @note page_offset begins counting at 1 and the Array index begins at 0.
+      def start_index
+        @start_index ||= page_offset - 1
+      end
+
+      # @return [Integer] the index into the terms Array for the last record to
+      #     include in the page data
+      def last_index
+        return @last_index if @last_index.present?
+        return @last_index = start_index if start_index >= last_possible_index
+        last_index = start_index + page_limit - 1
+        @last_index = last_index <= last_possible_index ? last_index : last_possible_index
+      end
+
+      # @return [Integer] the index for the last term in the Array
+      def last_possible_index
+        total_num_found - 1
+      end
+
+      # @return [Integer] actual number of results in the returned page of results;
+      #     0 if request is out of range
+      def actual_page_size
+        @actual_page_size ||= start_index <= last_possible_index ? last_index - start_index + 1 : 0
+      end
+
+      # @return [Integer] total number of terms matching the search query
+      def total_num_found
+        @results.length
+      end
+
+      # @return the URL to current page of results
+      def self_link
+        url_with(page_offset: page_offset)
+      end
+
+      # @return the URL to the first page of results
+      def first_link
+        url_with(page_offset: 1)
+      end
+
+      # @return the URL to the last page of results
+      def last_link
+        last_start = (total_num_found / page_limit) * page_limit + 1
+        last_start -= page_limit if last_start > total_num_found
+        last_start = 1 if last_start < 1
+        url_with(page_offset: last_start)
+      end
+
+      # @return the URL to the next page of results; nil if on last page
+      def next_link
+        next_start = page_offset + page_limit
+        next_start <= total_num_found ? url_with(page_offset: next_start) : nil
+      end
+
+      # @return the URL to the previous page of results; nil if on first page
+      def prev_link
+        return if page_offset == 1
+        prev_start = page_offset - page_limit
+        prev_start >= 1 ? url_with(page_offset: prev_start) : url_with(page_offset: 1)
+      end
+
+      # @return the original URL without the parameters
+      def url_without_parameters
+        URI.parse(request_base_url + request_path)
+      end
+
+      # Generate a URL based off the original URL and parameter values with page_offset
+      # updated based on the passed in value.
+      # @param page_offset [Integer] the value to use for page_offset
+      # @return [String] a full URL with the updated page_offset
+      def url_with(page_offset:)
+        updated_params = update_parameters(page_offset)
+
+        uri = url_without_parameters
+        uri.query = URI.encode_www_form(updated_params)
+        uri.to_s
+      end
+
+      # @param page_offset [Integer] the value to use for page_offset
+      # @return [Hash] parameter key-value pairs formatted for the URL using
+      #     the preferred parameter name and updated page_offset value
+      def update_parameters(page_offset)
+        updated_params = {}
+        request_query_params.each do |k, v|
+          next if ['page_offset', 'page_limit'].include? k
+          updated_params[k] = v
+        end
+        updated_params['page_limit'] = page_limit
+        updated_params['page_offset'] = page_offset
+        updated_params
+      end
+  end
+end

--- a/app/services/qa/pagination_service.rb
+++ b/app/services/qa/pagination_service.rb
@@ -58,28 +58,28 @@ module Qa
     #
     # @example json-api with pagination using default page_offset and page_limit
     #   # request: q=term, format=json-api
-    #   # response: format=json-api, paginated, results 1..8
+    #   # response: format=json-api, paginated, results 1..10
     #   {
     #     "data": [
     #       { "id": "1", "label": "term 1" },
     #       { "id": "2", "label": "term 2" },
     #       ...
-    #       { "id": "8", "label": "term 8" }
+    #       { "id": "10", "label": "term 10" }
     #     ],
     #     "meta": {
     #       "page": {
     #         "page_offset": "1",
-    #         "page_limit": "8",
-    #         "actual_page_size": "8",
+    #         "page_limit": "10",
+    #         "actual_page_size": "10",
     #         "total_num_found": "28",
     #       }
     #     }
     #     "links": {
-    #       "self_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=8&page_offset=1",
-    #       "first_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=8&page_offset=1",
+    #       "self_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=10&page_offset=1",
+    #       "first_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=10&page_offset=1",
     #       "prev_url": nil,
-    #       "next_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=8&page_offset=9",
-    #       "last_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=8&page_offset=25"
+    #       "next_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=10&page_offset=11",
+    #       "last_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=10&page_offset=21"
     #     }
     #   }
     #
@@ -123,10 +123,10 @@ module Qa
     #     }
     #     "links": {
     #       "self_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=-1&page_offset=0",
-    #       "first_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=8&page_offset=1",
+    #       "first_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=10&page_offset=1",
     #       "prev_url": nil,
     #       "next_url": nil,
-    #       "last_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=8&page_offset=25"
+    #       "last_url": "http://example.com/qa/search/local/states?q=new&format=json-api&page_limit=10&page_offset=21"
     #     }
     #     "errors": [
     #       {
@@ -368,7 +368,7 @@ module Qa
         @page_offset_error = ERROR_OUT_OF_RANGE_TOO_SMALL if offset < 1
         @page_offset_error = ERROR_OUT_OF_RANGE_TOO_LARGE if offset > total_num_found
         offset
-      rescue
+      rescue ArgumentError
         @page_offset_error = ERROR_NOT_INTEGER
         nil
       end
@@ -500,11 +500,7 @@ module Qa
       # @return [Hash] parameter key-value pairs formatted for the URL using
       #     the preferred parameter name and updated page_offset value
       def update_parameters(page_offset)
-        updated_params = {}
-        request_query_params.each do |k, v|
-          next if ['page_offset', 'page_limit'].include? k
-          updated_params[k] = v
-        end
+        updated_params = request_query_params.except('page_offset', 'page_limit')
         updated_params['page_limit'] = page_limit
         updated_params['page_offset'] = page_offset
         updated_params

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,0 +1,4 @@
+Mime::Type.register 'application/vnd.api+json', :jsonapi
+Mime::Type.register 'application/ld+json', :jsonld
+Mime::Type.register 'text/n3', :n3
+Mime::Type.register 'application/n-triples', :ntriples

--- a/spec/controllers/terms_controller_spec.rb
+++ b/spec/controllers/terms_controller_spec.rb
@@ -168,7 +168,7 @@ describe Qa::TermsController, type: :controller do
             expect(json_api_response["meta"]["page"]["total_num_found"]).to eq total_num_found
           end
 
-          it 'sets links with next set to nil' do
+          it 'sets links with prev and next having values' do
             get :search, params: params
 
             base_url = request.base_url

--- a/spec/services/pagination_service_spec.rb
+++ b/spec/services/pagination_service_spec.rb
@@ -1,0 +1,689 @@
+require 'spec_helper'
+
+RSpec.describe Qa::PaginationService do
+  let(:results) do
+    results = []
+    1.upto(36) { |i| results << { "id": i.to_s, "label": "term #{i}" } }
+    results
+  end
+  let(:request) { instance_double(ActionDispatch::Request) }
+  let(:requested_format) { :json }
+  let(:params) do
+    {
+      "q" => "n",
+      "controller" => "qa/terms",
+      "action" => "search",
+      "vocab" => "local",
+      "subauthority" => "my_terms"
+    }.with_indifferent_access
+  end
+  let(:query_params) do
+    { "q" => "term" }.with_indifferent_access
+  end
+
+  let(:service) do
+    described_class.new(request: request,
+                        results: results,
+                        format: requested_format)
+  end
+  let(:base_url) { 'http://example.com' }
+  let(:url_path) { '/qa/search/local/my_terms' }
+  let(:query_string) { 'q=term' }
+
+  before do
+    allow(request).to receive(:params).and_return(params)
+    allow(request).to receive(:query_parameters).and_return(query_params)
+    allow(request).to receive(:query_string).and_return(query_string)
+    allow(request).to receive(:base_url).and_return(base_url)
+    allow(request).to receive(:path).and_return(url_path)
+  end
+
+  describe '#build_response' do
+    let(:response) { service.build_response }
+
+    # rubocop:disable RSpec/NestedGroups
+    context 'when json format (default) is requested' do
+      context 'and page_offset is missing' do
+        context 'and page_limit is missing' do
+          it 'returns all results as an array' do
+            expect(response).to match_array(results)
+          end
+        end
+
+        context 'and page_limit is passed in as "3"' do
+          before { params[:page_limit] = "3" }
+
+          it 'returns the first 3 results as an array' do
+            expect(response).to match_array(results[0..2])
+          end
+        end
+      end
+
+      context 'and page_offset is passed in' do
+        before { params[:page_offset] = "4" }
+
+        context 'and page_limit is missing' do
+          it 'returns the first DEFAULT_PAGE_LIMIT (10) records starting at 4th result' do
+            expect(response).to match_array(results[3..12])
+          end
+        end
+
+        context 'and page_limit is passed in' do
+          before { params[:page_limit] = "3" }
+
+          it 'returns the first 3 results as an array starting at 4th result' do
+            expect(response).to match_array(results[3..5])
+          end
+        end
+      end
+    end
+
+    context 'when json api format is requested' do
+      let(:requested_format) { :jsonapi }
+      let(:first_page) { "#{base_url}#{url_path}?q=term&format=jsonapi&page_limit=10&page_offset=1" }
+      let(:second_page) { "#{base_url}#{url_path}?q=term&format=jsonapi&page_limit=10&page_offset=11" }
+      let(:third_page) { "#{base_url}#{url_path}?q=term&format=jsonapi&page_limit=10&page_offset=21" }
+      let(:fourth_page) { "#{base_url}#{url_path}?q=term&format=jsonapi&page_limit=10&page_offset=31" }
+      let(:last_page) { fourth_page }
+      let(:query_string) { 'q=term&format=jsonapi' }
+      before do
+        params[:format] = "jsonapi"
+        query_params[:format] = "jsonapi"
+      end
+
+      context 'with invalid page_offset' do
+        context 'that is not an integer' do
+          let(:query_string) { 'q=term&format=jsonapi&page_offset=BAD' }
+
+          before do
+            params[:page_offset] = "BAD"
+            query_params[:page_offset] = "BAD"
+          end
+
+          it 'sets invalid error' do
+            error = response['errors'].first
+            expect(error['status']).to eq '200'
+            expect(error['source']).to include("page_offset" => "BAD")
+            expect(error['title']).to eq 'Page Offset Invalid'
+            expect(error['detail']).to eq "Page offset BAD is not an Integer.  Returning empty results."
+          end
+
+          it 'returns json api response with no results' do
+            expect(response["data"]).to match_array([])
+          end
+
+          it "sets meta['page'] stats with page_offset showing the passed in value" do
+            expect(response["meta"]["page"]["page_offset"]).to eq "BAD"
+            expect(response["meta"]["page"]["page_limit"]).to eq "10"
+            expect(response["meta"]["page"]["actual_page_size"]).to eq "0"
+            expect(response["meta"]["page"]["total_num_found"]).to eq "36"
+          end
+
+          it "sets prev and next links to nil" do
+            expect(response['links']['prev']).to be_nil
+            expect(response['links']['next']).to be_nil
+          end
+
+          it "uses request values in self link" do
+            self_url = "#{base_url}#{url_path}?q=term&format=jsonapi&page_offset=BAD"
+            expect(response['links']['self']).to eq self_url
+          end
+
+          it "uses valid values in first and last links" do
+            expect(response['links']['first']).to eq first_page
+            expect(response['links']['last']).to eq last_page
+          end
+        end
+
+        context 'that is < 1' do
+          let(:query_string) { 'q=term&format=jsonapi&page_offset=0' }
+          before do
+            params[:page_offset] = "0"
+            query_params[:page_offset] = "0"
+          end
+
+          it 'sets out of range error' do
+            error = response['errors'].first
+            expect(error['status']).to eq '200'
+            expect(error['source']).to include("page_offset" => "0")
+            expect(error['title']).to eq 'Page Offset Out of Range'
+            expect(error['detail']).to eq "Page offset 0 < 1 (first result).  Returning empty results."
+          end
+
+          it 'returns json api response with no results' do
+            expect(response["data"]).to match_array([])
+          end
+
+          it "sets meta['page'] stats with page_offset showing the passed in value" do
+            expect(response["meta"]["page"]["page_offset"]).to eq "0"
+            expect(response["meta"]["page"]["page_limit"]).to eq "10"
+            expect(response["meta"]["page"]["actual_page_size"]).to eq "0"
+            expect(response["meta"]["page"]["total_num_found"]).to eq "36"
+          end
+
+          it "sets prev and next links to nil" do
+            expect(response['links']['prev']).to be_nil
+            expect(response['links']['next']).to be_nil
+          end
+
+          it "uses request values in self link" do
+            self_url = "#{base_url}#{url_path}?q=term&format=jsonapi&page_offset=0"
+            expect(response['links']['self']).to eq self_url
+          end
+
+          it "uses valid values in first and last links" do
+            expect(response['links']['first']).to eq first_page
+            expect(response['links']['last']).to eq last_page
+          end
+        end
+
+        context 'that is > number of results found' do
+          let(:query_string) { 'q=term&format=jsonapi&page_offset=40' }
+          before do
+            params[:page_offset] = "40"
+            query_params[:page_offset] = "40"
+          end
+
+          it 'sets out of range error' do
+            error = response['errors'].first
+            expect(error['status']).to eq '200'
+            expect(error['source']).to include("page_offset" => "40")
+            expect(error['title']).to eq 'Page Offset Out of Range'
+            expect(error['detail']).to eq "Page offset 40 > 36 (total number of results).  Returning empty results."
+          end
+
+          it 'returns json api response with no results' do
+            expect(response["data"]).to match_array([])
+          end
+
+          it "sets meta['page'] stats with page_offset showing the passed in value" do
+            expect(response["meta"]["page"]["page_offset"]).to eq "40"
+            expect(response["meta"]["page"]["page_limit"]).to eq "10"
+            expect(response["meta"]["page"]["actual_page_size"]).to eq "0"
+            expect(response["meta"]["page"]["total_num_found"]).to eq "36"
+          end
+
+          it "sets prev and next links to nil" do
+            expect(response['links']['prev']).to be_nil
+            expect(response['links']['next']).to be_nil
+          end
+
+          it "uses request values in self link" do
+            self_url = "#{base_url}#{url_path}?q=term&format=jsonapi&page_offset=40"
+            expect(response['links']['self']).to eq self_url
+          end
+
+          it "uses valid values in first and last links" do
+            expect(response['links']['first']).to eq first_page
+            expect(response['links']['last']).to eq last_page
+          end
+        end
+      end
+
+      context 'with invalid page_limit' do
+        context 'that is not an integer' do
+          let(:query_string) { 'q=term&format=jsonapi&page_limit=BAD' }
+          before do
+            params[:page_limit] = "BAD"
+            query_params[:page_limit] = "BAD"
+          end
+
+          it 'sets invalid error' do
+            error = response['errors'].first
+            expect(error['status']).to eq '200'
+            expect(error['source']).to include("page_limit" => "BAD")
+            expect(error['title']).to eq 'Page Limit Invalid'
+            expect(error['detail']).to eq "Page limit BAD is not an Integer.  Returning empty results."
+          end
+
+          it 'returns json api response with no results' do
+            expect(response["data"]).to match_array([])
+          end
+
+          it "sets meta['page'] stats with page_limit showing the passed in value" do
+            expect(response["meta"]["page"]["page_offset"]).to eq "1"
+            expect(response["meta"]["page"]["page_limit"]).to eq "BAD"
+            expect(response["meta"]["page"]["actual_page_size"]).to eq "0"
+            expect(response["meta"]["page"]["total_num_found"]).to eq "36"
+          end
+
+          it "sets prev and next links to nil" do
+            expect(response['links']['prev']).to be_nil
+            expect(response['links']['next']).to be_nil
+          end
+
+          it "uses request values in self link" do
+            self_url = "#{base_url}#{url_path}?q=term&format=jsonapi&page_limit=BAD"
+            expect(response['links']['self']).to eq self_url
+          end
+
+          it "uses valid values in first and last links" do
+            expect(response['links']['first']).to eq first_page
+            expect(response['links']['last']).to eq last_page
+          end
+        end
+
+        context 'that is < 1' do
+          let(:query_string) { 'q=term&format=jsonapi&page_limit=0' }
+          before do
+            params[:page_limit] = "0"
+            query_params[:page_limit] = "0"
+          end
+
+          it 'sets out of range error' do
+            error = response['errors'].first
+            expect(error['status']).to eq '200'
+            expect(error['source']).to include("page_limit" => "0")
+            expect(error['title']).to eq 'Page Limit Out of Range'
+            expect(error['detail']).to eq "Page limit 0 < 1 (minimum limit).  Returning empty results."
+          end
+
+          it 'returns json api response with no results' do
+            expect(response["data"]).to match_array([])
+          end
+
+          it "sets meta['page'] stats with page_limit showing the passed in value" do
+            expect(response["meta"]["page"]["page_offset"]).to eq "1"
+            expect(response["meta"]["page"]["page_limit"]).to eq "0"
+            expect(response["meta"]["page"]["actual_page_size"]).to eq "0"
+            expect(response["meta"]["page"]["total_num_found"]).to eq "36"
+          end
+
+          it "sets prev and next links to nil" do
+            expect(response['links']['prev']).to be_nil
+            expect(response['links']['next']).to be_nil
+          end
+
+          it "uses request values in self link" do
+            self_url = "#{base_url}#{url_path}?q=term&format=jsonapi&page_limit=0"
+            expect(response['links']['self']).to eq self_url
+          end
+
+          it "uses valid values in first and last links" do
+            expect(response['links']['first']).to eq first_page
+            expect(response['links']['last']).to eq last_page
+          end
+        end
+      end
+
+      context 'with multiple errors' do
+        context 'where page_offset is > number of results found and page_limit is < 1' do
+          let(:query_string) { 'q=term&format=jsonapi&page_limit=0&page_offset=40' }
+          before do
+            params[:page_limit] = "0"
+            params[:page_offset] = "40"
+            query_params[:page_limit] = "0"
+            query_params[:page_offset] = "40"
+          end
+
+          it 'sets page_offset out of range and page_limit out of range errors' do
+            expect(response['errors'].size).to eq 2
+            offset_error_is_first = response['errors'].first['title'].starts_with? 'Page Offset'
+            if offset_error_is_first
+              offset_error = response['errors'].first
+              limit_error = response['errors'].second
+            else
+              limit_error = response['errors'].first
+              offset_error = response['errors'].second
+            end
+
+            expect(offset_error['status']).to eq '200'
+            expect(offset_error['source']).to include("page_offset" => "40")
+            expect(offset_error['title']).to eq 'Page Offset Out of Range'
+            expect(offset_error['detail']).to eq "Page offset 40 > 36 (total number of results).  Returning empty results."
+
+            expect(limit_error['status']).to eq '200'
+            expect(limit_error['source']).to include("page_limit" => "0")
+            expect(limit_error['title']).to eq 'Page Limit Out of Range'
+            expect(limit_error['detail']).to eq "Page limit 0 < 1 (minimum limit).  Returning empty results."
+          end
+
+          it 'returns json api response with no results' do
+            expect(response["data"]).to match_array([])
+          end
+
+          it "sets meta['page'] stats with page_offset and page_limit showing the passed in values" do
+            expect(response["meta"]["page"]["page_offset"]).to eq "40"
+            expect(response["meta"]["page"]["page_limit"]).to eq "0"
+            expect(response["meta"]["page"]["actual_page_size"]).to eq "0"
+            expect(response["meta"]["page"]["total_num_found"]).to eq "36"
+          end
+
+          it "sets prev and next links to nil" do
+            expect(response['links']['prev']).to be_nil
+            expect(response['links']['next']).to be_nil
+          end
+
+          it "uses request values in self link" do
+            self_url = "#{base_url}#{url_path}?q=term&format=jsonapi&page_limit=0&page_offset=40"
+            expect(response['links']['self']).to eq self_url
+          end
+
+          it "uses valid values in first and last links" do
+            expect(response['links']['first']).to eq first_page
+            expect(response['links']['last']).to eq last_page
+          end
+        end
+      end
+
+      context 'with page_offset missing' do
+        context 'and page_limit is missing' do
+          it 'returns the first DEFAULT_PAGE_LIMIT (10) records' do
+            expect(response["data"]).to match_array(results[0..9])
+          end
+
+          it "sets meta['page'] stats" do
+            expect(response["meta"]["page"]["page_offset"]).to eq "1"
+            expect(response["meta"]["page"]["page_limit"]).to eq described_class::DEFAULT_PAGE_LIMIT.to_s
+            expect(response["meta"]["page"]["actual_page_size"]).to eq described_class::DEFAULT_PAGE_LIMIT.to_s
+            expect(response["meta"]["page"]["total_num_found"]).to eq "36"
+          end
+
+          it "sets prev link to nil and next link to next page" do
+            next_url = "#{base_url}#{url_path}?q=term&format=jsonapi&page_limit=10&page_offset=11"
+            expect(response['links']['prev']).to be_nil
+            expect(response['links']['next']).to eq next_url
+          end
+
+          it "sets first and self links to first page and last link to third page" do
+            expect(response['links']['first']).to eq first_page
+            expect(response['links']['last']).to eq last_page
+            expect(response['links']['self']).to eq first_page
+          end
+        end
+
+        context 'and page_limit is passed in' do
+          let(:query_string) { 'q=term&format=jsonapi&page_limit=8' }
+          let(:first_page) { "#{base_url}#{url_path}?q=term&format=jsonapi&page_limit=8&page_offset=1" }
+          let(:second_page) { "#{base_url}#{url_path}?q=term&format=jsonapi&page_limit=8&page_offset=9" }
+          let(:fifth_page) { "#{base_url}#{url_path}?q=term&format=jsonapi&page_limit=8&page_offset=33" }
+          before do
+            params[:page_limit] = "8"
+            query_params[:page_limit] = "8"
+          end
+
+          it 'returns json api response with the first 3 results as an array' do
+            expect(response["data"]).to match_array(results[0..7])
+          end
+
+          it "sets meta['page'] stats" do
+            expect(response["meta"]["page"]["page_offset"]).to eq "1"
+            expect(response["meta"]["page"]["page_limit"]).to eq "8"
+            expect(response["meta"]["page"]["actual_page_size"]).to eq "8"
+            expect(response["meta"]["page"]["total_num_found"]).to eq "36"
+          end
+
+          it "sets prev link to nil and next link to next page" do
+            expect(response['links']['prev']).to be_nil
+            expect(response['links']['next']).to eq second_page
+          end
+
+          it "sets first and self links to first page and last link to sixth page" do
+            expect(response['links']['first']).to eq first_page
+            expect(response['links']['last']).to eq fifth_page
+            expect(response['links']['self']).to eq first_page
+          end
+        end
+      end
+
+      context 'with page_offset passed being the middle of a page' do
+        let(:query_string) { 'q=term&format=jsonapi&page_offset=4' }
+        before do
+          params[:page_offset] = "4"
+          query_params[:page_offset] = "4"
+        end
+
+        context 'and page_limit is missing' do
+          it 'returns json api response with the first DEFAULT_PAGE_LIMIT (10) records starting at 4th result' do
+            expect(response["data"]).to match_array(results[3..12])
+          end
+
+          it "sets meta['page'] stats" do
+            expect(response["meta"]["page"]["page_offset"]).to eq "4"
+            expect(response["meta"]["page"]["page_limit"]).to eq described_class::DEFAULT_PAGE_LIMIT.to_s
+            expect(response["meta"]["page"]["actual_page_size"]).to eq described_class::DEFAULT_PAGE_LIMIT.to_s
+            expect(response["meta"]["page"]["total_num_found"]).to eq "36"
+          end
+
+          it "sets self to requested page_offset and default page_limit" do
+            self_url = "#{base_url}#{url_path}?q=term&format=jsonapi&page_limit=10&page_offset=4"
+            expect(response['links']['self']).to eq self_url
+          end
+
+          it "sets prev link to first page and next link to next offset" do
+            first_page = "#{base_url}#{url_path}?q=term&format=jsonapi&page_limit=10&page_offset=1"
+            next_url = "#{base_url}#{url_path}?q=term&format=jsonapi&page_limit=10&page_offset=14"
+            expect(response['links']['prev']).to eq first_page
+            expect(response['links']['next']).to eq next_url
+          end
+
+          it "sets first to first page and last link to third page" do
+            first_page = "#{base_url}#{url_path}?q=term&format=jsonapi&page_limit=10&page_offset=1"
+            third_page = "#{base_url}#{url_path}?q=term&format=jsonapi&page_limit=10&page_offset=31"
+            expect(response['links']['first']).to eq first_page
+            expect(response['links']['last']).to eq third_page
+          end
+        end
+      end
+
+      context 'and there are no results' do
+        let(:results) { [] }
+
+        it 'returns no results' do
+          expect(response["data"]).to match_array([])
+        end
+
+        it "sets meta['page'] stats" do
+          expect(response["meta"]["page"]["page_offset"]).to eq "1"
+          expect(response["meta"]["page"]["page_limit"]).to eq "10"
+          expect(response["meta"]["page"]["actual_page_size"]).to eq "0"
+          expect(response["meta"]["page"]["total_num_found"]).to eq "0"
+        end
+
+        it 'sets links with prev and next set to nil, last set to first' do
+          expect(response['links']["self"]).to eq first_page
+          expect(response['links']["first"]).to eq first_page
+          expect(response['links']["prev"]).to eq nil
+          expect(response['links']["next"]).to eq nil
+          expect(response['links']["last"]).to eq first_page
+        end
+
+        it 'does not include errors' do
+          expect(response.key?('errors')).to eq false
+        end
+      end
+
+      context 'and results do not include a full page' do
+        context 'and there are several results in range' do
+          let(:query_string) { 'q=term&format=jsonapi&page_offset=31&page_limit=10' }
+
+          before do
+            params[:page_offset] = "31"
+            query_params[:page_offset] = "31"
+          end
+
+          it 'returns json api response with a partial page of results starting at 11th result' do
+            expect(response["data"]).to match_array(results[30..35])
+          end
+
+          it "sets meta['page'] stats" do
+            expect(response["meta"]["page"]["page_offset"]).to eq "31"
+            expect(response["meta"]["page"]["page_limit"]).to eq "10"
+            expect(response["meta"]["page"]["actual_page_size"]).to eq "6"
+            expect(response["meta"]["page"]["total_num_found"]).to eq "36"
+          end
+
+          it "sets self to last page" do
+            expect(response['links']['self']).to eq last_page
+          end
+
+          it "sets prev link to 3rd page and next link to nil" do
+            expect(response['links']['prev']).to eq third_page
+            expect(response['links']['next']).to eq nil
+          end
+
+          it "sets first to first page and last link to fourth page" do
+            expect(response['links']['first']).to eq first_page
+            expect(response['links']['last']).to eq last_page
+          end
+        end
+
+        context 'and only the last result is in range' do
+          let(:query_string) { "q=term&format=jsonapi&page_offset=#{results.length}" }
+          before do
+            params[:page_offset] = results.length.to_s
+            query_params[:page_offset] = results.length.to_s
+          end
+
+          it 'returns json api response with a partial page with one result' do
+            expect(response["data"]).to match_array(results[35..35])
+          end
+
+          it "sets meta['page'] stats" do
+            expect(response["meta"]["page"]["page_offset"]).to eq "36"
+            expect(response["meta"]["page"]["page_limit"]).to eq "10"
+            expect(response["meta"]["page"]["actual_page_size"]).to eq "1"
+            expect(response["meta"]["page"]["total_num_found"]).to eq "36"
+          end
+
+          it "sets self to second page" do
+            self_url = "#{base_url}#{url_path}?q=term&format=jsonapi&page_limit=10&page_offset=36"
+            expect(response['links']['self']).to eq self_url
+          end
+
+          it "sets prev link to one page back and next link to nil" do
+            # when offset is middle of a page, then prev will also be middle of
+            # a page with `prev_offset = current_offset - page_limit`
+            prev_url = "#{base_url}#{url_path}?q=term&format=jsonapi&page_limit=10&page_offset=26"
+            expect(response['links']['prev']).to eq prev_url
+            expect(response['links']['next']).to eq nil
+          end
+
+          it "sets first to first page and last link to second page" do
+            # calculated assuming starting from offset=1
+            expect(response['links']['first']).to eq first_page
+            expect(response['links']['last']).to eq last_page
+          end
+        end
+      end
+
+      context 'and there are multiple pages of results' do
+        # data defined in main section has 3 pages of data
+        let(:query_string) { "q=term&format=jsonapi&page_offset=#{page_offset}" }
+        before do
+          params[:page_offset] = page_offset
+          query_params[:page_offset] = page_offset
+        end
+
+        context 'and page_offset is start of first page' do
+          let(:page_offset) { "1" }
+
+          it 'returns json api response first page of results' do
+            expect(response["data"]).to match_array(results[0..9])
+          end
+
+          it "sets meta['page'] stats" do
+            expect(response["meta"]["page"]["page_offset"]).to eq "1"
+            expect(response["meta"]["page"]["page_limit"]).to eq "10"
+            expect(response["meta"]["page"]["actual_page_size"]).to eq "10"
+            expect(response["meta"]["page"]["total_num_found"]).to eq "36"
+          end
+
+          it 'sets links with prev set to nil' do
+            expect(response['links']["self"]).to eq first_page
+            expect(response['links']["first"]).to eq first_page
+            expect(response['links']["prev"]).to be_nil
+            expect(response['links']["next"]).to eq second_page
+            expect(response['links']["last"]).to eq last_page
+          end
+
+          it 'does not include errors' do
+            expect(response.key?('errors')).to eq false
+          end
+        end
+
+        context 'and page_offset is start of second page' do
+          let(:page_offset) { "11" }
+
+          it 'returns json api response second page of results' do
+            expect(response["data"]).to match_array(results[10..19])
+          end
+
+          it "sets meta['page'] stats" do
+            expect(response["meta"]["page"]["page_offset"]).to eq "11"
+            expect(response["meta"]["page"]["page_limit"]).to eq "10"
+            expect(response["meta"]["page"]["actual_page_size"]).to eq "10"
+            expect(response["meta"]["page"]["total_num_found"]).to eq "36"
+          end
+
+          it 'sets links with prev and next having values' do
+            expect(response['links']["self"]).to eq second_page
+            expect(response['links']["first"]).to eq first_page
+            expect(response['links']["prev"]).to eq first_page
+            expect(response['links']["next"]).to eq third_page
+            expect(response['links']["last"]).to eq last_page
+          end
+
+          it 'does not include errors' do
+            expect(response.key?('errors')).to eq false
+          end
+        end
+
+        context 'and page_offset is start of third page' do
+          let(:page_offset) { "21" }
+
+          it 'returns json api response third page of results' do
+            expect(response["data"]).to match_array(results[20..29])
+          end
+
+          it "sets meta['page'] stats" do
+            expect(response["meta"]["page"]["page_offset"]).to eq "21"
+            expect(response["meta"]["page"]["page_limit"]).to eq "10"
+            expect(response["meta"]["page"]["actual_page_size"]).to eq "10"
+            expect(response["meta"]["page"]["total_num_found"]).to eq "36"
+          end
+
+          it 'sets links with next set to nil' do
+            expect(response['links']["self"]).to eq third_page
+            expect(response['links']["first"]).to eq first_page
+            expect(response['links']["prev"]).to eq second_page
+            expect(response['links']["next"]).to eq last_page
+            expect(response['links']["last"]).to eq last_page
+          end
+
+          it 'does not include errors' do
+            expect(response.key?('errors')).to eq false
+          end
+        end
+
+        context 'and page_offset is start of fourth page (last page)' do
+          let(:page_offset) { "31" }
+
+          it 'returns json api response third page of results' do
+            expect(response["data"]).to match_array(results[30..39])
+          end
+
+          it "sets meta['page'] stats" do
+            expect(response["meta"]["page"]["page_offset"]).to eq "31"
+            expect(response["meta"]["page"]["page_limit"]).to eq "10"
+            expect(response["meta"]["page"]["actual_page_size"]).to eq "6"
+            expect(response["meta"]["page"]["total_num_found"]).to eq "36"
+          end
+
+          it 'sets links with next set to nil' do
+            expect(response['links']["self"]).to eq last_page
+            expect(response['links']["first"]).to eq first_page
+            expect(response['links']["prev"]).to eq third_page
+            expect(response['links']["next"]).to be_nil
+            expect(response['links']["last"]).to eq last_page
+          end
+
+          it 'does not include errors' do
+            expect(response.key?('errors')).to eq false
+          end
+        end
+      end
+    end
+    # rubocop:enable RSpec/NestedGroups
+  end
+end

--- a/spec/services/pagination_service_spec.rb
+++ b/spec/services/pagination_service_spec.rb
@@ -318,14 +318,8 @@ RSpec.describe Qa::PaginationService do
 
           it 'sets page_offset out of range and page_limit out of range errors' do
             expect(response['errors'].size).to eq 2
-            offset_error_is_first = response['errors'].first['title'].starts_with? 'Page Offset'
-            if offset_error_is_first
-              offset_error = response['errors'].first
-              limit_error = response['errors'].second
-            else
-              limit_error = response['errors'].first
-              offset_error = response['errors'].second
-            end
+            offset_error = response['errors'].find { |err| err['title'].starts_with? 'Page Offset' }
+            limit_error = response['errors'].find { |err| err['title'].starts_with? 'Page Limit' }
 
             expect(offset_error['status']).to eq '200'
             expect(offset_error['source']).to include("page_offset" => "40")
@@ -374,15 +368,14 @@ RSpec.describe Qa::PaginationService do
 
           it "sets meta['page'] stats" do
             expect(response["meta"]["page"]["page_offset"]).to eq "1"
-            expect(response["meta"]["page"]["page_limit"]).to eq described_class::DEFAULT_PAGE_LIMIT.to_s
-            expect(response["meta"]["page"]["actual_page_size"]).to eq described_class::DEFAULT_PAGE_LIMIT.to_s
+            expect(response["meta"]["page"]["page_limit"]).to eq "10"
+            expect(response["meta"]["page"]["actual_page_size"]).to eq "10"
             expect(response["meta"]["page"]["total_num_found"]).to eq "36"
           end
 
           it "sets prev link to nil and next link to next page" do
-            next_url = "#{base_url}#{url_path}?q=term&format=jsonapi&page_limit=10&page_offset=11"
             expect(response['links']['prev']).to be_nil
-            expect(response['links']['next']).to eq next_url
+            expect(response['links']['next']).to eq second_page
           end
 
           it "sets first and self links to first page and last link to third page" do
@@ -502,7 +495,7 @@ RSpec.describe Qa::PaginationService do
             query_params[:page_offset] = "31"
           end
 
-          it 'returns json api response with a partial page of results starting at 11th result' do
+          it 'returns json api response with a partial page of results starting at 31th result' do
             expect(response["data"]).to match_array(results[30..35])
           end
 
@@ -643,7 +636,7 @@ RSpec.describe Qa::PaginationService do
             expect(response["meta"]["page"]["total_num_found"]).to eq "36"
           end
 
-          it 'sets links with next set to nil' do
+          it 'sets links with prev and next having values' do
             expect(response['links']["self"]).to eq third_page
             expect(response['links']["first"]).to eq first_page
             expect(response['links']["prev"]).to eq second_page
@@ -660,7 +653,7 @@ RSpec.describe Qa::PaginationService do
           let(:page_offset) { "31" }
 
           it 'returns json api response third page of results' do
-            expect(response["data"]).to match_array(results[30..39])
+            expect(response["data"]).to match_array(results[30..35])
           end
 
           it "sets meta['page'] stats" do


### PR DESCRIPTION
This implementation follows json-api recommendations with:
* response[‘data’] = the results
* response[‘meta’][‘page’] = pagination statistics (i.e., page_offset, page_limit, actual_page_size, total_num_found)
* response[‘links’] = set of links for pagination (i.e., self, first, prev, next, last)
* response[‘errors’] = any errors with requested page_offset or page_limit (only included if there are errors)

Reference:
* [Pagination](https://jsonapi.org/format/#fetching-pagination) section of [Latest JsonAPI spec](https://jsonapi.org/format/)
* [Pagination Links](https://jsonapi.org/examples/#pagination) example

NOTE: For backward compatibility, if the format is JSON (default) and neither page_offset or page_limit are set, then only the results, including all results, will be returned.