### PR TITLE
Ruby 3.1 and Rails 6.1 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,9 +51,27 @@ jobs:
 
       - samvera/parallel_rspec
 
+
+
 workflows:
   ci:
     jobs:
+      # Ruby 3.1 release
+      - bundle_and_test:
+          name: "ruby3-1_rails6-1"
+          ruby_version: 3.1.2
+          rails_version: 6.1.1
+
+      # Ruby 3.0 release
+      - bundle_and_test:
+          name: "ruby3-0_rails6-1"
+          ruby_version: 3.0.0
+          rails_version: 6.1.1
+      - bundle_and_test:
+          name: "ruby3-0_rails6-0"
+          ruby_version: 3.0.0
+          rails_version: 6.0.5
+
       # Ruby 2.7 release
       - bundle_and_test:
           name: "ruby2-7_rails6-1"
@@ -62,11 +80,11 @@ workflows:
       - bundle_and_test:
           name: "ruby2-7_rails6-0"
           ruby_version: 2.7.5
-          rails_version: 6.0.2
+          rails_version: 6.0.5
       - bundle_and_test:
           name: "ruby2-7_rails5-2"
           ruby_version: 2.7.5
-          rails_version: 5.2.4
+          rails_version: 5.2.6
       - bundle_and_test:
           name: "ruby2-7_rails5-1"
           ruby_version: 2.7.5
@@ -80,11 +98,11 @@ workflows:
       - bundle_and_test:
           name: "ruby2-6_rails6-0"
           ruby_version: 2.6.9
-          rails_version: 6.0.2
+          rails_version: 6.0.5
       - bundle_and_test:
           name: "ruby2-6_rails5-2"
           ruby_version: 2.6.9
-          rails_version: 5.2.4
+          rails_version: 5.2.6
       - bundle_and_test:
           name: "ruby2-6_rails5-1"
           ruby_version: 2.6.9
@@ -94,15 +112,15 @@ workflows:
       - bundle_and_test:
           name: "ruby2-5_rails6-1"
           ruby_version: 2.5.9
-          rails_version: 6.1.0
+          rails_version: 6.1.1
       - bundle_and_test:
           name: "ruby2-5_rails6-0"
           ruby_version: 2.5.9
-          rails_version: 6.0.2
+          rails_version: 6.0.5
       - bundle_and_test:
           name: "ruby2-5_rails5-2"
           ruby_version: 2.5.9
-          rails_version: 5.2.4
+          rails_version: 5.2.6
       - bundle_and_test:
           name: "ruby2-5_rails5-1"
           ruby_version: 2.5.9
@@ -118,6 +136,22 @@ workflows:
                 - main
 
     jobs:
+      # Ruby 3.1 release
+      - bundle_and_test:
+          name: "ruby3-1_rails6-1"
+          ruby_version: 3.1.2
+          rails_version: 6.1.1
+
+      # Ruby 3.0 release
+      - bundle_and_test:
+          name: "ruby3-0_rails6-1"
+          ruby_version: 3.0.0
+          rails_version: 6.1.1
+      - bundle_and_test:
+          name: "ruby3-0_rails6-0"
+          ruby_version: 3.0.0
+          rails_version: 6.0.5
+
       # Ruby 2.7 release
       - bundle_and_test:
           name: "ruby2-7_rails6-1"
@@ -126,11 +160,11 @@ workflows:
       - bundle_and_test:
           name: "ruby2-7_rails6-0"
           ruby_version: 2.7.5
-          rails_version: 6.0.2
+          rails_version: 6.0.5
       - bundle_and_test:
           name: "ruby2-7_rails5-2"
           ruby_version: 2.7.5
-          rails_version: 5.2.4
+          rails_version: 5.2.6
       - bundle_and_test:
           name: "ruby2-7_rails5-1"
           ruby_version: 2.7.5
@@ -144,11 +178,11 @@ workflows:
       - bundle_and_test:
           name: "ruby2-6_rails6-0"
           ruby_version: 2.6.9
-          rails_version: 6.0.2
+          rails_version: 6.0.5
       - bundle_and_test:
           name: "ruby2-6_rails5-2"
           ruby_version: 2.6.9
-          rails_version: 5.2.4
+          rails_version: 5.2.6
       - bundle_and_test:
           name: "ruby2-6_rails5-1"
           ruby_version: 2.6.9
@@ -158,15 +192,15 @@ workflows:
       - bundle_and_test:
           name: "ruby2-5_rails6-1"
           ruby_version: 2.5.9
-          rails_version: 6.1.0
+          rails_version: 6.1.1
       - bundle_and_test:
           name: "ruby2-5_rails6-0"
           ruby_version: 2.5.9
-          rails_version: 6.0.2
+          rails_version: 6.0.5
       - bundle_and_test:
           name: "ruby2-5_rails5-2"
           ruby_version: 2.5.9
-          rails_version: 5.2.4
+          rails_version: 5.2.6
       - bundle_and_test:
           name: "ruby2-5_rails5-1"
           ruby_version: 2.5.9

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,11 +65,11 @@ workflows:
       # Ruby 3.0 release
       - bundle_and_test:
           name: "ruby3-0_rails6-1"
-          ruby_version: 3.0.0
+          ruby_version: 3.0.3
           rails_version: 6.1.1
       - bundle_and_test:
           name: "ruby3-0_rails6-0"
-          ruby_version: 3.0.0
+          ruby_version: 3.0.3
           rails_version: 6.0.5
 
       # Ruby 2.7 release
@@ -145,11 +145,11 @@ workflows:
       # Ruby 3.0 release
       - bundle_and_test:
           name: "ruby3-0_rails6-1"
-          ruby_version: 3.0.0
+          ruby_version: 3.0.3
           rails_version: 6.1.1
       - bundle_and_test:
           name: "ruby3-0_rails6-0"
-          ruby_version: 3.0.0
+          ruby_version: 3.0.3
           rails_version: 6.0.5
 
       # Ruby 2.7 release

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_gem:
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.0
   DisplayCopNames: true
   Exclude:
     - 'db/**/*'

--- a/README.md
+++ b/README.md
@@ -152,9 +152,14 @@ If you're working on PR for this project, create a feature branch off of `main`.
 This repository follows the [Samvera Community Code of Conduct](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405212316/Code+of+Conduct) and [language recommendations](https://github.com/samvera/maintenance/blob/main/templates/CONTRIBUTING.md#language).  Please ***do not*** create a branch called `master` for this repository or as part of your pull request; the branch will either need to be removed or renamed before it can be considered for inclusion in the code base and history of this repository.
 
 ## Compatibility
+This gem works with Rails 5.0-6.1 and Ruby 2.5-3.1, provided the version of Rails supports the version of Ruby.
+ - Consult `.circleci/config.yml` for a list of supported combinations.
+ - The combination of Ruby 3.1 and Rails 6.0 comes with three caveats:
+   - your app will not be able to use `psych 4` (which ordinarily comes with 3.1). See https://bugs.ruby-lang.org/issues/17866 and https://stackoverflow.com/questions/71191685/visit-psych-nodes-alias-unknown-alias-default-psychbadalias/71192990#71192990 for an explanation. One workaround is to modify your app's `Gemfile` to hold back `psych`: `gem 'psych', '< 4'`.
+   - likewise, you want to add gem 'net-smtp', require: false to your Gemfile to get around the bug described in https://stackoverflow.com/questions/70500220/rails-7-ruby-3-1-loaderror-cannot-load-such-file-net-smtp .
+   - finally, you may want to opt in to the latest version of "mail". Again, add to your Gemfile the line `gem "mail", ">= 2.8.0.rc1"`.
 
-- Ruby 2.5 or the latest 2.4 version is recommended. Later versions may also work.
-- Rails 5 is required. We recommend the latest Rails 5.2 release.
+See also  `.circleci/config.yml` and `spec/test_app_templates/Gemfile.extra`.
 
 ## Product Owner & Maintenance
 

--- a/qa.gemspec
+++ b/qa.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rdf'
 
   # the hyrax style guide is based on `bixby`. see `.rubocop.yml`
-  s.add_development_dependency 'bixby', '~> 3.0.0'
+  s.add_development_dependency 'bixby', '~> 5.0', '>= 5.0.2' # bixby 5 briefly dropped Ruby 2.5
   s.add_development_dependency 'rails', '!=5.2.0', '!=5.2.1', '!=5.2.2'
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'engine_cart', '~> 2.0'

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -2,4 +2,17 @@
 
 group :development do
   gem 'linkeddata'
+  if ENV['RAILS_VERSION'] =~ /^6\.1\./ && ENV['RUBY_VERSION'] =~ /^3\.1\./
+    # Ruby 3.0 comes with Psych 3, while Ruby 3.1 comes with Psych 4,
+    # which has a major breaking change (diff 3.3.2 → 4.0.0).
+    # See: https://bugs.ruby-lang.org/issues/17866
+    # See also: https://stackoverflow.com/questions/71191685/visit-psych-nodes-alias-unknown-alias-default-psychbadalias/71192990#71192990
+    gem 'psych', '< 4'
+    # opt into mail 2.8.0.rc1 so we get extra dependencies
+    # Once mail 2.8.0 final is released this will not be required.
+    # https://github.com/mikel/mail/pull/1472
+    gem "mail", ">= 2.8.0.rc1"
+    # See https://stackoverflow.com/questions/70500220/rails-7-ruby-3-1-loaderror-cannot-load-such-file-net-smtp
+    gem 'net-smtp', require: false
+  end
 end


### PR DESCRIPTION
- Adds support for Ruby 3.0 and 3.1, as well as Rails 6.1
- Three changes to the enginecart test app to support Ruby 3.1 with Rails 6.1:
  - Opts into `'mail', '>= 2.8.0.rc1'`
  - Holds back `psych < 4`
  - `'net-smtp', require: false`

This should address both #345 and #331.