### PR TITLE
Fix CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,31 +60,31 @@ workflows:
       - bundle_and_test:
           name: "ruby3-1_rails6-1"
           ruby_version: 3.1.2
-          rails_version: 6.1.1
+          rails_version: 6.1.6.1
 
       # Ruby 3.0 release
       - bundle_and_test:
           name: "ruby3-0_rails6-1"
           ruby_version: 3.0.3
-          rails_version: 6.1.1
+          rails_version: 6.1.6.1
       - bundle_and_test:
           name: "ruby3-0_rails6-0"
           ruby_version: 3.0.3
-          rails_version: 6.0.5
+          rails_version: 6.0.5.1
 
       # Ruby 2.7 release
       - bundle_and_test:
           name: "ruby2-7_rails6-1"
           ruby_version: 2.7.5
-          rails_version: 6.1.1
+          rails_version: 6.1.6.1
       - bundle_and_test:
           name: "ruby2-7_rails6-0"
           ruby_version: 2.7.5
-          rails_version: 6.0.5
+          rails_version: 6.0.5.1
       - bundle_and_test:
           name: "ruby2-7_rails5-2"
           ruby_version: 2.7.5
-          rails_version: 5.2.6
+          rails_version: 5.2.8.1
       - bundle_and_test:
           name: "ruby2-7_rails5-1"
           ruby_version: 2.7.5
@@ -94,15 +94,15 @@ workflows:
       - bundle_and_test:
           name: "ruby2-6_rails6-1"
           ruby_version: 2.6.9
-          rails_version: 6.1.1
+          rails_version: 6.1.6.1
       - bundle_and_test:
           name: "ruby2-6_rails6-0"
           ruby_version: 2.6.9
-          rails_version: 6.0.5
+          rails_version: 6.0.5.1
       - bundle_and_test:
           name: "ruby2-6_rails5-2"
           ruby_version: 2.6.9
-          rails_version: 5.2.6
+          rails_version: 5.2.8.1
       - bundle_and_test:
           name: "ruby2-6_rails5-1"
           ruby_version: 2.6.9
@@ -112,15 +112,15 @@ workflows:
       - bundle_and_test:
           name: "ruby2-5_rails6-1"
           ruby_version: 2.5.9
-          rails_version: 6.1.1
+          rails_version: 6.1.6.1
       - bundle_and_test:
           name: "ruby2-5_rails6-0"
           ruby_version: 2.5.9
-          rails_version: 6.0.5
+          rails_version: 6.0.5.1
       - bundle_and_test:
           name: "ruby2-5_rails5-2"
           ruby_version: 2.5.9
-          rails_version: 5.2.6
+          rails_version: 5.2.8.1
       - bundle_and_test:
           name: "ruby2-5_rails5-1"
           ruby_version: 2.5.9
@@ -150,7 +150,7 @@ workflows:
       - bundle_and_test:
           name: "ruby3-0_rails6-0"
           ruby_version: 3.0.3
-          rails_version: 6.0.5
+          rails_version: 6.0.5.1
 
       # Ruby 2.7 release
       - bundle_and_test:
@@ -160,11 +160,11 @@ workflows:
       - bundle_and_test:
           name: "ruby2-7_rails6-0"
           ruby_version: 2.7.5
-          rails_version: 6.0.5
+          rails_version: 6.0.5.1
       - bundle_and_test:
           name: "ruby2-7_rails5-2"
           ruby_version: 2.7.5
-          rails_version: 5.2.6
+          rails_version: 5.2.8.1
       - bundle_and_test:
           name: "ruby2-7_rails5-1"
           ruby_version: 2.7.5
@@ -178,11 +178,11 @@ workflows:
       - bundle_and_test:
           name: "ruby2-6_rails6-0"
           ruby_version: 2.6.9
-          rails_version: 6.0.5
+          rails_version: 6.0.5.1
       - bundle_and_test:
           name: "ruby2-6_rails5-2"
           ruby_version: 2.6.9
-          rails_version: 5.2.6
+          rails_version: 5.2.8.1
       - bundle_and_test:
           name: "ruby2-6_rails5-1"
           ruby_version: 2.6.9
@@ -196,11 +196,11 @@ workflows:
       - bundle_and_test:
           name: "ruby2-5_rails6-0"
           ruby_version: 2.5.9
-          rails_version: 6.0.5
+          rails_version: 6.0.5.1
       - bundle_and_test:
           name: "ruby2-5_rails5-2"
           ruby_version: 2.5.9
-          rails_version: 5.2.6
+          rails_version: 5.2.8.1
       - bundle_and_test:
           name: "ruby2-5_rails5-1"
           ruby_version: 2.5.9

--- a/qa.gemspec
+++ b/qa.gemspec
@@ -30,7 +30,20 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rails', '!=5.2.0', '!=5.2.1', '!=5.2.2'
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'engine_cart', '~> 2.0'
-  s.add_development_dependency 'linkeddata'
+
+  # Not sure why these RDF-related gems are only being listed as development dependencies
+  # not general runtime dependencies...
+  # ... maybe meant to be optional dependencies only if you are using related
+  # func? See also the "meta" gem `linkeddata` which includes all of these deps.
+  #
+  # If apps find they need these optional dependencies for linked-data-related
+  # functionality from qa gem, they may find it easiest to include the `linkeddata`
+  # aggregator gem as one of their dependencies.
+  s.add_development_dependency 'rdf-n3', '~> 3.0'
+  s.add_development_dependency 'rdf-rdfxml', '~> 3.0'
+  s.add_development_dependency 'json-ld', '~> 3.0'
+  s.add_development_dependency 'rdf-vocab', '~> 3.0'
+
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rspec-rails'

--- a/spec/lib/authorities/discogs/generic_authority_spec.rb
+++ b/spec/lib/authorities/discogs/generic_authority_spec.rb
@@ -212,7 +212,7 @@ describe Qa::Authorities::Discogs::GenericAuthority do
           expect(JSON.parse(results).keys).to match_array ["@context", "@graph"]
           expect(JSON.parse(results)["@context"]["bf2"]).to eq("http://id.loc.gov/ontologies/bibframe/")
           expect(results).to include("You Go To My Head")
-          expect(results).to include("Rodgers & Hart")
+          expect(JSON.parse(results).inspect).to include("Rodgers & Hart")
           expect(results).to include("Ray Brown")
           expect(results).to include("1952")
           expect(results).to include("Single")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,10 @@
-require 'linkeddata'
+# Not sure why these RDF-related gems are only being used in CI and not general
+# dependencies... maybe meant to be optional dependencies?
+require 'rdf/n3'
+require 'rdf/rdfxml'
+require 'json/ld'
+require 'rdf/vocab'
+
 require 'json'
 require 'engine_cart'
 require 'byebug' unless ENV['TRAVIS']

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -12,10 +12,14 @@ group :development do
   if ENV['RAILS_VERSION'] && Gem::Version.new(ENV['RAILS_VERSION']) < Gem::Version.new("6.1")
     gem 'psych', '< 4'
 
-    # AND we need a version of linkeddata that will allow psych < 4, not sure why
-    # bundler can't resolve that on it's own.
-    # https://github.com/ruby-rdf/linkeddata/issues/16
-    gem 'linkeddata', "<= 3.2.0"
+    # Some versions of linkeddata dependency depend on yaml-ld gem... yaml-ld 0.0.1
+    # has a dependency on psych 4.x specifically, conflicting with above, bundler
+    # seems to be having trouble resolving to yaml-ld 0.0.2 on it's own.
+    # We don't actually depend on yaml-ld at all ourselves, just trying
+    # to help bundler resolve a tree that works.
+    #
+    # https://github.com/ruby-rdf/linkeddata/issues/16#issuecomment-1239912981
+    gem 'yaml-ld', ">= 0.0.2"
   end
 
   if ENV['RAILS_VERSION'] =~ /^6\.1\./ && ENV['RUBY_VERSION'] =~ /^3\.1\./

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -1,12 +1,7 @@
 # Use this file to reference specific commits of gems.
 
 
-
-
-
 group :development do
-  gem 'linkeddata'
-
   # Rails < 6.1 are not compatible with psych 4, although doesn't know it.
   # Local apps using old Rails will have to lock locally.  Latest versions
   # of Rails 6.1+ has been updated to work with psych 4.
@@ -16,6 +11,11 @@ group :development do
   #
   if ENV['RAILS_VERSION'] && Gem::Version.new(ENV['RAILS_VERSION']) < Gem::Version.new("6.1")
     gem 'psych', '< 4'
+
+    # AND we need a version of linkeddata that will allow psych < 4, not sure why
+    # bundler can't resolve that on it's own.
+    # https://github.com/ruby-rdf/linkeddata/issues/16
+    gem 'linkeddata', "<= 3.2.0"
   end
 
   if ENV['RAILS_VERSION'] =~ /^6\.1\./ && ENV['RUBY_VERSION'] =~ /^3\.1\./

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -1,13 +1,24 @@
 # Use this file to reference specific commits of gems.
 
+
+
+
+
 group :development do
   gem 'linkeddata'
-  if ENV['RAILS_VERSION'] =~ /^6\.1\./ && ENV['RUBY_VERSION'] =~ /^3\.1\./
-    # Ruby 3.0 comes with Psych 3, while Ruby 3.1 comes with Psych 4,
-    # which has a major breaking change (diff 3.3.2 → 4.0.0).
-    # See: https://bugs.ruby-lang.org/issues/17866
-    # See also: https://stackoverflow.com/questions/71191685/visit-psych-nodes-alias-unknown-alias-default-psychbadalias/71192990#71192990
+
+  # Rails < 6.1 are not compatible with psych 4, although doesn't know it.
+  # Local apps using old Rails will have to lock locally.  Latest versions
+  # of Rails 6.1+ has been updated to work with psych 4.
+  # See also:
+  #
+  # https://stackoverflow.com/questions/71191685/visit-psych-nodes-alias-unknown-alias-default-psychbadalias/71192990#71192990
+  #
+  if ENV['RAILS_VERSION'] && Gem::Version.new(ENV['RAILS_VERSION']) < Gem::Version.new("6.1")
     gem 'psych', '< 4'
+  end
+
+  if ENV['RAILS_VERSION'] =~ /^6\.1\./ && ENV['RUBY_VERSION'] =~ /^3\.1\./
     # opt into mail 2.8.0.rc1 so we get extra dependencies
     # Once mail 2.8.0 final is released this will not be required.
     # https://github.com/mikel/mail/pull/1472

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -11,15 +11,6 @@ group :development do
   #
   if ENV['RAILS_VERSION'] && Gem::Version.new(ENV['RAILS_VERSION']) < Gem::Version.new("6.1")
     gem 'psych', '< 4'
-
-    # Some versions of linkeddata dependency depend on yaml-ld gem... yaml-ld 0.0.1
-    # has a dependency on psych 4.x specifically, conflicting with above, bundler
-    # seems to be having trouble resolving to yaml-ld 0.0.2 on it's own.
-    # We don't actually depend on yaml-ld at all ourselves, just trying
-    # to help bundler resolve a tree that works.
-    #
-    # https://github.com/ruby-rdf/linkeddata/issues/16#issuecomment-1239912981
-    gem 'yaml-ld', ">= 0.0.2"
   end
 
   if ENV['RAILS_VERSION'] =~ /^6\.1\./ && ENV['RUBY_VERSION'] =~ /^3\.1\./


### PR DESCRIPTION
CI build started failing with no changes to local code.

See #373. 

We don't entirely understand why; clearly some change with latest release of dependencies or ruby itself (since there were no changes to local code), but we don't entirely understand what/why.  

- Only Rails 6.1+ works with psych 4, although older rails doens't know it, being unmaintained, and needs a local pin to psych 3
  * Don't know why this at one point passed, even after psych 4 had been released.


- Fix test of raw serialized JSON
  * In some versions of ruby/dependencies, there is a literal `&` in raw serialized JSON source; in other versions, it's a `\u0026` (which should mean the same thing once parsed). We don't understand why this differs between different ruby/rails versions, or why it started differing at some point in past with no changes to local code. (I don't really even understand where this String being tested comes from, or why the method under test is returning raw unparsed serialized JSON!)

    But it seems safe to have the test not care whether the serialized JSON contains `&` or `\u0026` -- should be semantically equivalent once parsed. So change the test code to test against parsed value rather than raw value. 
