### PR TITLE
wrap initialization in reloader.to_prepare to avoid autoload deprecation warning in some cases

### DIFF
--- a/config/initializers/authorities.rb
+++ b/config/initializers/authorities.rb
@@ -1,1 +1,3 @@
-Qa::Authorities::Local.load_config(File.expand_path("../../authorities.yml", __FILE__))
+Rails.application.reloader.to_prepare do
+  Qa::Authorities::Local.load_config(File.expand_path("../../authorities.yml", __FILE__))
+end

--- a/config/initializers/linked_data_authorities.rb
+++ b/config/initializers/linked_data_authorities.rb
@@ -1,1 +1,3 @@
-Qa::LinkedData::AuthorityService.load_authorities
+Rails.application.reloader.to_prepare do
+  Qa::LinkedData::AuthorityService.load_authorities
+end


### PR DESCRIPTION
My Rails 6.1.3.2 app that uses `qa` gem has this deprecation warning on startup in development mode:

```
DEPRECATION WARNING: Initialization autoloaded the constants Qa::LinkedData and Qa::LinkedData::AuthorityService.


Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload Qa::LinkedData, for example,
the expected changes won't be reflected in that stale Module object.

These autoloaded constants have been unloaded.

In order to autoload safely at boot time, please wrap your code in a reloader
callback this way:

    Rails.application.reloader.to_prepare do
      # Autoload classes and modules needed at boot time here.
    end

That block runs when the application boots, and every time there is a reload.
For historical reasons, it may run twice, so it has to be idempotent.

Check the "Autoloading and Reloading Constants" guide to learn more about how
Rails autoloads and reloads.
 (called from <main> at /Users/jrochkind/code/scihist_digicoll/config/environment.rb:5
```

`/Users/jrochkind/code/scihist_digicoll/config/environment.rb:5` is just `Rails.application.initialize!`. 

I haven't been able to reproduce this in a new fresh Rails 6.1.3.2 app -- I'm not sure what settings in my actual app are triggering this warning, when I can't get a fresh app too. I've spent some time trying. 

However, it seems like this is a legit problem, that could affect other apps, and should be fixed. Here is the Rails [Autoloading and Reloading Constants Guide](https://guides.rubyonrails.org/autoloading_and_reloading_constants.html). 

The small change in this PR eliminates the deprecation warning for me. And I believe is appropriate for Rails.  

Other possible changes could have been: 
* removing these initializers, doing the loading currently in these  initializers  on-demand lazily instead, at some point after initialization
* moving the classes referenced in the initializers somewhere will they will not be auto-loaded -- This gem has a lot of manual `extend ActiveSupport::Autoload` in various places (they've [been there for a long time](https://github.com/samvera/questioning_authority/commit/7f67159eec660d787961596ce8f49359081d2f4e)), to opt-in to Rails autoloading for classes that would ordinarily not be auto-loaded. (I think engine classes are not autoloaded by default at all). i think that's the root of the problem, and I'm not sure if it's really a good idea or necessary -- but seemed like a bigger change than I wanted to make for now. 

Those might actually make sense, but I was nervous to try to make more than the smallest change that seemed to resolve the problem, which this is. 

I have also confirmed:
* the code called in these initializers looks idempotent to me, as is required for anything in a `to_prepare` block
* The `Rails.application.reloader` API was introduced in Rails 5.0.0, which is the oldest version of Rails that this gem currently supports, so it is available in all versions of this gem. 

The only thing that makes me nervous is I don't understand why I can't reproduce in stock from scratch app. Still, I think this change should be harmless and appropriate and will fix this problem -- unless someone would prefer we go *removing* all the `extend ActiveSupport::Autoload` sprinkled throughout the gem, which may actually be a more fundamental fix. 