### PR TITLE
[WIP] Configurable timeout

### DIFF
--- a/config/authorities/linked_data/loc.json
+++ b/config/authorities/linked_data/loc.json
@@ -50,5 +50,7 @@
       "music_performance": "performanceMediums"
     }
   },
-  "search": {}
+  "search": {
+    "connection": { "timeout":"5"}
+  }
 }

--- a/config/authorities/linked_data/oclc_fast.json
+++ b/config/authorities/linked_data/oclc_fast.json
@@ -79,6 +79,7 @@
       "period":         "oclc.period",
       "form":           "oclc.form",
       "alt_lc":         "oclc.altlc"
-    }
+    },
+    "connection": { "timeout":"5"}
   }
 }

--- a/lib/qa/authorities/assign_fast/generic_authority.rb
+++ b/lib/qa/authorities/assign_fast/generic_authority.rb
@@ -19,7 +19,15 @@ module Qa::Authorities
       Faraday.get(url) do |req|
         req.options.params_encoder = space_fix_encoder
         req.headers['Accept'] = 'application/json'
+        unless connection_timeout_in_seconds.nil?
+          req.options.timeout = connection_timeout_in_seconds
+        end
       end
+    end
+
+    def connection_timeout_in_seconds
+      @connection_timeout_in_seconds ||= Qa.config.linked_data_authority_configs.
+        dig(:OCLC_FAST, :search, :connection, :timeout).to_i
     end
 
     # Search the FAST api

--- a/lib/qa/authorities/loc/generic_authority.rb
+++ b/lib/qa/authorities/loc/generic_authority.rb
@@ -13,10 +13,18 @@ module Qa::Authorities
       conn = Faraday.new "#{uri.scheme}://#{uri.host}"
       conn.options.params_encoder = Faraday::FlatParamsEncoder
       conn.get do |req|
+        unless connection_timeout_in_seconds.nil?
+          req.options.timeout = connection_timeout_in_seconds
+        end
         req.headers['Accept'] = 'application/json'
         req.url uri.path
         req.params = Rack::Utils.parse_query(uri.query)
       end
+    end
+
+    def connection_timeout_in_seconds
+      @connection_timeout_in_seconds ||= Qa.config.linked_data_authority_configs.
+        dig(:LOC, :search, :connection, :timeout).to_i
     end
 
     def search(q)


### PR DESCRIPTION
Introduces a new, optional configuration key/value pair into `loc.json` and `oclc_fast.json`:

```
"search": {
    "connection": { "timeout":"5"}
  }
```

When QA actually makes to the Faraday `get` request to this authority, we set a timeout on the request (if the config value is available) so that Faraday will abandon the request after five seconds.