### PR TITLE
Make Getty AAC url configurable

### DIFF
--- a/config/authorities/linked_data/getty_aac.json
+++ b/config/authorities/linked_data/getty_aac.json
@@ -1,0 +1,5 @@
+{
+  "search": {
+    "urls" : { "getty_vocab_url": "https://vocab.getty.edu" }
+  }
+}

--- a/config/authorities/linked_data/getty_aac.json
+++ b/config/authorities/linked_data/getty_aac.json
@@ -1,4 +1,5 @@
 {
+  "term": { },
   "search": {
     "urls" : { "getty_vocab_url": "https://vocab.getty.edu" }
   }

--- a/lib/qa/authorities/getty/aat.rb
+++ b/lib/qa/authorities/getty/aat.rb
@@ -64,7 +64,7 @@ module Qa::Authorities
       end
 
       def getty_vocab_url
-        @getty_vocab_url ||= (linked_data_authority_configs.dig(:GETTY_AAC, :search, :getty_vocab_url) || 'https://vocab.getty.edu')
+        @getty_vocab_url ||= (linked_data_authority_configs.dig(:GETTY_AAC, :search, :urls, :getty_vocab_url) || 'https://vocab.getty.edu')
       end
   end
 end

--- a/lib/qa/authorities/getty/aat.rb
+++ b/lib/qa/authorities/getty/aat.rb
@@ -7,7 +7,7 @@ module Qa::Authorities
     end
 
     def build_query_url(q)
-      "http://vocab.getty.edu/sparql.json?query=#{ERB::Util.url_encode(sparql(q))}&_implicit=false&implicit=true&_equivalent=false&_form=%2Fsparql"
+      "#{getty_vocab_url}/sparql.json?query=#{ERB::Util.url_encode(sparql(q))}&_implicit=false&implicit=true&_equivalent=false&_form=%2Fsparql"
     end
 
     def sparql(q) # rubocop:disable Metrics/MethodLength
@@ -38,7 +38,7 @@ module Qa::Authorities
     end
 
     def find_url(id)
-      "http://vocab.getty.edu/download/json?uri=http://vocab.getty.edu/aat/#{id}.json"
+      "#{getty_vocab_url}/download/json?uri=#{getty_vocab_url}/aat/#{id}.json"
     end
 
     def request_options
@@ -57,6 +57,14 @@ module Qa::Authorities
         cause = cause.presence || 'UNKNOWN'
         Rails.logger.warn "  ERROR fetching Getty response: #{e.message}; cause: #{cause}"
         {}
+      end
+
+      def linked_data_authority_configs
+        Qa.config.linked_data_authority_configs
+      end
+
+      def getty_vocab_url
+        @getty_vocab_url ||= (linked_data_authority_configs.dig(:GETTY_AAC, :search, :getty_vocab_url) || 'https://vocab.getty.edu')
       end
   end
 end

--- a/spec/lib/authorities/getty/aat_spec.rb
+++ b/spec/lib/authorities/getty/aat_spec.rb
@@ -5,12 +5,12 @@ describe Qa::Authorities::Getty::AAT do
 
   describe "#build_query_url" do
     subject { authority.build_query_url("foo") }
-    it { is_expected.to match(/^http:\/\/vocab\.getty\.edu\//) }
+    it { is_expected.to match(/^https:\/\/vocab\.getty\.edu\//) }
   end
 
   describe "#find_url" do
     subject { authority.find_url("300053264") }
-    it { is_expected.to eq "http://vocab.getty.edu/download/json?uri=http://vocab.getty.edu/aat/300053264.json" }
+    it { is_expected.to eq "https://vocab.getty.edu/download/json?uri=https://vocab.getty.edu/aat/300053264.json" }
   end
 
   describe "#search" do
@@ -62,7 +62,7 @@ describe Qa::Authorities::Getty::AAT do
   describe "#find" do
     context "using a subject id" do
       before do
-        stub_request(:get, "http://vocab.getty.edu/download/json?uri=http://vocab.getty.edu/aat/300265560.json")
+        stub_request(:get, "https://vocab.getty.edu/download/json?uri=https://vocab.getty.edu/aat/300265560.json")
           .to_return(status: 200, body: webmock_fixture("getty-aat-find-response.json"))
       end
       subject { authority.find("300265560") }

--- a/spec/services/linked_data/authority_service_spec.rb
+++ b/spec/services/linked_data/authority_service_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe Qa::LinkedData::AuthorityService do
   let(:auth_names) do
-    [:LOC,
+    [:GETTY_AAC,
+     :LOC,
      :LOD_ENCODING_CONFIG,
      :LOD_FULL_CONFIG,
      :LOD_FULL_CONFIG_1_0,


### PR DESCRIPTION
Ref https://github.com/samvera/questioning_authority/issues/415

This fixes the URL and makes it configurable by adding a new config file.

This PR does *not* make QA follow redirects in attempting to contact Getty, but at least we will now be able to update the URL without releasing a new version of the code.