### PR TITLE
Specify AssignFAST sort order to get expected and previous result ordering

### DIFF
--- a/lib/qa/authorities/assign_fast/generic_authority.rb
+++ b/lib/qa/authorities/assign_fast/generic_authority.rb
@@ -46,7 +46,10 @@ module Qa::Authorities
       index = AssignFast.index_for_authority(subauthority)
       return_data = "#{index}%2Cidroot%2Cauth%2Ctype"
       num_rows = 20 # max allowed by the API
-      "http://fast.oclc.org/searchfast/fastsuggest?&query=#{escaped_query}&queryIndex=#{index}&queryReturn=#{return_data}&suggest=autoSubject&rows=#{num_rows}"
+
+      # sort=usage+desc is not documented by OCLC but seems necessary to get the sort
+      # we formerly got without specifying, that is most useful in our use case.
+      "http://fast.oclc.org/searchfast/fastsuggest?&query=#{escaped_query}&queryIndex=#{index}&queryReturn=#{return_data}&suggest=autoSubject&rows=#{num_rows}&sort=usage+desc"
     end
 
     private

--- a/spec/controllers/terms_controller_spec.rb
+++ b/spec/controllers/terms_controller_spec.rb
@@ -199,7 +199,7 @@ describe Qa::TermsController, type: :controller do
 
     context "assign_fast" do
       before do
-        stub_request(:get, "http://fast.oclc.org/searchfast/fastsuggest?query=word&queryIndex=suggest50&queryReturn=suggest50,idroot,auth,type&rows=20&suggest=autoSubject")
+        stub_request(:get, "http://fast.oclc.org/searchfast/fastsuggest?query=word&queryIndex=suggest50&queryReturn=suggest50,idroot,auth,type&rows=20&suggest=autoSubject&sort=usage+desc")
           .with(headers: { 'Accept' => 'application/json' })
           .to_return(body: webmock_fixture("assign-fast-topical-result.json"), status: 200, headers: {})
       end

--- a/spec/lib/authorities/assign_fast_spec.rb
+++ b/spec/lib/authorities/assign_fast_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Qa::Authorities::AssignFast do
   let(:query) { "word (ling" }
-  let(:expected_url) { "http://fast.oclc.org/searchfast/fastsuggest?&query=word%20ling&queryIndex=suggestall&queryReturn=suggestall%2Cidroot%2Cauth%2Ctype&suggest=autoSubject&rows=20" }
+  let(:expected_url) { "http://fast.oclc.org/searchfast/fastsuggest?&query=word%20ling&queryIndex=suggestall&queryReturn=suggestall%2Cidroot%2Cauth%2Ctype&suggest=autoSubject&rows=20&sort=usage+desc" }
 
   # subauthority infrastructure
   describe "#new" do
@@ -60,7 +60,7 @@ describe Qa::Authorities::AssignFast do
 
     context "when query is blank" do
       let(:query) { "" }
-      let(:expected_url) { "http://fast.oclc.org/searchfast/fastsuggest?&query=&queryIndex=suggestall&queryReturn=suggestall%2Cidroot%2Cauth%2Ctype&suggest=autoSubject&rows=20" }
+      let(:expected_url) { "http://fast.oclc.org/searchfast/fastsuggest?&query=&queryIndex=suggestall&queryReturn=suggestall%2Cidroot%2Cauth%2Ctype&suggest=autoSubject&rows=20&sort=usage+desc" }
 
       # server returns results but no results header
       let :results do
@@ -104,7 +104,7 @@ describe Qa::Authorities::AssignFast do
 
     context "with topical results" do
       let(:query) { "word" }
-      let(:expected_url) { "http://fast.oclc.org/searchfast/fastsuggest?query=word&queryIndex=suggest50&queryReturn=suggest50,idroot,auth,type&rows=20&suggest=autoSubject" }
+      let(:expected_url) { "http://fast.oclc.org/searchfast/fastsuggest?query=word&queryIndex=suggest50&queryReturn=suggest50,idroot,auth,type&rows=20&suggest=autoSubject&sort=usage+desc" }
 
       let :results do
         stub_request(:get, expected_url)


### PR DESCRIPTION
We are pretty sure that the AssignFAST API sort ordering changed sometime in last 1-2 months, to become a strictly alphabetical sort, that our metadata staff found difficult to use for their use cases. 

OCLC was not able to confirm or deny that it had changed, but did offer this un-doc'd API query parameter to provide usage-based ordering. `&sort=usage+desc`

This restored API results to what our staff believes it may have been similarly. 

I think this change is necessary to keep the QA AssignFAST authority acting the way users have expected, and in a way useful for the use cases that people were were using it for. 

My own institution has locally patched to get this behavior already. 
