### PR TITLE
Remove two unneeded blocks

### DIFF
--- a/lib/qa/authorities/local.rb
+++ b/lib/qa/authorities/local.rb
@@ -36,10 +36,8 @@ module Qa::Authorities
       end
 
       def registry
-        @registry ||= begin
-          Registry.new do |reg|
-            register_defaults(reg)
-          end
+        @registry ||= Registry.new do |reg|
+          register_defaults(reg)
         end
       end
 

--- a/lib/qa/authorities/local/registry.rb
+++ b/lib/qa/authorities/local/registry.rb
@@ -19,9 +19,7 @@ module Qa::Authorities
       end
 
       def self.logger
-        @logger ||= begin
-          ::Rails.logger if defined? Rails && Rails.respond_to?(:logger)
-        end
+        @logger ||= ::Rails.logger if defined? Rails && Rails.respond_to?(:logger)
       end
 
       class << self


### PR DESCRIPTION
This will work under the more stringent rubocop rules we'll be enforcing as we move up to Rails 3.1 .