### PR TITLE
Fix rubocop offenses

### DIFF
--- a/app/services/qa/pagination_service.rb
+++ b/app/services/qa/pagination_service.rb
@@ -433,7 +433,7 @@ module Qa
       #       linked_data module pagination).
       def requested_page_offset
         return @requested_page_offset if @requested_page_offset.present?
-        @requested_page_offset = (request_params['page_offset'] || request_params['startRecord'])
+        @requested_page_offset = request_params['page_offset'] || request_params['startRecord']
       end
 
       # @return [Integer] The first record to include in the response data as
@@ -470,7 +470,7 @@ module Qa
       #       linked_data module pagination).
       def requested_page_limit
         return @requested_page_limit if @requested_page_limit.present?
-        @requested_page_limit ||= (request_params['page_limit'] || request_params['maxRecords'])
+        @requested_page_limit ||= request_params['page_limit'] || request_params['maxRecords']
       end
 
       # @return [Integer] The max number of records to include in response data as

--- a/lib/qa/authorities/assign_fast/space_fix_encoder.rb
+++ b/lib/qa/authorities/assign_fast/space_fix_encoder.rb
@@ -1,13 +1,11 @@
 module Qa::Authorities
   # for use with Faraday; encode spaces as '%20' not '+'
   class AssignFast::SpaceFixEncoder
+    delegate :decode, to: Faraday::NestedParamsEncoder
+
     def encode(hash)
       encoded = Faraday::NestedParamsEncoder.encode(hash)
       encoded.gsub('+', '%20')
-    end
-
-    def decode(str)
-      Faraday::NestedParamsEncoder.decode(str)
     end
   end
 end

--- a/lib/qa/authorities/getty/aat.rb
+++ b/lib/qa/authorities/getty/aat.rb
@@ -64,7 +64,7 @@ module Qa::Authorities
       end
 
       def getty_vocab_url
-        @getty_vocab_url ||= (linked_data_authority_configs.dig(:GETTY_AAC, :search, :urls, :getty_vocab_url) || 'https://vocab.getty.edu')
+        @getty_vocab_url ||= linked_data_authority_configs.dig(:GETTY_AAC, :search, :urls, :getty_vocab_url) || 'https://vocab.getty.edu'
       end
   end
 end

--- a/lib/qa/authorities/linked_data/search_query.rb
+++ b/lib/qa/authorities/linked_data/search_query.rb
@@ -179,7 +179,7 @@ module Qa::Authorities
         end
 
         def wrap_labels(labels)
-          lbl = "" if labels.nil? || labels.size.zero?
+          lbl = "" if labels.blank?
           lbl = labels.join(', ') if labels.size.positive?
           lbl = '[' + lbl + ']' if labels.size > 1
           lbl

--- a/lib/qa/authorities/loc_subauthority.rb
+++ b/lib/qa/authorities/loc_subauthority.rb
@@ -22,7 +22,7 @@ module Qa::Authorities::LocSubauthority
     return "authorities" if authorities.include?(authority)
     return "vocabulary" if vocabularies.include?(authority)
     return "datatype" if datatypes.include?(authority)
-    return "vocabulary/preservation" if preservation.include?(authority)
+    "vocabulary/preservation" if preservation.include?(authority)
   end
 
   def authorities

--- a/lib/qa/authorities/local/registry.rb
+++ b/lib/qa/authorities/local/registry.rb
@@ -1,21 +1,15 @@
 module Qa::Authorities
   module Local
     class Registry
+      delegate :keys, :fetch, to: :@hash
+
       def initialize
         @hash = {}
         yield self if block_given?
       end
 
-      def keys
-        @hash.keys
-      end
-
       def instance_for(key)
         fetch(key).instance
-      end
-
-      def fetch(key)
-        @hash.fetch(key)
       end
 
       def self.logger

--- a/spec/services/linked_data/response_header_service_spec.rb
+++ b/spec/services/linked_data/response_header_service_spec.rb
@@ -74,8 +74,7 @@ RSpec.describe Qa::LinkedData::ResponseHeaderService do
 
   describe '#fetch_header' do
     let(:request_header) do
-      {
-      }.with_indifferent_access
+      {}.with_indifferent_access
     end
     let(:term_config) { double }
     let(:graph) { instance_double(RDF::Graph) }


### PR DESCRIPTION
This PR humors RuboCop by making the changes it wants; presumably that's a good thing.

For me, in this branch, I can now run with no errors:
```
rake engine_cart:clean
rake ci
```