### PR TITLE
Remove simplecov and coveralls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,6 @@ source "https://rubygems.org"
 
 gemspec path: File.expand_path('..', __FILE__)
 
-group :development, :test do
-  gem 'coveralls', require: false
-  gem 'simplecov', require: false
-end
-
 # BEGIN ENGINE_CART BLOCK
 # engine_cart: 0.10.0
 # engine_cart stanza: 0.10.0

--- a/qa.gemspec
+++ b/qa.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rspec-rails'
-  s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'swagger-docs'
   s.add_development_dependency 'webmock'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,25 +1,11 @@
 require 'linkeddata'
 require 'json'
 require 'engine_cart'
-require 'simplecov'
-require 'coveralls'
 require 'byebug' unless ENV['TRAVIS']
 
 ENV["RAILS_ENV"] ||= "test"
 
-SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-SimpleCov.start('rails') do
-  add_filter '/.internal_test_app'
-  add_filter '/lib/generators'
-  add_filter '/spec'
-  add_filter '/tasks'
-  add_filter '/lib/qa/version.rb'
-  add_filter '/lib/qa/engine.rb'
-end
-SimpleCov.command_name 'spec'
-
 EngineCart.load_application!
-Coveralls.wear!
 
 require 'rspec/rails'
 require 'webmock/rspec'


### PR DESCRIPTION
I understand the consensus is that these are more trouble than they're worth. Getting rid of them is an easy way to make the code compatible with Ruby 3.1.

(_Note_: If it is important that we keep them, we will just need to ensure that the method that turns on test coverage is only invoked once. I do believe I know how to do this.)