### PR TITLE
Use << instead of insert, per `Rails/skipsmodelvalidations` rubocop

### DIFF
--- a/app/services/qa/linked_data/graph_service.rb
+++ b/app/services/qa/linked_data/graph_service.rb
@@ -57,7 +57,7 @@ module Qa
         def deep_copy(graph:)
           new_graph = RDF::Graph.new
           graph.statements.each do |st|
-            new_graph.insert(st.dup)
+            new_graph << st.dup
           end
           new_graph
         end


### PR DESCRIPTION
Note that this line of code is heavily tested in the corresponding unit test.