### PR TITLE
Pin `concurrent-ruby`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - samvera/bundle:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>
-          cache_version: << parameters.rails_version >>_2
+          cache_version: << parameters.rails_version >>
 
       - samvera/engine_cart_generate:
           cache_key: v7-internal-test-app-{{ checksum "qa.gemspec" }}-{{ checksum "spec/test_app_templates/lib/generators/test_app_generator.rb" }}-{{ checksum "lib/generators/qa/install/install_generator.rb" }}-<< parameters.rails_version >>-<< parameters.ruby_version >>
@@ -45,7 +45,7 @@ jobs:
       - samvera/bundle:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>
-          cache_version: << parameters.rails_version >>_2
+          cache_version: << parameters.rails_version >>
 
       - samvera/rubocop
 

--- a/Gemfile
+++ b/Gemfile
@@ -31,13 +31,21 @@ else
   when /^7\.1/
     # ought not to need this, not sure why we do
     gem 'puma', '>= 6'
-  when /^5.[12]/
+  when /^7\.0/
+    # concurrent-ruby 1.3.5 causes Rails versions below 7.1 to break
+    gem 'concurrent-ruby', '1.3.4'
+  when /^6\.[01]/
+    gem 'concurrent-ruby', '1.3.4'
+  when /^5\.[12]/
+    gem 'concurrent-ruby', '1.3.4'
     gem 'sass-rails', '~> 5.0'
   when /^4.2/
     gem 'coffee-rails', '~> 4.1.0'
+    gem 'concurrent-ruby', '1.3.4'
     gem 'responders', '~> 2.0'
     gem 'sass-rails', '>= 5.0'
   when /^4.[01]/
+    gem 'concurrent-ruby', '1.3.4'
     gem 'sass-rails', '< 5.0'
   end
   # rubocop:enable Bundler/DuplicatedGem

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -21,4 +21,9 @@ group :development do
     # See https://stackoverflow.com/questions/70500220/rails-7-ruby-3-1-loaderror-cannot-load-such-file-net-smtp
     gem 'net-smtp', require: false
   end
+
+  if Gem::Version.new(ENV['RAILS_VERSION']) < Gem::Version.new('7.1')
+    gem 'concurrent-ruby', '1.3.4'
+  end
+
 end


### PR DESCRIPTION
`concurrent-ruby` 1.3.5 breaks on Rails versions below 7, so we're pinning this to 1.3.4.
This is a common fix for this problem; see also e.g. https://github.com/samvera/hyrax/pull/6989