### PR TITLE
Get CI green

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,42 +58,42 @@ workflows:
       - bundle_and_test:
           name: "ruby3-2_rails7-1"
           ruby_version: 3.2.2
-          rails_version: 7.1.1
+          rails_version: 7.1.3.4
 
       - bundle_and_test:
           name: "ruby3-2_rails7-0"
           ruby_version: 3.2.0
-          rails_version: 7.0.4
+          rails_version: 7.0.8.4
 
       # Ruby 3.1 release
       - bundle_and_test:
           name: "ruby3-1_rails6-1"
           ruby_version: 3.1.2
-          rails_version: 6.1.6.1
+          rails_version: 6.1.7.8
       - bundle_and_test:
           name: "ruby3-1_rails7-0"
           ruby_version: 3.1.2
-          rails_version: 7.0.4
+          rails_version: 7.0.8.4
 
       # Ruby 3.0 release
       - bundle_and_test:
           name: "ruby3-0_rails6-1"
           ruby_version: 3.0.3
-          rails_version: 6.1.6.1
+          rails_version: 6.1.7.8
       - bundle_and_test:
           name: "ruby3-0_rails6-0"
           ruby_version: 3.0.3
-          rails_version: 6.0.5.1
+          rails_version: 6.0.6.1
 
       # Ruby 2.7 release
       - bundle_and_test:
           name: "ruby2-7_rails6-1"
           ruby_version: 2.7.5
-          rails_version: 6.1.6.1
+          rails_version: 6.1.7.8
       - bundle_and_test:
           name: "ruby2-7_rails6-0"
           ruby_version: 2.7.5
-          rails_version: 6.0.5.1
+          rails_version: 6.0.6.1
       - bundle_and_test:
           name: "ruby2-7_rails5-2"
           ruby_version: 2.7.5
@@ -125,11 +125,11 @@ workflows:
       - bundle_and_test:
           name: "ruby2-5_rails6-1"
           ruby_version: 2.5.9
-          rails_version: 6.1.6.1
+          rails_version: 6.1.7.8
       - bundle_and_test:
           name: "ruby2-5_rails6-0"
           ruby_version: 2.5.9
-          rails_version: 6.0.5.1
+          rails_version: 6.0.6.1
       - bundle_and_test:
           name: "ruby2-5_rails5-2"
           ruby_version: 2.5.9

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,68 +57,68 @@ workflows:
       # Ruby 3.2
       - bundle_and_test:
           name: "ruby3-2_rails7-1"
-          ruby_version: 3.2.2
+          ruby_version: 3.2.4
           rails_version: 7.1.3.4
 
       - bundle_and_test:
           name: "ruby3-2_rails7-0"
-          ruby_version: 3.2.0
+          ruby_version: 3.2.4
           rails_version: 7.0.8.4
 
       # Ruby 3.1 release
       - bundle_and_test:
           name: "ruby3-1_rails6-1"
-          ruby_version: 3.1.2
+          ruby_version: 3.1.6
           rails_version: 6.1.7.8
       - bundle_and_test:
           name: "ruby3-1_rails7-0"
-          ruby_version: 3.1.2
+          ruby_version: 3.1.6
           rails_version: 7.0.8.4
 
       # Ruby 3.0 release
       - bundle_and_test:
           name: "ruby3-0_rails6-1"
-          ruby_version: 3.0.3
+          ruby_version: 3.0.6
           rails_version: 6.1.7.8
       - bundle_and_test:
           name: "ruby3-0_rails6-0"
-          ruby_version: 3.0.3
+          ruby_version: 3.0.6
           rails_version: 6.0.6.1
 
       # Ruby 2.7 release
       - bundle_and_test:
           name: "ruby2-7_rails6-1"
-          ruby_version: 2.7.5
+          ruby_version: 2.7.8
           rails_version: 6.1.7.8
       - bundle_and_test:
           name: "ruby2-7_rails6-0"
-          ruby_version: 2.7.5
+          ruby_version: 2.7.8
           rails_version: 6.0.6.1
       - bundle_and_test:
           name: "ruby2-7_rails5-2"
-          ruby_version: 2.7.5
+          ruby_version: 2.7.8
           rails_version: 5.2.8.1
       - bundle_and_test:
           name: "ruby2-7_rails5-1"
-          ruby_version: 2.7.5
+          ruby_version: 2.7.8
           rails_version: 5.1.7
 
       # Ruby 2.6 release
       - bundle_and_test:
           name: "ruby2-6_rails6-1"
-          ruby_version: 2.6.9
+          ruby_version: 2.6.10
           rails_version: 6.1.6.1
       - bundle_and_test:
           name: "ruby2-6_rails6-0"
-          ruby_version: 2.6.9
+          ruby_version: 2.6.10
           rails_version: 6.0.5.1
       - bundle_and_test:
           name: "ruby2-6_rails5-2"
-          ruby_version: 2.6.9
+          ruby_version: 2.6.10
           rails_version: 5.2.8.1
       - bundle_and_test:
           name: "ruby2-6_rails5-1"
-          ruby_version: 2.6.9
+          ruby_version: 2.6.10
           rails_version: 5.1.7
 
       # Ruby 2.5 release

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ else
   end
 
   case ENV['RAILS_VERSION']
+  when /^7\.1/
+    # ought not to need this, not sure why we do
+    gem 'puma', '>= 6'
   when /^5.[12]/
     gem 'sass-rails', '~> 5.0'
   when /^4.2/

--- a/lib/qa/authorities/getty/aat.rb
+++ b/lib/qa/authorities/getty/aat.rb
@@ -54,7 +54,7 @@ module Qa::Authorities
         end
       rescue StandardError => e
         cause = response.fetch('error', {}).fetch('cause', 'UNKNOWN')
-        cause = cause.present? ? cause : 'UNKNOWN'
+        cause = cause.presence || 'UNKNOWN'
         Rails.logger.warn "  ERROR fetching Getty response: #{e.message}; cause: #{cause}"
         {}
       end


### PR DESCRIPTION
## Fix rubocop violation for ternary operator

Not sure how this used to pass but started failing with no code changes, but rubocop currently complains:

```
lib/qa/authorities/getty/aat.rb:57:17: C: [Correctable] Rails/Presence: Use cause.presence || 'UNKNOWN' instead of cause.present? ? cause : 'UNKNOWN'.
        cause = cause.present? ? cause : 'UNKNOWN'

```

## update CI to use current latest patch version of all ruby and Rails tested

Just in case that takes care of some of any remaining problems. 

Eg Rails `7.1.3.4` instead of previously `7.1.1`

And Ruby `3.2.4` instead of previously `3.2.2`

## Force puma to 6.x for Rails 7.1

Rails 7.1 can use rack 3.  You need puma 6 not puma 5 for rack 3. 

I don't really understand why we weren't getting puma 6 already -- as far as I can tell nothing in the requirements tree should have prevented puma 6, and I get puma 6 on my local copy when I run with ruby 3.2 and rails 7.1!

BUT on CircleCI, we were getting a dependency error:

```

An error occurred while loading ./spec/controllers/linked_data_terms_controller_spec.rb.
Failure/Error: EngineCart.load_application!

StandardError:
  Puma 5 is not compatible with Rack 3, please upgrade to Puma 6 or higher.
# ./vendor/bundle/ruby/3.2.0/gems/puma-5.6.8/lib/rack/version_restriction.rb:12:in `<top (required)>'
```

adding a version-specific extra dependency requireent to the Gemfile to force puma 6 when Rails 7.1 worked to get green. There are other rails-version-specific extra dependencies there, just used the pattern. 