### PR TITLE
Revert "wrap initialization in reloader.to_prepare to avoid autoload deprecation warning in some cases"

### DIFF
--- a/config/initializers/authorities.rb
+++ b/config/initializers/authorities.rb
@@ -1,3 +1,1 @@
-Rails.application.reloader.to_prepare do
-  Qa::Authorities::Local.load_config(File.expand_path("../../authorities.yml", __FILE__))
-end
+Qa::Authorities::Local.load_config(File.expand_path("../../authorities.yml", __FILE__))

--- a/config/initializers/linked_data_authorities.rb
+++ b/config/initializers/linked_data_authorities.rb
@@ -1,3 +1,1 @@
-Rails.application.reloader.to_prepare do
-  Qa::LinkedData::AuthorityService.load_authorities
-end
+Qa::LinkedData::AuthorityService.load_authorities

--- a/lib/qa/version.rb
+++ b/lib/qa/version.rb
@@ -1,4 +1,3 @@
 module Qa
   VERSION = "5.8.0".freeze
 end
-


### PR DESCRIPTION
Reverts samvera/questioning_authority#349

Based upon the issue [I was seeing in Hyrax](https://github.com/samvera/questioning_authority/pull/349#issuecomment-1030326627) trying to use the new release of QA, I think it would be good to revert this change, cut a new release, and open an issue to take a deeper look at how to resolve this.