### PR TITLE
Allow Faraday 2.x again

### DIFF
--- a/qa.gemspec
+++ b/qa.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activerecord-import'
   s.add_dependency 'deprecation'
-  s.add_dependency 'faraday', '< 2.0'
+  s.add_dependency 'faraday', '< 3.0', '!= 2.0.0'
   s.add_dependency 'geocoder'
   s.add_dependency 'ldpath'
   s.add_dependency 'nokogiri', '~> 1.6'


### PR DESCRIPTION
I am interested in upgrading an app that uses the qa gem to use faraday 2.x, to get advantage of new features and bugfixes, but I can't do that if qa doesn't allow it. 

tests seem to pass fine with latest faraday 2. I believe the issue that resulted in limiting to faraday 1.x only at 8378088 may have been resolved in faraday 2.0.1. I have excluded Faraday 2.0.1 as allowed, following advice at [Faraday upgrading guide](https://github.com/lostisland/faraday/blob/main/UPGRADING.md) "We strongly suggest you to skip version 2.0 and instead use version 2.0.1 or greater."


