### PR TITLE
Replace deprecated `Bundler.with_clean_env`

### DIFF
--- a/lib/generators/qa/apidoc/apidoc_generator.rb
+++ b/lib/generators/qa/apidoc/apidoc_generator.rb
@@ -11,7 +11,7 @@ This generator makes the following changes to your application:
   def add_to_gemfile
     gem 'swagger-docs'
 
-    Bundler.with_clean_env do
+    Bundler.with_unbundled_env do
       run "bundle install"
     end
   end

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -4,7 +4,7 @@ class TestAppGenerator < Rails::Generators::Base
   source_root Rails.root
 
   def update_app
-    Bundler.with_clean_env do
+    Bundler.with_unbundled_env do
       run "bundle install"
     end
   end


### PR DESCRIPTION
`Bundler.with_clean_env` was deprecated in Bundler 2.1 and completely removed in Bundler 4.0 .

Let's replace it with `Bundler.with_unbundled_env` .