### PR TITLE
Fix TGN_LANGAUGES.xml encoding attribute to be properly UTF-8

### DIFF
--- a/lib/qa/data/TGN_LANGUAGES.xml
+++ b/lib/qa/data/TGN_LANGUAGES.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="US-ASCII" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <Vocabulary xmlns="http://localhost/namespace" xmlns:vp="http://localhost/namespace" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://localhost/namespace Getty_Vocab_Export_Languages.xsd" Title="Thesaurus of Geographic Names" Part="Languages" Date="2011-04-11">
 <Language>
 <Language_Code>70115</Language_Code>


### PR DESCRIPTION
At some point nokogiri started actually paying attention to the `encoding` attribute in the <?xml> decleration in a way that made it parse improperly when it wrongly said "ASCII" when data actually had UTF-8

In `nokogiri-1.15.4-arm64-darwin` this discrepency was making code fail, with nokogiri failing to parse the file; even though this .XML file hasn't changed in 10 years, and it used to work fine.
