### PR TITLE
Changes to calls to `escape`, `unescape` and `open`

### DIFF
--- a/lib/qa/authorities/linked_data/find_term.rb
+++ b/lib/qa/authorities/linked_data/find_term.rb
@@ -136,7 +136,7 @@ module Qa::Authorities
         # Special processing for loc ids for backward compatibility.  IDs may be in the form 'n123' or 'n 123'.  This adds
         # the <blank> into the ID to allow it to be found as the object of a triple in the graph.
         def loc_id
-          loc_id = URI.unescape(id)
+          loc_id = CGI.unescape(id)
           digit_idx = loc_id.index(/\d/)
           loc_id.insert(digit_idx, ' ') if loc? && loc_id.index(' ').blank? && digit_idx > 0
           loc_id
@@ -164,7 +164,7 @@ module Qa::Authorities
         def extract_uri_by_id(id_predicate)
           @uri = graph_service.subjects_for_object_value(graph: @filtered_graph,
                                                          predicate: id_predicate,
-                                                         object_value: URI.unescape(id)).first
+                                                         object_value: CGI.unescape(id)).first
           return if @uri.present? || !loc?
 
           # NOTE: Second call to try and extract using the loc_id allows for special processing on the id for LOC authorities.
@@ -172,7 +172,7 @@ module Qa::Authorities
           #       the ID is provided without the <blank>, this tries a second time to find it with the <blank>.
           @uri = graph_service.subjects_for_object_value(graph: @filtered_graph,
                                                          predicate: id_predicate,
-                                                         object_value: URI.unescape(loc_id)).first
+                                                         object_value: CGI.unescape(loc_id)).first
           return if @uri.blank? # only show the depercation warning if the loc_id was used
           Qa.deprecation_warning(
             in_msg: 'Qa::Authorities::LinkedData::FindTerm',

--- a/lib/qa/authorities/oclcts/generic_oclc_authority.rb
+++ b/lib/qa/authorities/oclcts/generic_oclc_authority.rb
@@ -34,7 +34,7 @@ module Qa::Authorities
 
       def get_raw_response(query_type, id)
         query_url = Oclcts.url_pattern(query_type).gsub("{query}", id).gsub("{id}", id).gsub("{authority-id}", subauthority)
-        @raw_response = Nokogiri::XML(open(query_url))
+        @raw_response = Nokogiri::XML(URI.open(query_url))
       end
   end
 end


### PR DESCRIPTION
To ease the transition to Rails 3.0, I'm making the following changes:

- `URI.escape` → `CGI.escape`
- `URI.unescape` → `CGI.unescape`
- `open(some_url)` → `URI.open(some_url)`