### PR TITLE
Remove deprecation dependency from qa.gemspec

### DIFF
--- a/app/services/qa/linked_data/authority_url_service.rb
+++ b/app/services/qa/linked_data/authority_url_service.rb
@@ -65,9 +65,8 @@ module Qa
           # This is deprecated and will be removed in the next major release.
           def build_request_header(substitutions, subauthority, language) # rubocop:disable Metrics/CyclomaticComplexity
             return {} if substitutions.blank? && subauthority.blank? && language.blank?
-            Qa.deprecation_warning(
-              in_msg: 'Qa::LinkedData::AuthorityUrlService',
-              msg: "individual attributes for options (e.g. substitutions, subauthority, language) are deprecated; use request_header instead"
+            Deprecation.warn(
+              'individual attributes for options (e.g. substitutions, subauthority, language) are deprecated; use request_header instead'
             )
             request_header = {}
             request_header[:replacements] = substitutions unless substititions.blank?

--- a/app/services/qa/linked_data/mapper/graph_mapper_service.rb
+++ b/app/services/qa/linked_data/mapper/graph_mapper_service.rb
@@ -23,7 +23,7 @@ module Qa
         #    :altlabel=>[],
         #    :sort=>[#<RDF::Literal:0x3fcff54b4c18("2")>]}
         def self.map_values(graph:, predicate_map:, subject_uri:, &block)
-          Qa.deprecation_warning(msg: "`Qa::LinkedData::Mapper::GraphMapperService` is deprecated; update to `Qa::LinkedData::Mapper::GraphPredicateMapperService`.")
+          Deprecation.warn('`Qa::LinkedData::Mapper::GraphMapperService` is deprecated; update to `Qa::LinkedData::Mapper::GraphPredicateMapperService`.')
           Qa::LinkedData::Mapper::GraphPredicateMapperService.map_values(graph: graph, predicate_map: predicate_map, subject_uri: subject_uri, &block)
         end
       end

--- a/app/services/qa/linked_data/mapper/search_results_mapper_service.rb
+++ b/app/services/qa/linked_data/mapper/search_results_mapper_service.rb
@@ -102,9 +102,8 @@ module Qa
             end
 
             def map_values_with_predicate_map(graph:, predicate_map:, subject_uri:, sort_key:, context_map:)
-              Qa.deprecation_warning(
-                in_msg: 'Qa::LinkedData::Mapper::SearchResultsMapperService',
-                msg: 'predicate_map is deprecated; update to use ldpath_map'
+              Deprecation.warn(
+                'predicate_map is deprecated; update to use ldpath_map'
               )
               graph_predicate_mapper_service.map_values(graph: graph, predicate_map: predicate_map, subject_uri: subject_uri) do |value_map|
                 map_context(graph, sort_key, context_map, value_map, subject_uri)

--- a/app/services/qa/linked_data/mapper/term_results_mapper_service.rb
+++ b/app/services/qa/linked_data/mapper/term_results_mapper_service.rb
@@ -67,9 +67,8 @@ module Qa
             end
 
             def map_values_with_predicate_map(graph:, predicate_map:, subject_uri:)
-              Qa.deprecation_warning(
-                in_msg: 'Qa::LinkedData::Mapper::TermResultsMapperService',
-                msg: 'predicate_map is deprecated; update to use ldpath_map'
+              Deprecation.warn(
+                'predicate_map is deprecated; update to use ldpath_map'
               )
               graph_predicate_mapper_service.map_values(graph: graph, predicate_map: predicate_map, subject_uri: subject_uri)
             end

--- a/lib/qa.rb
+++ b/lib/qa.rb
@@ -25,12 +25,6 @@ module Qa
     @config
   end
 
-  def self.deprecation_warning(in_msg: nil, msg:)
-    return if Rails.env == 'test'
-    in_msg = in_msg.present? ? "In #{in_msg}, " : ''
-    warn "[DEPRECATED] #{in_msg}#{msg}  It will be removed in the next major release."
-  end
-
   # Raised when the authority is not valid
   class InvalidAuthorityError < RuntimeError
     def initialize(authority_class)

--- a/lib/qa/authorities/linked_data/config.rb
+++ b/lib/qa/authorities/linked_data/config.rb
@@ -87,7 +87,7 @@ module Qa::Authorities
         def convert_1_0_url_to_2_0_url(action_key)
           url_template = @authority_config.fetch(action_key, {}).fetch(:url, {}).fetch(:template, "")
           return if url_template.blank?
-          Qa.deprecation_warning(msg: "Linked data configuration #{authority_name} has 1.0 version format which is deprecated; update to version 2.0 configuration.")
+          Deprecation.warn("Linked data configuration #{authority_name} has 1.0 version format which is deprecated; update to version 2.0 configuration.")
           @authority_config[action_key][:url][:template] = url_template.gsub("{?", "{")
         end
     end

--- a/lib/qa/authorities/linked_data/config/search_config.rb
+++ b/lib/qa/authorities/linked_data/config/search_config.rb
@@ -58,9 +58,8 @@ module Qa::Authorities
       # Return results id_predicate
       # @return [String] the configured predicate to use to extract the id from the results
       def results_id_predicate
-        Qa.deprecation_warning(
-          in_msg: 'Qa::Authorities::LinkedData::SearchConfig',
-          msg: "`results_id_predicate` is deprecated; use `results_id_ldpath` by updating linked data search config results " \
+        Deprecation.warn(
+          "`results_id_predicate` is deprecated; use `results_id_ldpath` by updating linked data search config results " \
                "in authority #{authority_name} to specify as `id_ldpath`"
         )
         Config.predicate_uri(results, :id_predicate)
@@ -76,10 +75,9 @@ module Qa::Authorities
       # @return [String] the configured predicate to use to extract label values from the results
       def results_label_predicate(suppress_deprecation_warning: false)
         unless suppress_deprecation_warning
-          Qa.deprecation_warning(
-            in_msg: 'Qa::Authorities::LinkedData::SearchConfig',
-            msg: "`results_label_predicate` is deprecated; use `results_label_ldpath` by updating linked data search config results " \
-                 "in authority #{authority_name} to specify as `label_ldpath`"
+          Deprecation.warn(
+            "`results_label_predicate` is deprecated; use `results_label_ldpath` by updating linked data search config results " \
+               "in authority #{authority_name} to specify as `label_ldpath`"
           )
         end
         Config.predicate_uri(results, :label_predicate)
@@ -94,10 +92,9 @@ module Qa::Authorities
       # Return results altlabel_predicate
       # @return [String] the configured predicate to use to extract altlabel values from the results
       def results_altlabel_predicate
-        Qa.deprecation_warning(
-          in_msg: 'Qa::Authorities::LinkedData::SearchConfig',
-          msg: "`results_altlabel_predicate` is deprecated; use `results_altlabel_ldpath` by updating linked data " \
-               "search config results in authority #{authority_name} to specify as `altlabel_ldpath`"
+        Deprecation.warn(
+          "`results_altlabel_predicate` is deprecated; use `results_altlabel_ldpath` by updating linked data " \
+              "search config results in authority #{authority_name} to specify as `altlabel_ldpath`"
         )
         Config.predicate_uri(results, :altlabel_predicate)
       end
@@ -118,9 +115,8 @@ module Qa::Authorities
       # Return results sort_predicate
       # @return [String] the configured predicate to use for sorting results from the query search
       def results_sort_predicate
-        Qa.deprecation_warning(
-          in_msg: 'Qa::Authorities::LinkedData::SearchConfig',
-          msg: "`results_sort_predicate` is deprecated; use `results_sort_ldpath` by updating linked data " \
+        Deprecation.warn(
+          "`results_sort_predicate` is deprecated; use `results_sort_ldpath` by updating linked data " \
                "search config results in authority #{authority_name} to specify as `sort_ldpath`"
         )
         Config.predicate_uri(results, :sort_predicate)

--- a/lib/qa/authorities/linked_data/config/term_config.rb
+++ b/lib/qa/authorities/linked_data/config/term_config.rb
@@ -86,11 +86,10 @@ module Qa::Authorities
       #       id predicates.  This method remains for backward compatibility only but may cause issues if used in places expecting an Array
       def term_results_id_predicate(suppress_deprecation_warning: false)
         unless suppress_deprecation_warning
-          Qa.deprecation_warning(
-            in_msg: 'Qa::Authorities::LinkedData::TermConfig',
-            msg: "`term_results_id_predicate` is deprecated; use `term_results_id_ldpath` by updating linked data " \
+          Deprecation.warn(
+              "`term_results_id_predicate` is deprecated; use `term_results_id_ldpath` by updating linked data " \
                  "term config results in authority #{authority_name} to specify as `id_ldpath`"
-          )
+            )
         end
         id_predicates = term_results_id_predicates
         id_predicates.first
@@ -106,11 +105,10 @@ module Qa::Authorities
       # @return [String] the configured predicate to use to extract label values from the results
       def term_results_label_predicate(suppress_deprecation_warning: false)
         unless suppress_deprecation_warning
-          Qa.deprecation_warning(
-            in_msg: 'Qa::Authorities::LinkedData::TermConfig',
-            msg: "`term_results_label_predicate` is deprecated; use `term_results_label_ldpath` by updating linked data " \
+          Deprecation.warn(
+              "`term_results_label_predicate` is deprecated; use `term_results_label_ldpath` by updating linked data " \
                  "term config results in authority #{authority_name} to specify as `label_ldpath`"
-          )
+            )
         end
         Config.predicate_uri(term_results, :label_predicate)
       end
@@ -124,11 +122,10 @@ module Qa::Authorities
       # Return results altlabel_predicate
       # @return [String] the configured predicate to use to extract altlabel values from the results
       def term_results_altlabel_predicate
-        Qa.deprecation_warning(
-          in_msg: 'Qa::Authorities::LinkedData::TermConfig',
-          msg: "`term_results_altlabel_predicate` is deprecated; use `term_results_altlabel_ldpath` by updating linked data " \
+        Deprecation.warn(
+            "`term_results_altlabel_predicate` is deprecated; use `term_results_altlabel_ldpath` by updating linked data " \
                "term config results in authority #{authority_name} to specify as `altlabel_ldpath`"
-        )
+          )
         Config.predicate_uri(term_results, :altlabel_predicate)
       end
 
@@ -141,11 +138,10 @@ module Qa::Authorities
       # Return results broader_predicate
       # @return [String] the configured predicate to use to extract URIs for broader terms from the results
       def term_results_broader_predicate
-        Qa.deprecation_warning(
-          in_msg: 'Qa::Authorities::LinkedData::TermConfig',
-          msg: "`term_results_broader_predicate` is deprecated; use `term_results_broader_ldpath` by updating linked data " \
+        Deprecation.warn(
+            "`term_results_broader_predicate` is deprecated; use `term_results_broader_ldpath` by updating linked data " \
                "term config results in authority #{authority_name} to specify as `broader_ldpath`"
-        )
+          )
         Config.predicate_uri(term_results, :broader_predicate)
       end
 
@@ -158,9 +154,8 @@ module Qa::Authorities
       # Return results narrower_predicate
       # @return [String] the configured predicate to use to extract URIs for narrower terms from the results
       def term_results_narrower_predicate
-        Qa.deprecation_warning(
-          in_msg: 'Qa::Authorities::LinkedData::TermConfig',
-          msg: "`term_results_narrower_predicate` is deprecated; use `term_results_narrower_ldpath` by updating linked data " \
+        Deprecation.warn(
+          "`term_results_narrower_predicate` is deprecated; use `term_results_narrower_ldpath` by updating linked data " \
                "term config results in authority #{authority_name} to specify as `narrower_ldpath`"
         )
         Config.predicate_uri(term_results, :narrower_predicate)
@@ -175,11 +170,10 @@ module Qa::Authorities
       # Return results sameas_predicate
       # @return [String] the configured predicate to use to extract URIs for sameas terms from the results
       def term_results_sameas_predicate
-        Qa.deprecation_warning(
-          in_msg: 'Qa::Authorities::LinkedData::TermConfig',
-          msg: "`term_results_sameas_predicate` is deprecated; use `term_results_sameas_ldpath` by updating linked data " \
-               "term config results in authority #{authority_name} to specify as `sameas_ldpath`"
-        )
+        Deprecation.warn(
+         "`term_results_sameas_predicate` is deprecated; use `term_results_sameas_ldpath` by updating linked data " \
+           "term config results in authority #{authority_name} to specify as `sameas_ldpath`"
+       )
         Config.predicate_uri(term_results, :sameas_predicate)
       end
 

--- a/lib/qa/authorities/linked_data/find_term.rb
+++ b/lib/qa/authorities/linked_data/find_term.rb
@@ -116,10 +116,9 @@ module Qa::Authorities
           raise Qa::InvalidConfiguration, "must specify label_ldpath or label_predicate in term configuration for linked data authority #{authority_name} (label_ldpath is preferred)" unless ldpath_map.key?(:label) || predicate_map.key?(:label) # rubocop:disable Layout/LineLength
 
           if predicate_map.present?
-            Qa.deprecation_warning(
-              in_msg: 'Qa::Authorities::LinkedData::FindTerm',
-              msg: "defining results using predicates in term config is deprecated; update to define using ldpaths (authority: #{authority_name})"
-            )
+            Deprecation.warn(
+             "defining results using predicates in term config is deprecated; update to define using ldpaths (authority: #{authority_name})"
+           )
           end
 
           results_mapper_service.map_values(graph: @filtered_graph, subject_uri: uri, prefixes: prefixes,
@@ -180,9 +179,8 @@ module Qa::Authorities
                                                          predicate: id_predicate,
                                                          object_value: CGI.unescape(loc_id)).first
           return if @uri.blank? # only show the depercation warning if the loc_id was used
-          Qa.deprecation_warning(
-            in_msg: 'Qa::Authorities::LinkedData::FindTerm',
-            msg: 'Special processing of LOC ids is deprecated; id should be an exact match of the id in the graph'
+          Deprecation.warn(
+            'Special processing of LOC ids is deprecated; id should be an exact match of the id in the graph'
           )
           @uri
         end
@@ -316,9 +314,8 @@ module Qa::Authorities
         # This is deprecated and will be removed in the next major release.
         def build_request_header(language:, replacements:, subauth:, format:, performance_data:) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
           unless language.blank? && replacements.blank? && subauth.blank? && format == 'json' && !performance_data
-            Qa.deprecation_warning(
-              in_msg: 'Qa::Authorities::LinkedData::FindTerm',
-              msg: "individual attributes for options (e.g. replacements, subauth, language) are deprecated; use request_header instead"
+            Deprecation.warn(
+              "individual attributes for options (e.g. replacements, subauth, language) are deprecated; use request_header instead"
             )
           end
           request_header = {}

--- a/lib/qa/authorities/linked_data/search_query.rb
+++ b/lib/qa/authorities/linked_data/search_query.rb
@@ -78,9 +78,8 @@ module Qa::Authorities
           raise Qa::InvalidConfiguration, "must specify label_ldpath or label_predicate in search configuration for linked data authority #{authority_name} (label_ldpath is preferred)" unless ldpath_map.key?(:label) || predicate_map.key?(:label) # rubocop:disable Layout/LineLength
 
           if predicate_map.present?
-            Qa.deprecation_warning(
-              in_msg: 'Qa::Authorities::LinkedData::SearchQuery',
-              msg: "defining results using predicates in search config is deprecated; update to define using ldpaths (authority: #{authority_name})"
+            Deprecation.warn(
+              "defining results using predicates in search config is deprecated; update to define using ldpaths (authority: #{authority_name})"
             )
           end
 
@@ -207,9 +206,8 @@ module Qa::Authorities
         # This is deprecated and will be removed in the next major release.
         def build_request_header(language:, replacements:, subauth:, context:, performance_data:) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
           unless language.blank? && replacements.blank? && subauth.blank? && !context && !performance_data
-            Qa.deprecation_warning(
-              in_msg: 'Qa::Authorities::LinkedData::SearchQuery',
-              msg: "individual attributes for options (e.g. replacements, subauth, language) are deprecated; use request_header instead"
+            Deprecation.warn(
+              "individual attributes for options (e.g. replacements, subauth, language) are deprecated; use request_header instead"
             )
           end
           request_header = {}

--- a/qa.gemspec
+++ b/qa.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.metadata = { "rubygems_mfa_required" => "true" }
 
   s.add_dependency 'activerecord-import'
-  s.add_dependency 'deprecation'
   s.add_dependency 'faraday', '< 3.0', '!= 2.0.0'
   s.add_dependency 'geocoder'
   s.add_dependency 'ldpath'


### PR DESCRIPTION
Updates to use ActiveSupport::Deprecation instead of custom deprecation warning methods.