### PR TITLE
Pin `multi_json` when json is version `2.19.x` 

### DIFF
--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -29,7 +29,10 @@ group :development do
   # 1) this passes on all versions:
   #gem "multi_json", "1.17.0"
 
-  # 2) let's try this now:
-  gem "multi_json", "!= 1.19.1"
+  # 2) this gives us 1.19.0, which also fails.
+  #gem "multi_json", "!= 1.19.1"
+
+  # 3) now we try this:
+  gem "multi_json", ">= 1.17", "< 1.19"
 
 end

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -26,4 +26,6 @@ group :development do
     gem 'concurrent-ruby', '1.3.4'
   end
 
+  gem "multi_json", "1.17.0"
+
 end

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -32,7 +32,12 @@ group :development do
   # 2) this gives us 1.19.0, which also fails.
   #gem "multi_json", "!= 1.19.1"
 
-  # 3) now we try this:
-  gem "multi_json", ">= 1.17", "< 1.19"
+  # 3) this passes again:
+  #gem "multi_json", ">= 1.17", "< 1.19"
+
+  # 4) only apply the pin to failing versions:
+  if RUBY_VERSION =~ /^3\.[01]\./
+    gem "multi_json", ">= 1.17", "< 1.19"
+  end
 
 end

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -26,16 +26,11 @@ group :development do
     gem 'concurrent-ruby', '1.3.4'
   end
 
-  # 1) this passes on all versions:
-  #gem "multi_json", "1.17.0"
-
-  # 2) this gives us 1.19.0, which also fails.
-  #gem "multi_json", "!= 1.19.1"
-
-  # 3) this passes again:
-  #gem "multi_json", ">= 1.17", "< 1.19"
-
-  # 4) only apply the pin to failing versions:
+  # multi_json 1.19.x / json 2.19.x interaction causes
+  # RDF::Graph#dump(:jsonld, standard_prefixes: true) to raise:
+  # NoMethodError: undefined method `except' for JSON::Ext::Generator::State
+  # in e.g. lib/qa/authorities/linked_data/find_term.rb and
+  # lib/qa/authorities/discogs/discogs_translation.rb 
   if RUBY_VERSION =~ /^3\.[01]\./
     gem "multi_json", ">= 1.17", "< 1.19"
   end

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -26,6 +26,10 @@ group :development do
     gem 'concurrent-ruby', '1.3.4'
   end
 
-  gem "multi_json", "1.17.0"
+  # 1) this passes on all versions:
+  #gem "multi_json", "1.17.0"
+
+  # 2) let's try this now:
+  gem "multi_json", "!= 1.19.1"
 
 end


### PR DESCRIPTION
This fixes the tests, which were failing because  a `multi_json 1.19.x` / `json 2.19.x` interaction causes
 `RDF::Graph#dump(:jsonld, standard_prefixes: true)` to raise:
 `NoMethodError: undefined method 'except' for JSON::Ext::Generator::State` in:
* lib/qa/authorities/linked_data/find_term.rb
* lib/qa/authorities/discogs/discogs_translation.rb 