### PR TITLE
bump version for 5.15.0

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,2 +1,2 @@
 unreleased=true
-future-release=5.10.0
+future-release=5.15.0

--- a/lib/qa/version.rb
+++ b/lib/qa/version.rb
@@ -1,3 +1,3 @@
 module Qa
-  VERSION = "5.14.0".freeze
+  VERSION = "5.15.0".freeze
 end


### PR DESCRIPTION
Full [list of changes](https://github.com/samvera/questioning_authority/compare/v5.14.0...v5.15.0):


- Fixed CI tests by pinning concurent-ruby on certain combinations of Ruby and Rails
- Changes to assign_fast:
  - Add a new configuration file
  - Un-hardcode the default URL, and update the URL to somethign that works
  - Add a configurable timeout request.
