### PR TITLE
move benchmark require inside task so only required when needed

### DIFF
--- a/lib/tasks/mesh.rake
+++ b/lib/tasks/mesh.rake
@@ -1,9 +1,9 @@
-require 'benchmark'
-
 namespace :qa do
   namespace :mesh do
     desc "Import MeSH terms from the file $MESH_FILE, it will update any terms which are already in the database"
     task import: :environment do
+      require 'benchmark' # may require you to add benchmark dependency in ruby 4+
+
       fname = ENV['MESH_FILE']
       if fname.nil?
         puts "Need to set $MESH_FILE with path to file to ingest"


### PR DESCRIPTION
Instead of on application boot (loading all rakefiles). As benchmark is removed from default gems in ruby 4, requiring it triggers a warning in late ruby 3, or will require you to add as a dependency in ruby 4. For now, we just move require inside so only an issue if you actually run task instead of on booting any app.

Closes #414
