### PR TITLE
Replace custom deprecation gem with ActiveSupport::Deprecation

### DIFF
--- a/lib/qa.rb
+++ b/lib/qa.rb
@@ -25,10 +25,22 @@ module Qa
     @config
   end
 
+  def self.deprecator
+    @deprecator ||= deprecator_instance
+  end
+
+  # TODO: refactor when support for Rails < 7.1.0 is dropped
+  def self.deprecator_instance
+    if Gem::Version.new(Rails.version) >= Gem::Version.new('7.1.0')
+      ActiveSupport::Deprecation.new("6.0.0", "Qa")
+    else
+      Rails.logger
+    end
+  end
+
   def self.deprecation_warning(in_msg: nil, msg:)
-    return if Rails.env == 'test'
     in_msg = in_msg.present? ? "In #{in_msg}, " : ''
-    warn "[DEPRECATED] #{in_msg}#{msg}  It will be removed in the next major release."
+    deprecator.warn "#{in_msg}#{msg}  It will be removed in the next major release."
   end
 
   # Raised when the authority is not valid

--- a/lib/qa/engine.rb
+++ b/lib/qa/engine.rb
@@ -17,5 +17,12 @@ module Qa
         Rails.autoloaders.main.ignore(Rails.root.join('lib', 'generators'))
       end
     end
+
+    # Allow main application to configure deprecation behavior
+    if Gem::Version.new(Rails.version) >= Gem::Version.new('7.1.0')
+      initializer "qa.deprecator" do |app|
+        app.deprecators[:qa] = Qa.deprecator
+      end
+    end
   end
 end

--- a/qa.gemspec
+++ b/qa.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.metadata = { "rubygems_mfa_required" => "true" }
 
   s.add_dependency 'activerecord-import'
-  s.add_dependency 'deprecation'
   s.add_dependency 'faraday', '< 3.0', '!= 2.0.0'
   s.add_dependency 'geocoder'
   s.add_dependency 'ldpath'


### PR DESCRIPTION
**ISSUE**
The [deprecation gem](https://rubygems.org/gems/deprecation) is no longer being maintained (see https://github.com/projectblacklight/blacklight/pull/2793).

**RESOLUTION**
Update to use native Rails deprecation functionality.