### PR TITLE
Trivial rubocop changes

### DIFF
--- a/lib/qa/authorities/geonames.rb
+++ b/lib/qa/authorities/geonames.rb
@@ -64,7 +64,7 @@ module Qa::Authorities
       # Reformats the data received from the service
       def parse_authority_response(response)
         response['geonames'].map do |result|
-          # Note: the trailing slash is meaningful.
+          # NOTE: the trailing slash is meaningful.
           { 'id' => "https://sws.geonames.org/#{result['geonameId']}/",
             'label' => label.call(result) }
         end

--- a/lib/qa/authorities/linked_data/config.rb
+++ b/lib/qa/authorities/linked_data/config.rb
@@ -60,7 +60,7 @@ module Qa::Authorities
       def authority_config
         @authority_config ||= Qa::LinkedData::AuthorityService.authority_config(@authority_name)
         raise Qa::InvalidLinkedDataAuthority, "Unable to initialize linked data authority '#{@authority_name}'" if @authority_config.nil?
-        convert_1_0_to_2_0 if @authority_config.fetch(:QA_CONFIG_VERSION, '1.0') == '1.0'
+        convert_1_0_to_2_0_version if @authority_config.fetch(:QA_CONFIG_VERSION, '1.0') == '1.0'
         @authority_config
       end
 
@@ -78,7 +78,7 @@ module Qa::Authorities
 
       private
 
-        def convert_1_0_to_2_0
+        def convert_1_0_to_2_0_version
           convert_1_0_url_to_2_0_url(:search)
           convert_1_0_url_to_2_0_url(:term)
         end

--- a/lib/qa/authorities/mesh_tools/mesh_data_parser.rb
+++ b/lib/qa/authorities/mesh_tools/mesh_data_parser.rb
@@ -7,7 +7,9 @@ module Qa::Authorities
         @file = file
       end
 
-      def each_mesh_record # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/CyclomaticComplexity
+      def each_mesh_record
         current_data = {}
         in_record = false
         file.each_line do |line|


### PR DESCRIPTION
Three trivial changes prompted by Rubocop:

- a private method name in `lib/qa/authorities/linked_data/config.rb`;
- a comment in `lib/qa/authorities/geonames.rb`;
- another comment turning off the `Metrics/CyclomaticComplexity` cop for `lib/qa/authorities/mesh_tools/mesh_data_parser.rb` which appears to me just fine as it is.