### PR TITLE
Add ISO 639-3 as a Subauthority for LOC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,12 @@ jobs:
               echo "$(git branch --all --list master */master)"
             fi
             [[ -z "$(git branch --all --list master */master)" ]]
-
+      - run:
+          name: Add Google Chrome public key
+          command: |
+            sudo apt-get update -y
+            sudo apt-get install -y wget
+            wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
       - run: 'sudo apt-get update'
       - run: 'sudo apt-get install -y libsqlite3-dev'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,10 @@ jobs:
               echo "$(git branch --all --list master */master)"
             fi
             [[ -z "$(git branch --all --list master */master)" ]]
-
+      - run:
+          name: Add Google Chrome public key
+          command: |
+            wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
       - run: 'sudo apt-get update'
       - run: 'sudo apt-get install -y libsqlite3-dev'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,12 +30,7 @@ jobs:
               echo "$(git branch --all --list master */master)"
             fi
             [[ -z "$(git branch --all --list master */master)" ]]
-      - run:
-          name: Add Google Chrome public key
-          command: |
-            sudo apt-get update -y
-            sudo apt-get install -y wget
-            wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+
       - run: 'sudo apt-get update'
       - run: 'sudo apt-get install -y libsqlite3-dev'
 

--- a/lib/qa/authorities/loc_subauthority.rb
+++ b/lib/qa/authorities/loc_subauthority.rb
@@ -47,6 +47,7 @@ module Qa::Authorities::LocSubauthority
       "languages",
       "iso639-1",
       "iso639-2",
+      "iso639-3",
       "iso639-5",
       "preservation",
       "actionsGranted",

--- a/spec/controllers/terms_controller_spec.rb
+++ b/spec/controllers/terms_controller_spec.rb
@@ -32,7 +32,7 @@ describe Qa::TermsController, type: :controller do
         msg = "Unable to initialize sub-authority non-existent-subauthority for Qa::Authorities::Loc. Valid sub-authorities are " \
               "[\"subjects\", \"names\", \"classification\", \"childrensSubjects\", \"genreForms\", \"performanceMediums\", " \
               "\"graphicMaterials\", \"organizations\", \"relators\", \"countries\", \"ethnographicTerms\", \"geographicAreas\", " \
-              "\"languages\", \"iso639-1\", \"iso639-2\", \"iso639-5\", \"preservation\", \"actionsGranted\", \"agentType\", " \
+              "\"languages\", \"iso639-1\", \"iso639-2\", \"iso639-3\", \"iso639-5\", \"preservation\", \"actionsGranted\", \"agentType\", " \
               "\"edtf\", \"contentLocationType\", \"copyrightStatus\", \"cryptographicHashFunctions\", " \
               "\"environmentCharacteristic\", \"environmentPurpose\", \"eventRelatedAgentRole\", \"eventRelatedObjectRole\", " \
               "\"eventType\", \"formatRegistryRole\", \"hardwareType\", \"inhibitorTarget\", \"inhibitorType\", \"objectCategory\", " \


### PR DESCRIPTION
The LOC supports search for ISO639-3 language codes, which institutions might want to use instead of ISO639-2 or the MARC list for languages. The [LOC's website](https://id.loc.gov/vocabulary/iso369-3.html) says the following: "Whereas ISO 639-2 covers a few hundred languages, ISO 639-3 provides a comprehensive code set for all known languages, both living and historical." The [ISO 639-3 guidelines document](https://www.loc.gov/aba/pcc/scs/documents/ISO-639-3-guidelines.pdf) describes the specific differences between ISO 639-3 and the MARC list of languages on page 11.

Since ISO639-3 works like other LOC vocabularies, all we really need to do is add it to the list of valid vocabularies. (I also had to modify the Circle CI config to get the checks to pass.)

Example of ISO639-3 search results for "dutch" (`/qa/search/loc/iso639-3?q=dutch` in a test app):
```json
[
{
"id": "info:lc/vocabulary/iso639-3/nld",
"label": "Dutch"
},
{
"id": "info:lc/vocabulary/iso639-3/dum",
"label": "Middle Dutch (ca. 1050-1350)"
},
{
"id": "info:lc/vocabulary/iso639-3/odt",
"label": "Old Dutch"
},
{
"id": "info:lc/vocabulary/iso639-3/skw",
"label": "Skepi Creole Dutch"
},
{
"id": "info:lc/vocabulary/iso639-3/dse",
"label": "Dutch Sign Language"
},
{
"id": "info:lc/vocabulary/iso639-3/brc",
"label": "Berbice Creole Dutch"
}
]
```