### PR TITLE
Use a regular expression to match error messages

### DIFF
--- a/spec/lib/authorities/getty/aat_spec.rb
+++ b/spec/lib/authorities/getty/aat_spec.rb
@@ -35,7 +35,10 @@ describe Qa::Authorities::Getty::AAT do
         end
 
         it 'logs error and returns empty results' do
-          expect(Rails.logger).to receive(:warn).with("  ERROR fetching Getty response: undefined method `[]' for nil:NilClass; cause: UNKNOWN")
+          # Rails 3.1 actually quotes the failing code in the error message,
+          # so let's match this error message with a multiline regex instead of
+          # a string.
+          expect(Rails.logger).to receive(:warn).with(/ERROR fetching Getty response: .*undefined method.*for nil:NilClass.*; cause: UNKNOWN/m)
           expect(subject).to be {}
         end
       end

--- a/spec/lib/authorities/getty/tgn_spec.rb
+++ b/spec/lib/authorities/getty/tgn_spec.rb
@@ -35,7 +35,10 @@ describe Qa::Authorities::Getty::TGN do
         end
 
         it 'logs error and returns empty results' do
-          expect(Rails.logger).to receive(:warn).with("  ERROR fetching Getty response: undefined method `[]' for nil:NilClass; cause: UNKNOWN")
+          # Rails 3.1 actually quotes the failing code in the error message,
+          # so let's match this error message with a multiline regex instead of
+          # a string.
+          expect(Rails.logger).to receive(:warn).with(/ERROR fetching Getty response: .*undefined method.*for nil:NilClass.*; cause: UNKNOWN/m)
           expect(subject).to be {}
         end
       end

--- a/spec/lib/authorities/getty/ulan_spec.rb
+++ b/spec/lib/authorities/getty/ulan_spec.rb
@@ -35,7 +35,10 @@ describe Qa::Authorities::Getty::Ulan do
         end
 
         it 'logs error and returns empty results' do
-          expect(Rails.logger).to receive(:warn).with("  ERROR fetching Getty response: undefined method `[]' for nil:NilClass; cause: UNKNOWN")
+          # Rails 3.1 actually quotes the failing code in the error message,
+          # so let's match this error message with a multiline regex instead of
+          # a string.
+          expect(Rails.logger).to receive(:warn).with(/ERROR fetching Getty response: .*undefined method.*for nil:NilClass.*; cause: UNKNOWN/m)
           expect(subject).to be {}
         end
       end


### PR DESCRIPTION
In Ruby 3.1, the `https://github.com/ruby/ruby/tree/master/lib/error_highlight` gem will start highlighting the part of the code that breaks. Let's match both the old-style and new-style error using a clever regex.