### PR TITLE
Call `super()` in a bunch of initializers

### DIFF
--- a/lib/qa/authorities/assign_fast/generic_authority.rb
+++ b/lib/qa/authorities/assign_fast/generic_authority.rb
@@ -4,7 +4,9 @@ module Qa::Authorities
   # http://www.oclc.org/developer/develop/web-services/fast-api/assign-fast.en.html
   class AssignFast::GenericAuthority < Base
     attr_reader :subauthority
+
     def initialize(subauthority)
+      super()
       @subauthority = subauthority
     end
 

--- a/lib/qa/authorities/crossref/generic_authority.rb
+++ b/lib/qa/authorities/crossref/generic_authority.rb
@@ -5,6 +5,7 @@ module Qa::Authorities
     attr_reader :subauthority
 
     def initialize(subauthority)
+      super()
       @subauthority = subauthority
     end
 

--- a/lib/qa/authorities/discogs/generic_authority.rb
+++ b/lib/qa/authorities/discogs/generic_authority.rb
@@ -11,6 +11,7 @@ module Qa::Authorities
 
     # @param [String] subauthority to use
     def initialize(subauthority)
+      super()
       @subauthority = subauthority
       self.primary_artists = []
       self.work_uri = "workn1"

--- a/lib/qa/authorities/linked_data/generic_authority.rb
+++ b/lib/qa/authorities/linked_data/generic_authority.rb
@@ -20,6 +20,7 @@ module Qa::Authorities
       delegate :subauthority?, :subauthorities?, to: :search_config, prefix: 'search'
 
       def initialize(auth_name)
+        super()
         @authority_config = Qa::Authorities::LinkedData::Config.new(auth_name)
       end
 

--- a/lib/qa/authorities/loc/generic_authority.rb
+++ b/lib/qa/authorities/loc/generic_authority.rb
@@ -2,6 +2,7 @@ module Qa::Authorities
   class Loc::GenericAuthority < Base
     attr_reader :subauthority
     def initialize(subauthority)
+      super()
       @subauthority = subauthority
     end
 

--- a/lib/qa/authorities/local/file_based_authority.rb
+++ b/lib/qa/authorities/local/file_based_authority.rb
@@ -2,6 +2,7 @@ module Qa::Authorities
   class Local::FileBasedAuthority < Base
     attr_reader :subauthority
     def initialize(subauthority)
+      super()
       @subauthority = subauthority
     end
 

--- a/lib/qa/authorities/local/table_based_authority.rb
+++ b/lib/qa/authorities/local/table_based_authority.rb
@@ -34,6 +34,7 @@ module Qa::Authorities
     attr_reader :subauthority
 
     def initialize(subauthority)
+      super()
       self.class.check_for_index
       @subauthority = subauthority
     end

--- a/lib/qa/authorities/oclcts/generic_oclc_authority.rb
+++ b/lib/qa/authorities/oclcts/generic_oclc_authority.rb
@@ -3,6 +3,7 @@ module Qa::Authorities
     attr_reader :subauthority
 
     def initialize(subauthority)
+      super()
       @subauthority = subauthority
     end
     include WebServiceBase

--- a/spec/controllers/terms_controller_spec.rb
+++ b/spec/controllers/terms_controller_spec.rb
@@ -65,6 +65,7 @@ describe Qa::TermsController, type: :controller do
         class Qa::Authorities::Local::TwoArgs < Qa::Authorities::Base
           attr_reader :subauthority
           def initialize(subauthority)
+            super()
             @subauthority = subauthority
           end
 


### PR DESCRIPTION
`Lint/MissingSuper` wants us to call `super()` at the beginning of these initializers.

I'm mindful of the discussion at https://github.com/rubocop/ruby-style-guide/issues/809 but this looks to me like a harmless change.