### PR TITLE
Remove unnecessary setting

### DIFF
--- a/config/authorities/assign_fast/oclc_assign_fast.json
+++ b/config/authorities/assign_fast/oclc_assign_fast.json
@@ -2,6 +2,5 @@
   "search": {
     "urls" : { "fastsuggest": "https://fast.oclc.org/searchfast/fastsuggest" },
     "connection": { "timeout":"5"}
-    // "follow_redirects": true,
   }
 }


### PR DESCRIPTION
It turns out QA does follow redirects within the same host; we won't be needing this setting.