### PR TITLE
Extracting `Qa.authority_for`

### DIFF
--- a/app/controllers/qa/linked_data_terms_controller.rb
+++ b/app/controllers/qa/linked_data_terms_controller.rb
@@ -158,8 +158,8 @@ class Qa::LinkedDataTermsController < ::ApplicationController
     end
 
     def init_authority
-      @authority = Qa::Authorities::LinkedData::GenericAuthority.new(vocab_param)
-    rescue Qa::InvalidLinkedDataAuthority => e
+      @authority = Qa.authority_for(vocab: params[:vocab], subauthority: params[:subauthority])
+    rescue Qa::InvalidAuthorityError, Qa::InvalidLinkedDataAuthority => e
       msg = e.message
       logger.warn msg
       render json: { errors: msg }, status: :bad_request

--- a/app/controllers/qa/linked_data_terms_controller.rb
+++ b/app/controllers/qa/linked_data_terms_controller.rb
@@ -42,7 +42,7 @@ class Qa::LinkedDataTermsController < ::ApplicationController
   # get "/search/linked_data/:vocab(/:subauthority)"
   # @see Qa::Authorities::LinkedData::SearchQuery#search
   def search # rubocop:disable Metrics/MethodLength
-    terms = @authority.search(query, request_header: request_header_service.search_header)
+    terms = @authority.search(query)
     cors_allow_origin_header(response)
     render json: terms
   rescue Qa::ServiceUnavailable
@@ -65,7 +65,7 @@ class Qa::LinkedDataTermsController < ::ApplicationController
   # get "/show/linked_data/:vocab/:subauthority/:id
   # @see Qa::Authorities::LinkedData::FindTerm#find
   def show # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-    term = @authority.find(id, request_header: request_header_service.fetch_header)
+    term = @authority.find(id)
     cors_allow_origin_header(response)
     render json: term, content_type: request_header_service.content_type_for_format
   rescue Qa::TermNotFound
@@ -95,7 +95,7 @@ class Qa::LinkedDataTermsController < ::ApplicationController
   # get "/fetch/linked_data/:vocab"
   # @see Qa::Authorities::LinkedData::FindTerm#find
   def fetch # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-    term = @authority.find(uri, request_header: request_header_service.fetch_header)
+    term = @authority.find(uri)
     cors_allow_origin_header(response)
     render json: term, content_type: request_header_service.content_type_for_format
   rescue Qa::TermNotFound
@@ -157,8 +157,13 @@ class Qa::LinkedDataTermsController < ::ApplicationController
       @request_header_service = request_header_service_class.new(request: request, params: params)
     end
 
+    # @see Qa::AuthorityWrapper for these methods
+    delegate :search_header, :fetch_header, to: :request_header_service
+
     def init_authority
-      @authority = Qa.authority_for(vocab: params[:vocab], subauthority: params[:subauthority])
+      @authority = Qa.authority_for(vocab: params[:vocab],
+                                    subauthority: params[:subauthority],
+                                    context: self)
     rescue Qa::InvalidAuthorityError, Qa::InvalidLinkedDataAuthority => e
       msg = e.message
       logger.warn msg

--- a/app/controllers/qa/terms_controller.rb
+++ b/app/controllers/qa/terms_controller.rb
@@ -72,7 +72,8 @@ class Qa::TermsController < ::ApplicationController
     @authority = Qa.authority_for(vocab: params[:vocab],
                                   subauthority: params[:subauthority],
                                   # Included to preserve error message text
-                                  try_linked_data_config: false)
+                                  try_linked_data_config: false,
+                                  context: self)
   rescue Qa::InvalidAuthorityError, Qa::InvalidSubAuthority, Qa::MissingSubAuthority => e
     msg = e.message
     logger.warn msg

--- a/lib/qa/authorities/base.rb
+++ b/lib/qa/authorities/base.rb
@@ -29,5 +29,8 @@ module Qa::Authorities
     def find(_id)
       raise NotImplementedError, "#{self.class}#find is unimplemented."
     end
+
+    class_attribute :linked_data, instance_writer: false
+    self.linked_data = false
   end
 end

--- a/lib/qa/authorities/linked_data/generic_authority.rb
+++ b/lib/qa/authorities/linked_data/generic_authority.rb
@@ -13,6 +13,8 @@ module Qa::Authorities
       attr_reader :authority_config
       private :authority_config
 
+      self.linked_data = true
+
       delegate :supports_term?, :term_subauthorities?, :term_subauthority?,
                :term_id_expects_uri?, :term_id_expects_id?, to: :term_config
 

--- a/lib/qa/authorities/loc/generic_authority.rb
+++ b/lib/qa/authorities/loc/generic_authority.rb
@@ -35,7 +35,8 @@ module Qa::Authorities
     end
 
     def find_url(id)
-      "https://id.loc.gov/authorities/#{@subauthority}/#{id}.json"
+      root_fetch_slug = Loc.root_fetch_slug_for(@subauthority)
+      File.join("https://id.loc.gov/", root_fetch_slug, "/#{@subauthority}/#{id}.json")
     end
 
     private

--- a/lib/qa/authorities/loc_subauthority.rb
+++ b/lib/qa/authorities/loc_subauthority.rb
@@ -1,10 +1,28 @@
 module Qa::Authorities::LocSubauthority
+  # @todo Rename to reflect that this is a URI encoded url fragement used only for searching.
   def get_url_for_authority(authority)
     if authorities.include?(authority) then authority_base_url
     elsif vocabularies.include?(authority) then vocab_base_url
     elsif datatypes.include?(authority)    then datatype_base_url
     elsif preservation.include?(authority) then vocab_preservation_base_url
     end
+  end
+
+  # @note The returned value is the root directory of the URL.  The graphicMaterials sub-authority
+  #       has a "type" of vocabulary.  https://id.loc.gov/vocabulary/graphicMaterials/tgm008083.html
+  #       In some cases, this is plural and in others this is singular.
+  #
+  # @param authority [String] the LOC authority that matches one of the types
+  # @return [String]
+  #
+  # @note there is a relationship between the returned value and the encoded URLs returned by
+  #       {#get_url_for_authority}.
+  def root_fetch_slug_for(authority)
+    validate_subauthority!(authority)
+    return "authorities" if authorities.include?(authority)
+    return "vocabulary" if vocabularies.include?(authority)
+    return "datatype" if datatypes.include?(authority)
+    return "vocabulary/preservation" if preservation.include?(authority)
   end
 
   def authorities

--- a/lib/qa/authority_request_context.rb
+++ b/lib/qa/authority_request_context.rb
@@ -1,0 +1,44 @@
+module Qa
+  # @note THIS IS NOT TESTED NOR EXERCISED CODE IT IS PROVIDED AS CONJECTURE.  FUTURE CHANGES MIGHT
+  #       BUILD AND REFACTOR UPON THIS.
+  #
+  # @api private
+  # @abstract
+  #
+  # This class is responsible for exposing methods that are required by both linked data and
+  # non-linked data authorities.  As of v5.10.0, those three methods are: params, search_header,
+  # fetch_header.  Those are the methods that are used in {Qa::LinkedData::RequestHeaderService} and
+  # in {Qa::Authorities::Discogs::GenericAuthority}.
+  #
+  # The intention is to provide a class that can behave like a controller object without being that
+  # entire controller object.
+  #
+  # @see Qa::LinkedData::RequestHeaderService
+  # @see Qa::Authorities::Discogs::GenericAuthority
+  class AuthorityRequestContext
+    def self.fallback
+      new
+    end
+
+    def initialize(params: {}, **kwargs)
+      @params = params
+      (SEARCH_HEADER_KEYS + FETCH_HEADER_KEYS).uniq.each do |key|
+        send("#{key}=", kwargs[key]) if kwargs.key?(key)
+      end
+    end
+
+    SEARCH_HEADER_KEYS = %i[request request_id subauthority user_language performance_data context response_header replacements].freeze
+    FETCH_HEADER_KEYS = %i[request request_id subauthority user_language performance_data format response_header replacements].freeze
+
+    attr_accessor :params
+    attr_accessor(*(SEARCH_HEADER_KEYS + FETCH_HEADER_KEYS).uniq)
+
+    def search_header
+      @headers.slice(*SEARCH_HEADER_KEYS).compact
+    end
+
+    def fetch_header
+      @headers.slice(*FETCH_HEADER_KEYS).compact
+    end
+  end
+end

--- a/lib/qa/authority_request_context.rb
+++ b/lib/qa/authority_request_context.rb
@@ -36,13 +36,13 @@ module Qa
 
     def search_header
       SEARCH_HEADER_KEYS.each_with_object(headers.deep_dup) do |key, header|
-        header[key] = send(key).present?
+        header[key] = send(key) if send(key).present?
       end.compact
     end
 
     def fetch_header
       FETCH_HEADER_KEYS.each_with_object(headers.deep_dup) do |key, header|
-        header[key] = send(key).present?
+        header[key] = send(key) if send(key).present?
       end.compact
     end
   end

--- a/lib/qa/authority_request_context.rb
+++ b/lib/qa/authority_request_context.rb
@@ -20,8 +20,9 @@ module Qa
       new
     end
 
-    def initialize(params: {}, **kwargs)
+    def initialize(params: {}, headers: {}, **kwargs)
       @params = params
+      @headers = headers
       (SEARCH_HEADER_KEYS + FETCH_HEADER_KEYS).uniq.each do |key|
         send("#{key}=", kwargs[key]) if kwargs.key?(key)
       end
@@ -30,15 +31,19 @@ module Qa
     SEARCH_HEADER_KEYS = %i[request request_id subauthority user_language performance_data context response_header replacements].freeze
     FETCH_HEADER_KEYS = %i[request request_id subauthority user_language performance_data format response_header replacements].freeze
 
-    attr_accessor :params
+    attr_accessor :params, :headers
     attr_accessor(*(SEARCH_HEADER_KEYS + FETCH_HEADER_KEYS).uniq)
 
     def search_header
-      @headers.slice(*SEARCH_HEADER_KEYS).compact
+      SEARCH_HEADER_KEYS.each_with_object(headers.deep_dup) do |key, header|
+        header[key] = send(key).present?
+      end.compact
     end
 
     def fetch_header
-      @headers.slice(*FETCH_HEADER_KEYS).compact
+      FETCH_HEADER_KEYS.each_with_object(headers.deep_dup) do |key, header|
+        header[key] = send(key).present?
+      end.compact
     end
   end
 end

--- a/lib/qa/authority_wrapper.rb
+++ b/lib/qa/authority_wrapper.rb
@@ -1,0 +1,62 @@
+module Qa
+  # @api public
+  # @since v5.11.0
+  #
+  # The intention of this wrapper is to provide a common interface that both linked and non-linked
+  # data can use.  There are implementation differences between the two, but with this wrapper, the
+  # goal is to draw attention to those differences and insulate the end user from those issues.
+  #
+  # One benefit in introducing this class is that when interacting with a questioning authority
+  # implementation you don't need to consider "Hey when I instantiate an authority, is this linked
+  # data or not?"  And what specifically are the parameter differences.  You will need to perhaps
+  # include some additional values in the context if you don't call this from a controller.
+  class AuthorityWrapper
+    # @param authority [#find, #search]
+    # @param subauthority [#to_s]
+    # @param context [#params, #search_header, #fetch_header]
+    def initialize(authority:, subauthority:, context:)
+      @authority = authority
+      @subauthority = subauthority
+      @context = context
+      configure!
+    end
+    attr_reader :authority, :context, :subauthority
+
+    def search(value)
+      if linked_data?
+        # should respond to search_header
+        authority.search(value, request_header: context.search_header)
+      elsif authority.method(:search).arity == 2
+        # This context should respond to params; see lib/qa/authorities/discogs/generic_authority.rb
+        authority.search(value, context)
+      else
+        authority.search(value)
+      end
+    end
+
+    # context has params
+    def find(value)
+      if linked_data?
+        # should respond to fetch_header
+        authority.find(value, request_header: context.fetch_header)
+      elsif authority.method(:find).arity == 2
+        authority.find(value, context)
+      else
+        authority.find(value)
+      end
+    end
+    alias fetch find
+
+    def method_missing(method_name, *arguments, &block)
+      authority.send(method_name, *arguments, &block)
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      authority.respond_to?(method_name, include_private)
+    end
+
+    def configure!
+      @context.subauthority = @subauthority if @context.respond_to?(:subauthority)
+    end
+  end
+end

--- a/lib/qa/authority_wrapper.rb
+++ b/lib/qa/authority_wrapper.rb
@@ -11,6 +11,7 @@ module Qa
   # data or not?"  And what specifically are the parameter differences.  You will need to perhaps
   # include some additional values in the context if you don't call this from a controller.
   class AuthorityWrapper
+    require 'qa/authority_request_context.rb'
     # @param authority [#find, #search]
     # @param subauthority [#to_s]
     # @param context [#params, #search_header, #fetch_header]

--- a/spec/lib/authorities/loc_spec.rb
+++ b/spec/lib/authorities/loc_spec.rb
@@ -42,6 +42,18 @@ describe Qa::Authorities::Loc do
     end
   end
 
+  describe ".root_fetch_slug_for" do
+    it "raises an error for an invalid subauthority" do
+      expect do
+        described_class.root_fetch_slug_for("no-one-would-ever-have-this-one")
+      end.to raise_error Qa::InvalidSubAuthority
+    end
+
+    it "returns the corresponding type for the given subauthority" do
+      expect(described_class.root_fetch_slug_for("graphicMaterials")).to eq("vocabulary")
+    end
+  end
+
   describe "#response" do
     subject { authority.response(url) }
     let :authority do


### PR DESCRIPTION
## Extracting `Qa.authority_for`

24776bc3a47d6211383874f06544ba5a9225ede9

Prior to this commit, we used different initialization logic for linked
data authorities and non-linked data.  Further, the initialization logic
was locked away inside of a controller.

With this commit, we expose a method that provides consistent
initialization logic; albeit with different returned classes that have
slightly different implementation nuances.  The application can then
rely on that and we can share initialization logic across controllers
and also expose a method that allows non-controller initialization to
begin to follow the same logic pathway.

Where are the tests?  The initializations are covered by controller
tests, so I have chosen not to write new ones.

There is further work to do because LinkedData and non-LinkedData there
are different signatures for `find` and `search`.  Ideally, we would
normalize the public facing implementation logic.  However, this commit
preserves backwards compatibility, simply introducing a new feature.

## Introducing `Qa::AuthorityWrapper`

baf399f2dba6c45c99f90483242dc047ff94e47b

Prior to this commit, the returned value from `Qa.authority_for` was
something that was inconsistent.  Depending on the controller (or authority), the `find`
and `search` would require different parameters.

With this commit, those nuances are encapsulated in their own methods.
This begins to work towards a more foundational promise of questioning
authority; namely that the end point that asked questions of QA didn't
need to know which type of authority it was.

That promise was partially delivered at the routes level but this commit
pushes that down to the internal API level.

As a bonus, and perhaps confusion, I've included the
`Qa::AuthorityRequestContext` as an interface to help convey how one
might provide a different (non-controller) context to instantiating and
authority.

## WIP Reworking authority request context

4fd490729e5b0c9a17f7686a3ad4c773fb879f33


## require context and update logic of fetch/search header methods

d3c51a573f7d96f2cddb01a1c2379373b8559482


## Adding a `Qa::Authorities::Loc.type_for`

79a13f959e00b08c32557dbe7484c0912f4b9908

Prior to this commit, we always assumed that each "find" would request
from `https://id.loc.gov/authorities`.

With this commit, we use the "subauthority" to inform what the base URL
is for the `https://id.loc.gov/` host.  In some cases this is
`authorities` and in others it's as the code indicates.

Hopefully works to close the following:

- scientist-softserv/utk-hyku#267
