### PR TITLE
Run CI with Ruby 3.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,12 @@ jobs:
 workflows:
   ci:
     jobs:
+      # Ruby 3.2
+      - bundle_and_test:
+          name: "ruby3-2_rails7-0"
+          ruby_version: 3.2.0
+          rails_version: 7.0.4
+
       # Ruby 3.1 release
       - bundle_and_test:
           name: "ruby3-1_rails6-1"


### PR DESCRIPTION
Locally tests passed under Rails 7.0 and Ruby 3.2 with no changes to code. 
